### PR TITLE
feat: Curriculum Progression UI + Phase 3 completion

### DIFF
--- a/.build/BACKLOG.md
+++ b/.build/BACKLOG.md
@@ -1,13 +1,14 @@
 ---
 project: "Calculating Glory"
 type: "build"
-lastUpdated: "2026-03-03"
+lastUpdated: "2026-03-09"
 ---
 
 # Calculating Glory - Backlog & Ideas
 
 ## Features / Functionality
 
+- [ ] Stadium View — dual home screen with MECE core/sub-unit grid (#21 — needs planning session first)
 - [ ] Player database/market — pool of purchasable players with real(ish) names and stats
 - [ ] Transfer window UI — browse market, make offers, negotiate
 - [ ] Full isometric rendering — pixel art stadium/facilities, 64x32px tiles
@@ -16,6 +17,12 @@ lastUpdated: "2026-03-03"
 - [ ] Season end screen — promotion/relegation celebration/commiseration
 - [ ] Multiplayer sync — async turn-based between friends
 - [ ] Save/load to server (beyond localStorage)
+- [x] InboxCard overhaul — result cards, dismissal, preview cap ✅
+- [x] InboxHistory full slide-over ✅
+- [x] Seeded news generator (transfer/injury/league) ✅
+- [x] Backroom Team slide-over ✅
+- [x] Reputation flash animation ✅
+- [x] Learning Progress slide-over ✅
 
 ## Improvements / Optimisations
 
@@ -24,21 +31,26 @@ lastUpdated: "2026-03-03"
 - [ ] AI team evolution — form/results affect strength over the season
 - [ ] Morale system — explicit morale stat rather than folded into randomness
 - [ ] Match events beyond goals — injuries, red cards, suspensions
-- [ ] Business acumen UI — star rating display, per-topic breakdown
+- [ ] Practice mode — Marcus Webb free math drills for business acumen improvement
+- [x] Business acumen tile clickable → Learning Progress slide-over ✅
+- [x] Challenge difficulty capped by curriculum level ✅
+- [x] Star player name injected into wage-demand event ✅
 
 ## Educational / Curriculum
 
-- [ ] Wire curriculum progression system to UI (level gates, difficulty scaling)
-- [ ] Adaptive difficulty based on rolling business acumen scores
+- [ ] Adaptive difficulty fully wired to curriculum assessment (currently gated by level, not by live evidence)
 - [ ] Hint system — curriculum-appropriate scaffolding for math challenges
 - [ ] All branching club event chains — 15 templates, 4 branching follow-ups fully written
 - [ ] Teacher dashboard — class view of student progress
+- [x] Learning Progress slide-over (5-level pip track, readiness criteria, topic chips) ✅
+- [x] Curriculum difficulty cap in challenge generator ✅
 
 ## Research / Exploration
 
 - [ ] Chromebook performance profiling — ensure smooth at 1366x768
 - [ ] Accessibility audit — keyboard nav, colour contrast for school use
 - [ ] Offline capability — service worker for no-internet classrooms
+- [ ] Stadium View MECE analysis — map every playable game aspect to a unit/sub-unit
 
 ## Future Phases
 
@@ -53,3 +65,6 @@ lastUpdated: "2026-03-03"
 - Branching path dependency (past decisions unlock/block future events) creates replay value
 - Star ratings for business acumen should feel rewarding, not punishing
 - Integer pence arithmetic was the right call — no floating-point issues anywhere
+- Stadium View needs MECE coverage: every playable aspect of the game should map to exactly one core unit, no gaps, no overlaps
+- `CLUB_COMMERCIAL_CENTRE` concept: kit shop, sponsorship deals, TV rights — likely a Phase 5 sub-unit under a Commercial core unit
+- Two-tier grid principle: Core units = navigation anchors (clickable); Sub-units = visual/stat effects only (pointer-events: none)

--- a/.build/NEXT.md
+++ b/.build/NEXT.md
@@ -1,27 +1,27 @@
 ---
 project: "Calculating Glory"
 type: "build"
-lastUpdated: "2026-03-03"
+lastUpdated: "2026-03-09"
 ---
 
 # Calculating Glory - Next Steps
 
 ## Immediate (This Session/Week)
 
-1. Wire up full playable loop: game start → week 20 → resolve club events via Social Feed → advance week → see match results in league table
-2. Fix root package.json workspace scripts (`--workspace=frontend` fails, needs `--workspace=@calculating-glory/frontend`)
-3. Test the end-to-end flow in browser — confirm state updates propagate from domain through useGameState to UI
+1. Merge confident-colden PR into main
+2. Stadium View planning session — map core/sub-unit MECE grid before writing any code (issue #21)
+3. End-to-end smoke test: new game → resolve events via Social Feed → advance week → see match results update live
 
 ## Short Term (Next 2-4 Weeks)
 
-1. UI polish pass — error states, loading indicators, responsive layout on 1366x768
-2. Math challenge flow refinement — hint levels, answer validation, feedback
-3. Club event narrative copy — flesh out Social Feed chat bubbles for all 15 event templates
-4. Negotiation flow — Agent Rodriguez conversation threads with math-gated outcomes
-5. Practice mode — Marcus Webb free math drills for business acumen improvement
+1. Stadium View build — dual home screen, core units as navigation anchors, sub-units as visual stat effects
+2. UI polish pass — responsive layout at 1366x768, error states, loading skeletons
+3. Club event narrative copy — flesh out all 15 event templates' Social Feed chat bubbles
+4. Practice mode (Marcus Webb free drills) — business acumen improvement without game-state cost
+5. End-to-end integration tests (issue #12)
 
 ## Questions / Unknowns
 
-- Is the 3-week loop sufficient for the MVP demo, or do stakeholders want a longer playable segment?
-- What's the deployment target? (School network, hosted URL, standalone Chromebook app?)
-- Are there specific Year 7 curriculum topics to prioritise in the first math challenges?
+- Stadium View: what are the definitive core units? (Training, Medical, Youth, Stadium, Office, Commercial confirmed — any others?)
+- Is the 3-week mid-season loop sufficient for the MVP demo or do stakeholders want a longer segment?
+- Deployment target: school network hosted URL, or standalone Chromebook app?

--- a/.build/ROADMAP.md
+++ b/.build/ROADMAP.md
@@ -2,7 +2,7 @@
 project: "Calculating Glory"
 type: "build"
 createdAt: "2026-03-03"
-lastUpdated: "2026-03-03"
+lastUpdated: "2026-03-09"
 ---
 
 # Calculating Glory - Roadmap
@@ -11,46 +11,55 @@ An educational football club management game for Year 7 maths, built on event-so
 
 ## Current Phase: MVP Build
 
-- 2.1 React + Tailwind CSS frontend scaffolded ✅ (issue #1)
-- 2.2 `useGameState()` hook — wraps domain `buildState(events)` ✅ (issue #2)
-- 2.3 Command Centre hub layout (12-column grid) ✅ (issue #3)
-- 2.4 League table component ✅ (issue #4)
-- 2.5 Data tiles (budget, board confidence, week, position) ✅ (issue #5)
-- 2.6 News ticker (partial headlines) ✅ (issue #6)
-- 2.7 Social Feed slide-over (chat bubble UI, WhatsApp-style) ✅ (issue #7)
-- 2.8 Math challenge card + hint system ✅ (issue #8)
-- 2.9 Week advance button (disabled until events resolved) ✅ (issue #9)
-- 2.10 Isometric Blueprint placeholder tiles (card-based) ✅ (issue #10)
-- 2.11 First playable: 3-week mid-season loop (week 20 onward) — in progress (issue #11)
-- 2.12 End-to-end integration testing (issue #12)
-- 2.13 UI polish pass (responsiveness, error states, loading) (issue #13)
+### Phase 2: Frontend Foundation ✅
+- 2.1 React + Tailwind CSS frontend scaffolded ✅ (#1)
+- 2.2 `useGameState()` hook — wraps domain `buildState(events)` ✅ (#2)
+- 2.3 Command Centre hub layout (12-column grid) ✅ (#3)
+- 2.4 League table component ✅ (#4)
+- 2.5 Data tiles (budget, board confidence, week, position) ✅ (#5)
+- 2.6 News ticker (partial headlines) ✅ (#6)
+- 2.7 Social Feed slide-over (chat bubble UI, WhatsApp-style) ✅ (#7)
+- 2.8 Math challenge card + hint system ✅ (#8)
+- 2.9 Week advance button (disabled until events resolved) ✅ (#9)
+- 2.10 Isometric Blueprint placeholder tiles (card-based) ✅ (#10)
+- 2.11 First playable: 3-week mid-season loop (week 20 onward) ✅ (#11)
+- 2.12 End-to-end integration testing (pending)
+- 2.13 UI polish pass (responsiveness, error states, loading) (pending)
 
-## Completed Phase: Domain Logic
+### Phase 3: UI Polish & Feature Completion ✅
+- 3.1–3.4 InboxCard overhaul, InboxHistory slide-over, Command Centre restructure ✅ (#14, #19)
+- 3.5 Seeded deterministic news generator (transfer/injury/league copy) ✅ (#15)
+- 3.6 Reputation tile flash animation (green/red keyframe glow) ✅ (#16)
+- 3.7 Backroom Team slide-over (5 roles, hire CTA, wage summary) ✅ (#17)
+- 3.8 Star player name injected into wage-demand club event ✅ (#18)
+- 3.9 Learning Progress slide-over + Business Acumen tile click ✅ (#20)
+- 3.10 Challenge difficulty capped by curriculum level ✅ (#20)
 
-- 1.1 Event sourcing architecture ✅
-- 1.2 Deterministic match simulation (Poisson, seeded RNG) ✅
-- 1.3 Season fixtures (circle method round-robin, 24 teams, 46 weeks) ✅
-- 1.4 Command handlers + validation ✅
-- 1.5 Club events system (15 templates, branching chains) ✅
-- 1.6 Business acumen tracking ✅
-- 1.7 Curriculum progression system ✅
-- 1.8 245 tests passing across 14 suites ✅
+## Next Phase: Stadium View & Integration
+
+- 4.1 Stadium View planning — define MECE core/sub-unit grid (#21)
+- 4.2 Stadium View build — dual home screen, core units as nav anchors
+- 4.3 End-to-end integration test pass (#12)
+- 4.4 UI polish for Chromebook 1366x768 (#13)
 
 ## Future Phases
 
-### Phase 3: Full Season Flow
-- Pre-season, transfer windows, season end
-- Player database/market (pool of purchasable players)
+### Phase 5: Full Season Flow
+- Pre-season flow — squad building before season starts
+- Transfer window UI — browse market, make offers, negotiate
+- Player database/market — pool of purchasable players
 - Tutorial/onboarding system
-- Full isometric rendering (upgrade from card placeholders to pixel art)
+- Season end screen — promotion/relegation
 
-### Phase 4: Educational Depth
-- Full curriculum progression system wired to UI
-- Adaptive difficulty based on business acumen scores
-- All branching club event chains (15 templates, 4 branching follow-ups)
+### Phase 6: Educational Depth
+- Adaptive difficulty fully wired to curriculum progression UI
+- All 15 club event chains with full branching follow-ups
+- Practice mode (Marcus Webb free drills)
+- Teacher dashboard — class view of student progress
 - Hint system with curriculum-appropriate scaffolding
 
-### Phase 5: Polish & Multiplayer Prep
+### Phase 7: Polish & Multiplayer Prep
+- Full isometric rendering (pixel art upgrade from card placeholders)
 - AI team evolution (form/results affect strength over season)
 - Morale system
 - Match events beyond goals (injuries, red cards, suspensions)

--- a/.build/STATUS.md
+++ b/.build/STATUS.md
@@ -3,16 +3,16 @@ project: "Calculating Glory"
 type: "build"
 priority: 2
 phase: "MVP Build"
-progress: 77
-lastUpdated: "2026-03-04"
-lastTouched: "2026-03-04"
+progress: 90
+lastUpdated: "2026-03-09"
+lastTouched: "2026-03-09"
 status: "in-progress"
 ---
 
 # Calculating Glory - Current Status
 
-**Phase:** MVP Build (77% complete — 10/13 issues closed)
-**Last Updated:** 2026-03-04
+**Phase:** MVP Build (90% complete — 20 issues closed)
+**Last Updated:** 2026-03-09
 
 ## What's Done
 
@@ -31,20 +31,30 @@ status: "in-progress"
 - Social Feed slide-over (chat bubbles, negotiation keyboard, math challenges)
 - Isometric Blueprint placeholder (card-based facility upgrades)
 - News ticker, pending event cards, week advance button
+- InboxCard overhaul (result cards, dismissal, preview cap)
+- InboxHistory full slide-over (scrollable results + news, dismiss all)
+- Seeded deterministic news generator (transfer/injury/league copy, splitmix32 PRNG)
+- Reputation tile flash animation (green/red keyframe glow, useRepFlash hook)
+- Backroom Team slide-over (5 staff roles, star ratings, hire CTA, wage summary)
+- Star player name injection into player-unhappy event
+- Learning Progress slide-over (5-level pip track, 5 readiness criteria, topic chips, teacher level selector)
+- Business Acumen tile clickable → opens Learning Progress slide-over
+- generateChallenge difficulty cap by curriculum level (Year 7 → d1 only, Year 8 → d1-2, Year 9+ → all)
 
 ## What's In Progress
 
-- End-to-end playable loop (start → resolve events → advance week → see results)
-- UI polish and responsiveness for Chromebook target (1366x768)
+- End-to-end playable loop fully wired (events → resolve → advance → results)
+- UI polish pass for Chromebook target (1366x768)
+- Stadium View planning (issue #21 — full MECE planning session required before build)
 
 ## Blockers
 
-- None
+- Stadium View (#21) needs a dedicated planning session to map core/sub-unit grid before any implementation
 
 ## Notes
 
 - Target device: Chromebook 1366x768 (keyboard + trackpad)
 - MVP scope: 3-week mid-season loop starting week 20 — not full season
-- Dev server runs on http://localhost:3000/ via `npx vite` in packages/frontend
-- Root workspace scripts need fixing (workspace name mismatch for `frontend`)
-- Domain tests: `npm run build --workspace=@calculating-glory/domain && npm test --workspace=@calculating-glory/domain`
+- Dev server: `npm run dev --workspace=@calculating-glory/frontend` (reads PORT env var via vite.config.ts)
+- Domain tests: `npm test --workspace=@calculating-glory/domain`
+- All changes in confident-colden worktree; pending merge to main

--- a/packages/frontend/src/components/command-centre/CommandCentre.tsx
+++ b/packages/frontend/src/components/command-centre/CommandCentre.tsx
@@ -12,6 +12,7 @@ import { SlideOver } from '../shared/SlideOver';
 import { SocialFeed } from '../social-feed/SocialFeed';
 import { IsometricBlueprint } from '../isometric/IsometricBlueprint';
 import { BackroomTeamSlideOver } from './BackroomTeamSlideOver';
+import { LearningProgressSlideOver } from './LearningProgressSlideOver';
 
 interface CommandCentreProps {
   state: GameState;
@@ -27,6 +28,7 @@ export function CommandCentre({ state, events, dispatch, isLoading }: CommandCen
   const [isometricOpen, setIsometricOpen]     = useState(false);
   const [inboxOpen, setInboxOpen]             = useState(false);
   const [backroomOpen, setBackroomOpen]       = useState(false);
+  const [learningOpen, setLearningOpen]       = useState(false);
   const [dismissed, setDismissed]             = useState<Set<number>>(new Set());
 
   function handleDismiss(idx: number) {
@@ -122,7 +124,7 @@ export function CommandCentre({ state, events, dispatch, isLoading }: CommandCen
           </div>
 
           {/* RIGHT row 1: DataTiles */}
-          <DataTiles state={state} gridMode onBackroomClick={() => setBackroomOpen(true)} />
+          <DataTiles state={state} gridMode onBackroomClick={() => setBackroomOpen(true)} onAcumenClick={() => setLearningOpen(true)} />
 
           {/* RIGHT row 2: Stadium & Facilities + Chats side-by-side */}
           <div className="grid grid-cols-2 gap-2">
@@ -225,6 +227,17 @@ export function CommandCentre({ state, events, dispatch, isLoading }: CommandCen
       >
         {backroomOpen && (
           <BackroomTeamSlideOver state={state} dispatch={dispatch} onError={setError} />
+        )}
+      </SlideOver>
+
+      {/* ── Learning Progress slide-over ─────────────────────────────────── */}
+      <SlideOver
+        isOpen={learningOpen}
+        onClose={() => setLearningOpen(false)}
+        title="Learning Progress"
+      >
+        {learningOpen && (
+          <LearningProgressSlideOver state={state} events={events} />
         )}
       </SlideOver>
 

--- a/packages/frontend/src/components/command-centre/DataTiles.tsx
+++ b/packages/frontend/src/components/command-centre/DataTiles.tsx
@@ -6,6 +6,7 @@ interface DataTilesProps {
   state: GameState;
   gridMode?: boolean;
   onBackroomClick?: () => void;
+  onAcumenClick?: () => void;
 }
 
 interface Tile {
@@ -71,7 +72,7 @@ function useRepFlash(reputation: number): string {
   return cls;
 }
 
-export function DataTiles({ state, gridMode, onBackroomClick }: DataTilesProps) {
+export function DataTiles({ state, gridMode, onBackroomClick, onAcumenClick }: DataTilesProps) {
   const { club, league, boardConfidence, currentWeek, businessAcumen } = state;
 
   const playerEntry = league.entries.find(e => e.clubId === club.id);
@@ -126,6 +127,7 @@ export function DataTiles({ state, gridMode, onBackroomClick }: DataTilesProps) 
       value: '★'.repeat(acumenAvg) + '☆'.repeat(5 - acumenAvg),
       sub: `Fin ${businessAcumen.financial}★  Stat ${businessAcumen.statistical}★  Strat ${businessAcumen.strategic}★`,
       color: 'text-warn-amber',
+      onClick: onAcumenClick,
     },
     {
       label: 'Backroom Team',

--- a/packages/frontend/src/components/command-centre/LearningProgressSlideOver.tsx
+++ b/packages/frontend/src/components/command-centre/LearningProgressSlideOver.tsx
@@ -1,0 +1,342 @@
+import { useState } from 'react';
+import {
+  GameState,
+  GameEvent,
+  assessReadinessForProgression,
+  getAllCurriculumLevels,
+  setCurriculumLevel,
+  CurriculumLevel,
+  ProgressionEvidence,
+  CURRICULUM_LEVELS,
+} from '@calculating-glory/domain';
+
+// ── Criterion row ─────────────────────────────────────────────────────────────
+
+interface CriterionRowProps {
+  label: string;
+  met: boolean;
+  value: number;
+  required: number;
+  format: (n: number) => string;
+  higherIsBetter?: boolean;
+}
+
+function CriterionRow({ label, met, value, required, format, higherIsBetter = true }: CriterionRowProps) {
+  const fillPct = higherIsBetter
+    ? Math.min(100, (value / required) * 100)
+    : Math.min(100, (required / Math.max(value, 0.01)) * 100);
+
+  return (
+    <div className="flex flex-col gap-1 py-2 border-b border-bg-raised last:border-0">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className={`text-xs font-mono shrink-0 ${met ? 'text-pitch-green' : 'text-alert-red'}`}>
+            {met ? '✓' : '✗'}
+          </span>
+          <span className="text-xs text-txt-primary">{label}</span>
+        </div>
+        <div className="text-right shrink-0">
+          <span className={`text-xs font-mono ${met ? 'text-pitch-green' : 'text-txt-muted'}`}>
+            {format(value)}
+          </span>
+          <span className="text-xs2 text-txt-muted/60 ml-1">/ {format(required)}</span>
+        </div>
+      </div>
+      {/* Progress bar */}
+      <div className="h-1 bg-bg-raised rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${met ? 'bg-pitch-green' : 'bg-data-blue/60'}`}
+          style={{ width: `${fillPct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ── Topic chips ───────────────────────────────────────────────────────────────
+
+const TOPIC_LABELS: Record<string, string> = {
+  BASIC_ARITHMETIC:    'Arithmetic',
+  DECIMALS:            'Decimals',
+  PERCENTAGES:         'Percentages',
+  SIMPLE_FRACTIONS:    'Fractions',
+  RATIOS:              'Ratios',
+  BASIC_ALGEBRA:       'Algebra',
+  DATA_INTERPRETATION: 'Data',
+  COMPOUND_PERCENTAGES:'Compound %',
+  NEGATIVE_NUMBERS:    'Negatives',
+  SIMULTANEOUS_EQUATIONS: 'Simultaneous Eq.',
+  PROBABILITY:         'Probability',
+  SEQUENCES:           'Sequences',
+  TRIGONOMETRY:        'Trigonometry',
+  QUADRATIC_EQUATIONS: 'Quadratics',
+  ADVANCED_PROBABILITY:'Adv. Probability',
+  STATISTICAL_ANALYSIS:'Statistics',
+  GRAPH_INTERPRETATION:'Graphs',
+};
+
+// ── Level selector (teacher control) ─────────────────────────────────────────
+
+interface LevelSelectorProps {
+  current: CurriculumLevel;
+  onChange: (level: CurriculumLevel) => void;
+}
+
+function LevelSelector({ current, onChange }: LevelSelectorProps) {
+  const [open, setOpen] = useState(false);
+  const levels = getAllCurriculumLevels();
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="w-full flex items-center justify-between px-3 py-2 rounded-card
+                   bg-bg-raised border border-bg-raised hover:border-data-blue/40
+                   text-xs text-txt-muted transition-colors"
+      >
+        <span>Change level</span>
+        <span className={`transition-transform ${open ? 'rotate-180' : ''}`}>▾</span>
+      </button>
+      {open && (
+        <div className="absolute bottom-full mb-1 left-0 right-0 bg-bg-surface border border-bg-raised
+                        rounded-card overflow-hidden shadow-xl z-10">
+          {levels.map(l => (
+            <button
+              key={l.level}
+              onClick={() => { onChange(l.level); setOpen(false); }}
+              className={[
+                'w-full text-left px-3 py-2 text-xs transition-colors',
+                l.level === current
+                  ? 'bg-data-blue/15 text-data-blue font-semibold'
+                  : 'text-txt-muted hover:bg-bg-raised hover:text-txt-primary',
+              ].join(' ')}
+            >
+              {l.displayName}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Evidence section ──────────────────────────────────────────────────────────
+
+function EvidenceSection({ evidence }: { evidence: ProgressionEvidence }) {
+  const pct = (v: number) => `${(v * 100).toFixed(0)}%`;
+  const dp2 = (v: number) => v.toFixed(2);
+
+  return (
+    <div className="px-4">
+      <CriterionRow
+        label="Overall accuracy"
+        met={evidence.overallAccuracy.met}
+        value={evidence.overallAccuracy.value}
+        required={evidence.overallAccuracy.required}
+        format={pct}
+      />
+      <CriterionRow
+        label="Hard problem accuracy"
+        met={evidence.hardProblemAccuracy.met}
+        value={evidence.hardProblemAccuracy.value}
+        required={evidence.hardProblemAccuracy.required}
+        format={pct}
+      />
+      <CriterionRow
+        label="Hints used per problem"
+        met={evidence.hintsUsage.met}
+        value={evidence.hintsUsage.value}
+        required={evidence.hintsUsage.required}
+        format={dp2}
+        higherIsBetter={false}
+      />
+      <CriterionRow
+        label="Speed vs. expected"
+        met={evidence.timeEfficiency.met}
+        value={evidence.timeEfficiency.value}
+        required={evidence.timeEfficiency.required}
+        format={v => `${v.toFixed(1)}×`}
+        higherIsBetter={false}
+      />
+      <CriterionRow
+        label="Topic consistency"
+        met={evidence.topicConsistency.met}
+        value={evidence.topicConsistency.value}
+        required={evidence.topicConsistency.required}
+        format={pct}
+      />
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+interface LearningProgressSlideOverProps {
+  state: GameState;
+  events: GameEvent[];
+}
+
+export function LearningProgressSlideOver({ state, events }: LearningProgressSlideOverProps) {
+  const [curriculumLevel, setCurrLevel] = useState<CurriculumLevel>(state.curriculum.level);
+
+  const config  = CURRICULUM_LEVELS[curriculumLevel];
+  const assessment = assessReadinessForProgression(events);
+  const { evidence, readinessScore, recommendations, nextLevel } = assessment;
+  const hasData = evidence.sampleSize >= 20;
+
+  function handleLevelChange(level: CurriculumLevel) {
+    setCurrLevel(level);
+    setCurriculumLevel(level);
+  }
+
+  const allLevels: CurriculumLevel[] = ['YEAR_7', 'YEAR_8', 'YEAR_9', 'GCSE_FOUNDATION', 'GCSE_HIGHER'];
+  const levelIndex = allLevels.indexOf(curriculumLevel);
+
+  return (
+    <div className="flex flex-col h-full pb-4">
+
+      {/* ── Current level header ──────────────────────────────────────────── */}
+      <div className="px-4 py-4 bg-bg-raised border-b border-bg-raised/50 shrink-0">
+        <div className="flex items-center justify-between mb-3">
+          <div>
+            <p className="text-xs text-txt-muted uppercase tracking-wide mb-0.5">Current Level</p>
+            <p className="text-xl font-bold text-txt-primary">{config.displayName}</p>
+            <p className="text-xs2 text-txt-muted">{config.leagueLevel.replace('_', ' ')} · {config.topics.length} topics active</p>
+          </div>
+          {/* Level pip track */}
+          <div className="flex gap-1.5 items-center">
+            {allLevels.map((l, i) => (
+              <div
+                key={l}
+                className={[
+                  'rounded-full transition-all',
+                  i < levelIndex ? 'w-2 h-2 bg-pitch-green' :
+                  i === levelIndex ? 'w-3 h-3 bg-data-blue ring-2 ring-data-blue/30' :
+                  'w-2 h-2 bg-bg-surface',
+                ].join(' ')}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Progress toward next level */}
+        {nextLevel && (
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <span className="text-xs2 text-txt-muted">
+                Progress → {CURRICULUM_LEVELS[nextLevel].displayName}
+              </span>
+              <span className={`text-xs2 font-mono ${
+                readinessScore >= 80 ? 'text-pitch-green' :
+                readinessScore >= 50 ? 'text-warn-amber' : 'text-txt-muted'
+              }`}>
+                {Math.round(readinessScore)}%
+              </span>
+            </div>
+            <div className="h-1.5 bg-bg-surface rounded-full overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all duration-700 ${
+                  readinessScore >= 100 ? 'bg-pitch-green' :
+                  readinessScore >= 60  ? 'bg-warn-amber' : 'bg-data-blue/70'
+                }`}
+                style={{ width: `${Math.min(100, readinessScore)}%` }}
+              />
+            </div>
+          </div>
+        )}
+        {!nextLevel && (
+          <p className="text-xs text-pitch-green font-medium">
+            ★ Highest level reached
+          </p>
+        )}
+      </div>
+
+      {/* ── Scrollable body ───────────────────────────────────────────────── */}
+      <div className="flex-1 overflow-y-auto">
+
+        {/* Readiness criteria */}
+        <div className="pt-2">
+          <p className="text-xs font-semibold text-txt-muted uppercase tracking-wider px-4 pb-1 pt-2">
+            Readiness criteria {hasData ? `· ${evidence.sampleSize} problems` : ''}
+          </p>
+
+          {!hasData ? (
+            <div className="mx-4 my-2 px-3 py-3 rounded-card bg-bg-raised border border-bg-raised/50 text-center">
+              <p className="text-xs text-txt-muted">
+                Complete {Math.max(0, 20 - evidence.sampleSize)} more problems to unlock your assessment
+              </p>
+              <div className="mt-2 h-1 bg-bg-surface rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-data-blue/60 rounded-full"
+                  style={{ width: `${(evidence.sampleSize / 20) * 100}%` }}
+                />
+              </div>
+              <p className="text-xs2 text-txt-muted/60 mt-1">{evidence.sampleSize} / 20 problems</p>
+            </div>
+          ) : (
+            <EvidenceSection evidence={evidence} />
+          )}
+        </div>
+
+        {/* Recommendations */}
+        {hasData && recommendations.length > 0 && (
+          <div className="px-4 pt-3 pb-1">
+            <p className="text-xs font-semibold text-txt-muted uppercase tracking-wider mb-2">
+              Recommendations
+            </p>
+            <div className="flex flex-col gap-1">
+              {recommendations.map((rec, i) => (
+                <p key={i} className="text-xs2 text-txt-muted/90 leading-relaxed">
+                  {rec}
+                </p>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Active topics */}
+        <div className="px-4 pt-4 pb-2">
+          <p className="text-xs font-semibold text-txt-muted uppercase tracking-wider mb-2">
+            Active Topics
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {config.topics.map(t => (
+              <span
+                key={t}
+                className="badge bg-data-blue/10 text-data-blue/80 text-xs2"
+              >
+                {TOPIC_LABELS[t] ?? t}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* Unlocked features */}
+        <div className="px-4 pt-2 pb-4">
+          <p className="text-xs font-semibold text-txt-muted uppercase tracking-wider mb-2">
+            Features at this level
+          </p>
+          <div className="flex flex-col gap-1">
+            {Object.entries(config.features).map(([key, enabled]) => (
+              <div key={key} className="flex items-center gap-2">
+                <span className={`text-xs2 shrink-0 ${enabled ? 'text-pitch-green' : 'text-txt-muted/30'}`}>
+                  {enabled ? '✓' : '○'}
+                </span>
+                <span className={`text-xs2 ${enabled ? 'text-txt-muted' : 'text-txt-muted/40'}`}>
+                  {key.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase())}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* ── Teacher control footer ────────────────────────────────────────── */}
+      <div className="px-4 pt-3 border-t border-bg-raised shrink-0">
+        <p className="text-xs2 text-txt-muted/60 mb-2">Teacher — change curriculum level:</p>
+        <LevelSelector current={curriculumLevel} onChange={handleLevelChange} />
+      </div>
+
+    </div>
+  );
+}

--- a/packages/frontend/src/components/social-feed/generateChallenge.ts
+++ b/packages/frontend/src/components/social-feed/generateChallenge.ts
@@ -419,10 +419,22 @@ export function generateChallenge(
     },
   ];
 
+  // ── Curriculum difficulty cap ─────────────────────────────────────────────────
+  const MAX_DIFFICULTY_BY_LEVEL: Record<string, number> = {
+    YEAR_7:          1,
+    YEAR_8:          2,
+    YEAR_9:          3,
+    GCSE_FOUNDATION: 3,
+    GCSE_HIGHER:     3,
+  };
+  const maxDifficulty = MAX_DIFFICULTY_BY_LEVEL[state.curriculum?.level ?? 'YEAR_7'] ?? 3;
+  const diffCapped = challenges.filter(c => c.difficulty <= maxDifficulty);
+  const challengePool = diffCapped.length > 0 ? diffCapped : challenges;
+
   // ── Topic override: filter bank to a single topic ────────────────────────────
   const topicFiltered = topicOverride
-    ? challenges.filter(c => c.topic === topicOverride)
-    : challenges;
+    ? challengePool.filter(c => c.topic === topicOverride)
+    : challengePool;
 
   // ── Exclude the previously shown template to avoid back-to-back duplicates ──
   const templateSlug = excludeTemplateSlug ?? '';
@@ -432,7 +444,7 @@ export function generateChallenge(
 
   // Fall back to full topic pool if exclusion would empty it
   const pool = deduped.length > 0 ? deduped : topicFiltered;
-  const safePool = pool.length > 0 ? pool : challenges;
+  const safePool = pool.length > 0 ? pool : challengePool;
 
   // ── No performance data or all zeros → plain index cycling ─────────────────
   const hasPerformanceData =

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     },
   },
   server: {
-    port: 3000,
+    port: process.env.PORT ? parseInt(process.env.PORT) : 3000,
     host: true,
   },
 });


### PR DESCRIPTION
## Summary

- **Learning Progress slide-over** — clicking the Business Acumen tile opens a full progression panel: 5-level pip track, 5 readiness criteria (gated behind 20-problem minimum), active topic chips, feature flags list, and a teacher-only curriculum level selector
- **Challenge difficulty cap** — `generateChallenge` now filters the challenge bank by curriculum level before selection (Year 7 → difficulty 1 only; Year 8 → 1–2; Year 9+ → all)
- **Vite port fix** — `vite.config.ts` reads `process.env.PORT` so the preview tool can assign its own port rather than fighting over 3000
- **`.build/` docs** — STATUS, ROADMAP, NEXT, BACKLOG updated: Phase 3 marked complete, Stadium View (#21) flagged as needing a planning session before build, progress updated to 90%

## Test plan

- [x] `npm test --workspace=@calculating-glory/domain` — 245/245 passing
- [x] `npm run build --workspace=@calculating-glory/frontend` — clean build, no TypeScript errors
- [x] Click Business Acumen tile → Learning Progress slide-over opens with correct Year 7 content
- [x] Slide-over shows "Complete 20 more problems" gating message when no challenge data exists
- [x] Teacher level selector present in slide-over footer
- [ ] Advance week and complete challenges → verify readiness criteria populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)