### PR TITLE
feat: Stadium View foundation — facility types, view toggle, card grid

### DIFF
--- a/.build/BACKLOG.md
+++ b/.build/BACKLOG.md
@@ -1,22 +1,27 @@
 ---
 project: "Calculating Glory"
 type: "build"
-lastUpdated: "2026-03-09"
+lastUpdated: "2026-03-10"
 ---
 
 # Calculating Glory - Backlog & Ideas
 
 ## Features / Functionality
 
-- [ ] Stadium View — dual home screen with MECE core/sub-unit grid (#21 — needs planning session first)
+- [ ] Isometric SVG renderer — 20x14 tile grid, 10 core units, sub-unit art progression (#21 PR 3)
+- [ ] Navigation wiring — core unit clicks open slide-overs, BuildPanel for upgrades (#21 PR 4)
+- [ ] Weekly Training Focus — SET_TRAINING_FOCUS command, training drill challenges (#21 PR 5)
+- [ ] Geometry challenges — 4 new MathTopics, stadium-themed templates (#21 PR 6)
 - [ ] Player database/market — pool of purchasable players with real(ish) names and stats
 - [ ] Transfer window UI — browse market, make offers, negotiate
-- [ ] Full isometric rendering — pixel art stadium/facilities, 64x32px tiles
 - [ ] Tutorial/onboarding flow — first-time player guidance
 - [ ] Pre-season flow — squad building before the season starts
 - [ ] Season end screen — promotion/relegation celebration/commiseration
 - [ ] Multiplayer sync — async turn-based between friends
 - [ ] Save/load to server (beyond localStorage)
+- [x] Stadium View plan — MECE coverage, grid layout, hit regions, sub-unit progression ✅
+- [x] Domain foundation — 9 facility types, FACILITY_CONFIG, weekly revenue ✅
+- [x] App shell — ViewToggle, StadiumView card grid, shared FacilityCard ✅
 - [x] InboxCard overhaul — result cards, dismissal, preview cap ✅
 - [x] InboxHistory full slide-over ✅
 - [x] Seeded news generator (transfer/injury/league) ✅
@@ -32,6 +37,7 @@ lastUpdated: "2026-03-09"
 - [ ] Morale system — explicit morale stat rather than folded into randomness
 - [ ] Match events beyond goals — injuries, red cards, suspensions
 - [ ] Practice mode — Marcus Webb free math drills for business acumen improvement
+- [ ] Decision density overhaul — squad selection, transfers, contracts, sponsorship (separate issue)
 - [x] Business acumen tile clickable → Learning Progress slide-over ✅
 - [x] Challenge difficulty capped by curriculum level ✅
 - [x] Star player name injected into wage-demand event ✅
@@ -42,6 +48,8 @@ lastUpdated: "2026-03-09"
 - [ ] Hint system — curriculum-appropriate scaffolding for math challenges
 - [ ] All branching club event chains — 15 templates, 4 branching follow-ups fully written
 - [ ] Teacher dashboard — class view of student progress
+- [ ] Geometry/shape challenges from Stadium View (AREA_AND_PERIMETER, ANGLES, SCALE_AND_PROPORTION, PROPERTIES_OF_SHAPES)
+- [ ] "Groundskeeper" NPC for geometry practice from Stadium View
 - [x] Learning Progress slide-over (5-level pip track, readiness criteria, topic chips) ✅
 - [x] Curriculum difficulty cap in challenge generator ✅
 
@@ -50,7 +58,7 @@ lastUpdated: "2026-03-09"
 - [ ] Chromebook performance profiling — ensure smooth at 1366x768
 - [ ] Accessibility audit — keyboard nav, colour contrast for school use
 - [ ] Offline capability — service worker for no-internet classrooms
-- [ ] Stadium View MECE analysis — map every playable game aspect to a unit/sub-unit
+- [x] Stadium View MECE analysis — every game system mapped to exactly one core unit ✅
 
 ## Future Phases
 
@@ -65,6 +73,10 @@ lastUpdated: "2026-03-09"
 - Branching path dependency (past decisions unlock/block future events) creates replay value
 - Star ratings for business acumen should feel rewarding, not punishing
 - Integer pence arithmetic was the right call — no floating-point issues anywhere
-- Stadium View needs MECE coverage: every playable aspect of the game should map to exactly one core unit, no gaps, no overlaps
-- `CLUB_COMMERCIAL_CENTRE` concept: kit shop, sponsorship deals, TV rights — likely a Phase 5 sub-unit under a Commercial core unit
+- FACILITY_CONFIG is single source of truth — domain, reducers, and frontend all read from it
+- Pitch and Stands are two visual core units backed by one STADIUM facility
 - Two-tier grid principle: Core units = navigation anchors (clickable); Sub-units = visual/stat effects only (pointer-events: none)
+- Grounds & Security directly impacts attendance rate — natural math hook for percentages
+- Food & Beverage ties into existing "Hot Dog Hygiene" club events — narrative hooks built in
+- Fan Zone + Grounds & Security were late additions that improve decision density and visual variety
+- ~2.8 mandatory decisions/week is too thin — Weekly Training Focus (PR 5) is the quick win

--- a/.build/NEXT.md
+++ b/.build/NEXT.md
@@ -1,27 +1,27 @@
 ---
 project: "Calculating Glory"
 type: "build"
-lastUpdated: "2026-03-09"
+lastUpdated: "2026-03-10"
 ---
 
 # Calculating Glory - Next Steps
 
 ## Immediate (This Session/Week)
 
-1. Merge confident-colden PR into main
-2. Stadium View planning session — map core/sub-unit MECE grid before writing any code (issue #21)
-3. End-to-end smoke test: new game → resolve events via Social Feed → advance week → see match results update live
+1. PR 3: Isometric SVG renderer — IsometricGrid.tsx, CoreUnit.tsx, SubUnitRenderer.tsx, stadium-layout.ts, isometric-utils.ts, sub-unit art files (SNES pixel-art style)
+2. PR 4: Navigation wiring — core unit clicks open correct slide-overs, BuildPanel.tsx for undeveloped plots, "coming soon" placeholders
+3. Commit and PR the current work (domain foundation + app shell + stadium view cards)
 
 ## Short Term (Next 2-4 Weeks)
 
-1. Stadium View build — dual home screen, core units as navigation anchors, sub-units as visual stat effects
-2. UI polish pass — responsive layout at 1366x768, error states, loading skeletons
-3. Club event narrative copy — flesh out all 15 event templates' Social Feed chat bubbles
-4. Practice mode (Marcus Webb free drills) — business acumen improvement without game-state cost
-5. End-to-end integration tests (issue #12)
+1. PR 5: Weekly Training Focus — new command SET_TRAINING_FOCUS, training drill math challenges, adds ~2 decisions/week
+2. PR 6: Geometry challenges — 4 new MathTopics (AREA_AND_PERIMETER, ANGLES, SCALE_AND_PROPORTION, PROPERTIES_OF_SHAPES), stadium-themed templates
+3. End-to-end integration tests (issue #12)
+4. UI polish for Chromebook 1366x768 (issue #13)
+5. File separate issue: Decision Density Overhaul (squad selection, transfers, contracts, sponsorship)
 
 ## Questions / Unknowns
 
-- Stadium View: what are the definitive core units? (Training, Medical, Youth, Stadium, Office, Commercial confirmed — any others?)
-- Is the 3-week mid-season loop sufficient for the MVP demo or do stakeholders want a longer segment?
+- Sub-unit art style: how detailed should the SNES pixel-art SVG be? Simple geometric shapes or more elaborate?
+- Should isometric view support zoom/pan for smaller screens, or fixed viewport only?
 - Deployment target: school network hosted URL, or standalone Chromebook app?

--- a/.build/ROADMAP.md
+++ b/.build/ROADMAP.md
@@ -2,14 +2,14 @@
 project: "Calculating Glory"
 type: "build"
 createdAt: "2026-03-03"
-lastUpdated: "2026-03-09"
+lastUpdated: "2026-03-10"
 ---
 
 # Calculating Glory - Roadmap
 
 An educational football club management game for Year 7 maths, built on event-sourced domain logic with deterministic simulation. Players manage a League Two club through a season, making decisions that require mathematical problem-solving.
 
-## Current Phase: MVP Build
+## Completed Phases
 
 ### Phase 2: Frontend Foundation ✅
 - 2.1 React + Tailwind CSS frontend scaffolded ✅ (#1)
@@ -23,8 +23,6 @@ An educational football club management game for Year 7 maths, built on event-so
 - 2.9 Week advance button (disabled until events resolved) ✅ (#9)
 - 2.10 Isometric Blueprint placeholder tiles (card-based) ✅ (#10)
 - 2.11 First playable: 3-week mid-season loop (week 20 onward) ✅ (#11)
-- 2.12 End-to-end integration testing (pending)
-- 2.13 UI polish pass (responsiveness, error states, loading) (pending)
 
 ### Phase 3: UI Polish & Feature Completion ✅
 - 3.1–3.4 InboxCard overhaul, InboxHistory slide-over, Command Centre restructure ✅ (#14, #19)
@@ -34,13 +32,20 @@ An educational football club management game for Year 7 maths, built on event-so
 - 3.8 Star player name injected into wage-demand club event ✅ (#18)
 - 3.9 Learning Progress slide-over + Business Acumen tile click ✅ (#20)
 - 3.10 Challenge difficulty capped by curriculum level ✅ (#20)
+- 3.11 Curriculum progression UI ✅ (#22)
 
-## Next Phase: Stadium View & Integration
+## Current Phase: Stadium View & Integration
 
-- 4.1 Stadium View planning — define MECE core/sub-unit grid (#21)
-- 4.2 Stadium View build — dual home screen, core units as nav anchors
-- 4.3 End-to-end integration test pass (#12)
-- 4.4 UI polish for Chromebook 1366x768 (#13)
+### Phase 4: Stadium View (#21)
+- 4.1 Stadium View planning — MECE core/sub-unit grid, architectural decisions ✅
+- 4.2 Domain foundation — 9 facility types, FACILITY_CONFIG, weekly revenue, getDefaultFacilities() ✅
+- 4.3 App shell — ViewToggle, StadiumView card grid, shared FacilityCard ✅
+- 4.4 Isometric SVG renderer — 20x14 grid, 10 core units, sub-unit art (in progress)
+- 4.5 Navigation wiring — core unit clicks open slide-overs, BuildPanel
+- 4.6 Weekly Training Focus — SET_TRAINING_FOCUS command, training drill challenges
+- 4.7 Geometry challenges — 4 new MathTopics, stadium-themed templates
+- 4.8 End-to-end integration test pass (#12)
+- 4.9 UI polish for Chromebook 1366x768 (#13)
 
 ## Future Phases
 
@@ -59,10 +64,10 @@ An educational football club management game for Year 7 maths, built on event-so
 - Hint system with curriculum-appropriate scaffolding
 
 ### Phase 7: Polish & Multiplayer Prep
-- Full isometric rendering (pixel art upgrade from card placeholders)
 - AI team evolution (form/results affect strength over season)
 - Morale system
 - Match events beyond goals (injuries, red cards, suspensions)
+- Decision density overhaul (squad selection, transfers, contracts, sponsorship)
 - Multiplayer sync architecture (async, turn-based)
 
 ## Out of Scope (for now)

--- a/.build/SESSION_START.md
+++ b/.build/SESSION_START.md
@@ -1,44 +1,85 @@
-# Session Progress - 2026-03-03
+# Session Progress - 2026-03-10
 
 ## Session Goals
-- Review and update .build/ project initialisation files
-- Get dev server running
-- Assess current state of frontend and domain packages
+- Complete Stadium View architectural planning (issue #21)
+- Implement PR 1: Domain foundation (new facility types, revenue, config)
+- Implement PR 2: App shell + Stadium View (view toggle, facility card grid)
 
 ## Completed Work
 
-### 1. Dev Environment
-- **Dependencies reinstalled** ✅
-  - Removed stale node_modules and package-lock.json
-  - Clean `npm install` to fix rollup native module issue
-- **Domain package builds** ✅
-  - `npm run build --workspace=@calculating-glory/domain`
-- **Dev server running** ✅
-  - Vite on http://localhost:3000/ via `npx vite` in packages/frontend
+### 1. Stadium View Architectural Plan
+- **MECE Coverage** ✅
+  - Mapped all 15+ game systems to exactly 10 core units, no orphans
+  - Core units: Pitch, Stands, Training, Medical, Youth, Office, Commercial, Food & Beverage, Fan Zone, Grounds & Security
+  - Key decisions: Pitch = cosmetic only (driven by STADIUM level), Stands = gameplay progression
+  - Week advance moved to persistent top bar (accessible from both views)
+- **Grid Layout** ✅
+  - 20x14 isometric grid at 64x32px tiles, fits 1366x720 viewport
+  - All 10 core units positioned with concrete grid coordinates
+  - ~25% grid utilisation — room for growth
+- **Hit Region Model** ✅
+  - SVG `<g>` with transparent rect overlay (not Canvas)
+  - React-managed HTML tooltip over SVG
+- **Sub-Unit Progression** ✅
+  - 5-level visual progression tables for all 10 core units
+  - Stands: South L1, North L2, East L3, West L4, Floodlights+Roofs L5
+- **Geometry Challenges** ✅
+  - 4 new MathTopics planned: AREA_AND_PERIMETER, ANGLES, SCALE_AND_PROPORTION, PROPERTIES_OF_SHAPES
+  - Stadium-themed challenge templates for each core unit
+- **Decision Density** ✅
+  - Analysed ~2.8 mandatory decisions/week (too thin)
+  - Weekly Training Focus (PR 5) adds ~2 more decisions/week
+  - Separate issue planned for full density overhaul
 
-### 2. Project Initialisation
-- **Updated .build/ files** ✅
-  - ROADMAP.md — reflects completed domain phase and current MVP Build
-  - STATUS.md — priority 2, 20% progress, accurate blockers and notes
-  - NEXT.md — current actionable next steps and unknowns
-  - BACKLOG.md — comprehensive feature/improvement backlog
+### 2. PR 1: Domain Foundation
+- **facility.ts** ✅
+  - 9 facility types (added CLUB_OFFICE, CLUB_COMMERCIAL, FOOD_AND_BEVERAGE, FAN_ZONE, GROUNDS_SECURITY)
+  - 7 benefit types (added board_confidence, reputation, attendance)
+  - FACILITY_CONFIG as single source of truth with upgrade costs
+  - getDefaultFacilities() driven by FACILITY_CONFIG
+- **reducers/index.ts** ✅
+  - handleGameStarted initialises facilities via getDefaultFacilities()
+  - handleWeekAdvanced calculates weekly revenue from CLUB_COMMERCIAL + FOOD_AND_BEVERAGE
+  - handleFacilityUpgraded recalculates upgradeCost from FACILITY_CONFIG
+- **Verification** ✅
+  - 245 domain tests passing, TypeScript compiles cleanly
+
+### 3. PR 2: App Shell + Stadium View
+- **ViewToggle.tsx** (new) ✅
+  - Persistent top bar: club info (left), Command Centre/Stadium View toggle (centre), week advance (right)
+- **FacilityCard.tsx** (new shared) ✅
+  - Extracted from IsometricBlueprint, reusable across views
+- **StadiumView.tsx** (new) ✅
+  - Full-screen facility management: stadium header, budget banner, 2-col card grid
+  - All 9 facility types render with upgrade buttons
+- **App.tsx** ✅
+  - activeView state, ViewToggle + conditional CommandCentre/StadiumView render
+  - Error toast + loading overlay moved from CommandCentre to App
+- **CommandCentre.tsx** ✅
+  - Removed header (moved to ViewToggle), removed isometric slide-over
+  - HubTile "Stadium & Facilities" navigates to Stadium View via onNavigateToStadium prop
+- **Verification** ✅
+  - Dev server: both views render, toggle works, no console errors
+  - All 9 facilities visible in Stadium View
 
 ## Architecture Notes
 
-- Root workspace scripts use `--workspace=frontend` but the package name is `@calculating-glory/frontend` — causes `npm run dev` from root to fail
-- Dev server works when run directly: `cd packages/frontend && npx vite`
-- Domain package must be built before frontend can resolve `@calculating-glory/domain` imports
+- FACILITY_CONFIG is now the single source of truth — domain, reducers, and frontend all read from it
+- Pitch and Stands share the STADIUM facility type but are separate visual core units
+- View toggle is `useState<'command' | 'stadium'>` in App.tsx — no router needed
+- IsometricBlueprint.tsx retained as slide-over component but now uses shared FacilityCard
 
 ## Current Status
 
 ### ✅ Working
-- Domain package (245 tests, clean build)
-- Frontend dev server (Vite on port 3000)
-- All .build/ files up to date
+- Domain package (245 tests, 9 facility types, weekly revenue)
+- View toggle between Command Centre and Stadium View
+- Stadium View with all 9 facility cards
+- All existing Command Centre functionality intact
 
-### 🟡 In Progress
-- End-to-end playable loop verification
-- UI polish for Chromebook target
+### 🟡 Ready for Next PR
+- PR 3: Isometric SVG renderer (grid, core units, sub-unit art)
+- PR 4: Navigation wiring (core unit clicks open slide-overs)
 
 ### 🔴 Blocked
 - Nothing blocked
@@ -46,25 +87,36 @@
 ## Build Commands / Key Files
 
 ```bash
-# Build domain (must do first)
-npm run build --workspace=@calculating-glory/domain
+# Build domain
+cd packages/domain && npm run build
 
-# Start frontend dev server
-cd packages/frontend && npx vite
+# Type check frontend
+cd packages/frontend && npx tsc --noEmit
 
 # Run domain tests
-npm test --workspace=@calculating-glory/domain
+cd packages/domain && npm test
 
-# Run determinism tests
-npm run test:determinism --workspace=@calculating-glory/domain
+# Start dev server
+npm run dev --workspace=@calculating-glory/frontend
 ```
+
+## Key Files Modified This Session
+
+- `packages/domain/src/types/facility.ts` — 9 facility types, FACILITY_CONFIG
+- `packages/domain/src/reducers/index.ts` — facility init, weekly revenue, upgrade cost
+- `packages/frontend/src/App.tsx` — view toggle, conditional rendering
+- `packages/frontend/src/components/shared/ViewToggle.tsx` — persistent top bar (new)
+- `packages/frontend/src/components/shared/FacilityCard.tsx` — shared facility card (new)
+- `packages/frontend/src/components/stadium-view/StadiumView.tsx` — stadium view (new)
+- `packages/frontend/src/components/command-centre/CommandCentre.tsx` — removed header/isometric
+- `packages/frontend/src/components/isometric/IsometricBlueprint.tsx` — uses shared FacilityCard
 
 ## Next Session Goals
 
-- Wire up and test the full playable loop in browser
-- Fix root package.json workspace script names
-- Begin UI polish pass
+- PR 3: Isometric SVG renderer (stadium-layout.ts, isometric-utils.ts, CoreUnit.tsx, sub-unit art)
+- PR 4: Navigation wiring (core unit clicks open correct slide-overs)
+- Consider PR 5: Weekly Training Focus (decision density quick win)
 
 ---
 
-**Status**: Dev environment working, .build/ files refreshed, ready to focus on playable loop next session.
+**Status**: Stadium View plan complete, domain foundation + app shell implemented. Ready for isometric SVG renderer (PR 3).

--- a/.build/STATUS.md
+++ b/.build/STATUS.md
@@ -2,17 +2,17 @@
 project: "Calculating Glory"
 type: "build"
 priority: 2
-phase: "MVP Build"
-progress: 90
-lastUpdated: "2026-03-09"
-lastTouched: "2026-03-09"
+phase: "Stadium View & Integration"
+progress: 30
+lastUpdated: "2026-03-10"
+lastTouched: "2026-03-10"
 status: "in-progress"
 ---
 
 # Calculating Glory - Current Status
 
-**Phase:** MVP Build (90% complete — 20 issues closed)
-**Last Updated:** 2026-03-09
+**Phase:** Stadium View & Integration (30% — planning complete, domain + app shell coded)
+**Last Updated:** 2026-03-10
 
 ## What's Done
 
@@ -29,7 +29,6 @@ status: "in-progress"
 - Frontend scaffolded: React + Vite + Tailwind, all components built
 - Command Centre hub (12-column grid, data tiles, league table, squad audit)
 - Social Feed slide-over (chat bubbles, negotiation keyboard, math challenges)
-- Isometric Blueprint placeholder (card-based facility upgrades)
 - News ticker, pending event cards, week advance button
 - InboxCard overhaul (result cards, dismissal, preview cap)
 - InboxHistory full slide-over (scrollable results + news, dismiss all)
@@ -39,22 +38,30 @@ status: "in-progress"
 - Star player name injection into player-unhappy event
 - Learning Progress slide-over (5-level pip track, 5 readiness criteria, topic chips, teacher level selector)
 - Business Acumen tile clickable → opens Learning Progress slide-over
-- generateChallenge difficulty cap by curriculum level (Year 7 → d1 only, Year 8 → d1-2, Year 9+ → all)
+- generateChallenge difficulty cap by curriculum level
+- **Stadium View architectural plan complete** (MECE coverage, grid layout, hit regions, sub-unit progression)
+- **9 facility types** (added FAN_ZONE, GROUNDS_SECURITY, CLUB_OFFICE, CLUB_COMMERCIAL, FOOD_AND_BEVERAGE)
+- **FACILITY_CONFIG** as single source of truth for all facility metadata
+- **Weekly revenue system** (CLUB_COMMERCIAL + FOOD_AND_BEVERAGE generate income per week)
+- **Persistent ViewToggle** top bar (Command Centre / Stadium View toggle + week advance)
+- **StadiumView** full-screen facility management with 2-col card grid
 
 ## What's In Progress
 
-- End-to-end playable loop fully wired (events → resolve → advance → results)
-- UI polish pass for Chromebook target (1366x768)
-- Stadium View planning (issue #21 — full MECE planning session required before build)
+- PR 3: Isometric SVG renderer (grid, core units, sub-unit art) — next up
+- PR 4: Navigation wiring (core unit clicks open correct slide-overs)
 
 ## Blockers
 
-- Stadium View (#21) needs a dedicated planning session to map core/sub-unit grid before any implementation
+- None
 
 ## Notes
 
 - Target device: Chromebook 1366x768 (keyboard + trackpad)
 - MVP scope: 3-week mid-season loop starting week 20 — not full season
-- Dev server: `npm run dev --workspace=@calculating-glory/frontend` (reads PORT env var via vite.config.ts)
-- Domain tests: `npm test --workspace=@calculating-glory/domain`
-- All changes in confident-colden worktree; pending merge to main
+- Dev server: `npm run dev --workspace=@calculating-glory/frontend`
+- Domain tests: `cd packages/domain && npm test`
+- Plan file: `.claude/plans/iterative-tinkering-snowglobe.md`
+- 10 core units map to 9 facility types (Pitch + Stands share STADIUM)
+- PR 5 (Weekly Training Focus) planned as decision density quick win
+- PR 6 (Geometry Challenges) planned for stadium-themed maths

--- a/packages/domain/src/reducers/index.ts
+++ b/packages/domain/src/reducers/index.ts
@@ -10,6 +10,7 @@ import { Club } from '../types/club';
 import { LeagueTable, LeagueTableEntry, sortLeagueTable } from '../types/league';
 import { CURRICULUM_LEVELS } from '../curriculum/curriculum-config';
 import { LEAGUE_TWO_TEAMS } from '../data/league-two-teams';
+import { getDefaultFacilities, getUpgradeCost } from '../types/facility';
 
 /**
  * Reduce an event into state
@@ -135,7 +136,8 @@ function handleGameStarted(state: GameState, event: GameStartedEvent): GameState
       id: event.clubId,
       name: event.clubName,
       transferBudget: event.initialBudget,
-      wageBudget: event.initialBudget / 10 // 10% of budget for weekly wages
+      wageBudget: event.initialBudget / 10, // 10% of budget for weekly wages
+      facilities: getDefaultFacilities()
     },
     league: {
       ...state.league,
@@ -251,7 +253,7 @@ function handleFacilityUpgraded(state: GameState, event: any): GameState {
       ...state.club,
       facilities: state.club.facilities.map(f =>
         f.type === event.facilityType
-          ? { ...f, level: event.level }
+          ? { ...f, level: event.level, upgradeCost: getUpgradeCost(event.facilityType, event.level) }
           : f
       ),
       transferBudget: state.club.transferBudget - event.cost
@@ -345,6 +347,13 @@ function handleMathAttemptRecorded(state: GameState, event: MathAttemptRecordedE
 function handleWeekAdvanced(state: GameState, event: any): GameState {
   const week: number = event.week;
 
+  // Calculate weekly revenue from revenue-generating facilities
+  const commercial = state.club.facilities.find(f => f.type === 'CLUB_COMMERCIAL');
+  const foodBev = state.club.facilities.find(f => f.type === 'FOOD_AND_BEVERAGE');
+  const commercialRevenue = commercial ? commercial.level * 50_000 : 0; // £500/week per level
+  const foodRevenue = foodBev ? foodBev.level * 30_000 : 0;            // £300/week per level
+  const weeklyRevenue = commercialRevenue + foodRevenue;
+
   let phase = state.phase;
   if (week <= 15) {
     phase = 'EARLY_SEASON';
@@ -357,7 +366,11 @@ function handleWeekAdvanced(state: GameState, event: any): GameState {
   return {
     ...state,
     currentWeek: week,
-    phase
+    phase,
+    club: {
+      ...state.club,
+      transferBudget: state.club.transferBudget + weeklyRevenue,
+    }
   };
 }
 

--- a/packages/domain/src/types/facility.ts
+++ b/packages/domain/src/types/facility.ts
@@ -6,27 +6,158 @@ export type FacilityType =
   | 'TRAINING_GROUND'
   | 'MEDICAL_CENTER'
   | 'YOUTH_ACADEMY'
-  | 'STADIUM';
+  | 'STADIUM'
+  | 'CLUB_OFFICE'
+  | 'CLUB_COMMERCIAL'
+  | 'FOOD_AND_BEVERAGE'
+  | 'FAN_ZONE'
+  | 'GROUNDS_SECURITY';
 
 export interface Facility {
   type: FacilityType;
-  
+
   /** Level (0-5) */
   level: number;
-  
+
   /** Cost to upgrade to next level (in pence) */
   upgradeCost: number;
-  
+
   /** Benefit description */
   benefit: FacilityBenefit;
 }
 
 export interface FacilityBenefit {
   /** What this facility improves */
-  type: 'performance' | 'injury_reduction' | 'youth_quality' | 'revenue';
-  
+  type: 'performance' | 'injury_reduction' | 'youth_quality' | 'revenue' | 'board_confidence' | 'reputation' | 'attendance';
+
   /** Percentage improvement per level */
   improvement: number;
+}
+
+/**
+ * Single source of truth for facility configuration.
+ * Used by domain logic, frontend display, and Stadium View rendering.
+ */
+export const FACILITY_CONFIG: Record<FacilityType, {
+  label: string;
+  icon: string;
+  description: string;
+  benefitType: FacilityBenefit['type'];
+  improvementPerLevel: number;
+  startingLevel: number;
+  /** Cost to upgrade TO each level (index 0 = cost to reach level 1, etc.) */
+  upgradeCosts: [number, number, number, number, number];
+}> = {
+  STADIUM: {
+    label: 'Stadium',
+    icon: '🏟',
+    description: 'Boosts matchday revenue and atmosphere.',
+    benefitType: 'revenue',
+    improvementPerLevel: 10,
+    startingLevel: 0,
+    upgradeCosts: [50_000_00, 150_000_00, 400_000_00, 800_000_00, 1_500_000_00],
+  },
+  TRAINING_GROUND: {
+    label: 'Training Ground',
+    icon: '⚽',
+    description: 'Improves squad performance week-on-week.',
+    benefitType: 'performance',
+    improvementPerLevel: 5,
+    startingLevel: 0,
+    upgradeCosts: [30_000_00, 80_000_00, 200_000_00, 500_000_00, 1_000_000_00],
+  },
+  MEDICAL_CENTER: {
+    label: 'Medical Centre',
+    icon: '🏥',
+    description: 'Reduces injury risk and speeds recovery.',
+    benefitType: 'injury_reduction',
+    improvementPerLevel: 8,
+    startingLevel: 0,
+    upgradeCosts: [25_000_00, 60_000_00, 150_000_00, 400_000_00, 800_000_00],
+  },
+  YOUTH_ACADEMY: {
+    label: 'Youth Academy',
+    icon: '🎓',
+    description: 'Produces better young players each season.',
+    benefitType: 'youth_quality',
+    improvementPerLevel: 7,
+    startingLevel: 0,
+    upgradeCosts: [40_000_00, 100_000_00, 250_000_00, 600_000_00, 1_200_000_00],
+  },
+  CLUB_OFFICE: {
+    label: 'Club Office',
+    icon: '🏢',
+    description: 'Improves board confidence and unlocks admin tools.',
+    benefitType: 'board_confidence',
+    improvementPerLevel: 5,
+    startingLevel: 1,
+    upgradeCosts: [0, 75_000_00, 200_000_00, 500_000_00, 1_000_000_00],
+  },
+  CLUB_COMMERCIAL: {
+    label: 'Commercial Centre',
+    icon: '💰',
+    description: 'Generates weekly revenue from sponsorship, kit sales, and media.',
+    benefitType: 'revenue',
+    improvementPerLevel: 10,
+    startingLevel: 0,
+    upgradeCosts: [100_000_00, 250_000_00, 500_000_00, 1_000_000_00, 2_000_000_00],
+  },
+  FOOD_AND_BEVERAGE: {
+    label: 'Food & Beverage',
+    icon: '🍔',
+    description: 'Matchday catering from burger vans to fine dining.',
+    benefitType: 'revenue',
+    improvementPerLevel: 8,
+    startingLevel: 0,
+    upgradeCosts: [20_000_00, 60_000_00, 150_000_00, 400_000_00, 900_000_00],
+  },
+  FAN_ZONE: {
+    label: 'Fan Zone',
+    icon: '🎉',
+    description: 'Matchday atmosphere from bar areas to international fan clubs.',
+    benefitType: 'reputation',
+    improvementPerLevel: 5,
+    startingLevel: 0,
+    upgradeCosts: [30_000_00, 80_000_00, 200_000_00, 500_000_00, 1_000_000_00],
+  },
+  GROUNDS_SECURITY: {
+    label: 'Grounds & Security',
+    icon: '🎟',
+    description: 'Front-of-house infrastructure: tickets, parking, turnstiles, transport.',
+    benefitType: 'attendance',
+    improvementPerLevel: 5,
+    startingLevel: 0,
+    upgradeCosts: [15_000_00, 50_000_00, 120_000_00, 300_000_00, 700_000_00],
+  },
+};
+
+/**
+ * Get the upgrade cost for a facility at a given level.
+ * Returns 0 if already at max level (5).
+ */
+export function getUpgradeCost(type: FacilityType, currentLevel: number): number {
+  if (currentLevel >= 5) return 0;
+  return FACILITY_CONFIG[type].upgradeCosts[currentLevel];
+}
+
+/**
+ * Create the default set of facilities for a new club.
+ * CLUB_OFFICE starts at level 1 (the back office hut exists from day one).
+ * All others start at level 0.
+ */
+export function getDefaultFacilities(): Facility[] {
+  return (Object.keys(FACILITY_CONFIG) as FacilityType[]).map(type => {
+    const config = FACILITY_CONFIG[type];
+    return {
+      type,
+      level: config.startingLevel,
+      upgradeCost: getUpgradeCost(type, config.startingLevel),
+      benefit: {
+        type: config.benefitType,
+        improvement: config.improvementPerLevel,
+      },
+    };
+  });
 }
 
 /**
@@ -35,13 +166,13 @@ export interface FacilityBenefit {
 export function calculateFacilityROI(
   facility: Facility,
   seasonLength: number = 46 // League Two has 46 games
-): { 
+): {
   cost: number;
   benefit: number;
   breakEven: number; // Weeks to break even
 } {
   const cost = facility.upgradeCost;
-  
+
   // Different benefits calculated differently
   if (facility.benefit.type === 'revenue') {
     // Revenue improvement
@@ -52,7 +183,7 @@ export function calculateFacilityROI(
       breakEven: Math.ceil(cost / weeklyBenefit)
     };
   }
-  
+
   // Performance benefits are harder to quantify
   // Estimate as equivalent to X squad points improvement
   const equivalentValue = cost * 0.8; // Rough approximation

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,17 +1,66 @@
+import { useState } from 'react';
 import { useGameState } from './hooks/useGameState';
 import { CommandCentre } from './components/command-centre/CommandCentre';
+import { StadiumView } from './components/stadium-view/StadiumView';
+import { ViewToggle, ActiveView } from './components/shared/ViewToggle';
 
 export default function App() {
   const { state, events, dispatch, isLoading } = useGameState();
+  const [activeView, setActiveView] = useState<ActiveView>('command');
+  const [error, setError] = useState<string | null>(null);
 
   return (
-    <div className="min-h-screen bg-bg-deep text-txt-primary">
-      <CommandCentre
+    <div className="min-h-screen bg-bg-deep text-txt-primary flex flex-col">
+      <ViewToggle
+        activeView={activeView}
+        onViewChange={setActiveView}
         state={state}
-        events={events}
-        dispatch={dispatch}
         isLoading={isLoading}
+        dispatch={dispatch}
+        onError={setError}
       />
+
+      {/* Error toast */}
+      {error && (
+        <div
+          className="mx-4 mt-2 bg-alert-red/10 border border-alert-red/40 rounded-card px-4 py-2
+                     text-sm text-alert-red flex items-center justify-between"
+        >
+          <span>{error}</span>
+          <button
+            onClick={() => setError(null)}
+            className="ml-4 text-alert-red/70 hover:text-alert-red"
+          >
+            ✕
+          </button>
+        </div>
+      )}
+
+      {activeView === 'command' ? (
+        <CommandCentre
+          state={state}
+          events={events}
+          dispatch={dispatch}
+          isLoading={isLoading}
+          onNavigateToStadium={() => setActiveView('stadium')}
+        />
+      ) : (
+        <StadiumView
+          state={state}
+          dispatch={dispatch}
+          onError={setError}
+        />
+      )}
+
+      {/* Loading overlay */}
+      {isLoading && (
+        <div className="fixed inset-0 bg-bg-deep/60 flex items-center justify-center z-50">
+          <div className="card flex items-center gap-3 text-sm text-txt-primary">
+            <div className="w-4 h-4 rounded-full border-2 border-data-blue border-t-transparent animate-spin" />
+            Simulating week…
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/frontend/src/components/command-centre/CommandCentre.tsx
+++ b/packages/frontend/src/components/command-centre/CommandCentre.tsx
@@ -4,13 +4,11 @@ import { DataTiles } from './DataTiles';
 import { LeagueTable } from './LeagueTable';
 import { SquadAuditTable } from './SquadAuditTable';
 import { NewsTicker } from './NewsTicker';
-import { WeekAdvanceButton } from './WeekAdvanceButton';
 import { InboxCard } from './InboxCard';
 import { InboxHistory } from './InboxHistory';
 import { HubTile } from './HubTiles';
 import { SlideOver } from '../shared/SlideOver';
 import { SocialFeed } from '../social-feed/SocialFeed';
-import { IsometricBlueprint } from '../isometric/IsometricBlueprint';
 import { BackroomTeamSlideOver } from './BackroomTeamSlideOver';
 import { LearningProgressSlideOver } from './LearningProgressSlideOver';
 
@@ -19,13 +17,13 @@ interface CommandCentreProps {
   events: GameEvent[];
   dispatch: (command: GameCommand) => { error?: string };
   isLoading: boolean;
+  onNavigateToStadium: () => void;
 }
 
-export function CommandCentre({ state, events, dispatch, isLoading }: CommandCentreProps) {
+export function CommandCentre({ state, events, dispatch, isLoading, onNavigateToStadium }: CommandCentreProps) {
   const [error, setError]                     = useState<string | null>(null);
   const [socialOpen, setSocialOpen]           = useState(false);
   const [socialLinkedEvent, setSocialLinked]  = useState<PendingClubEvent | null>(null);
-  const [isometricOpen, setIsometricOpen]     = useState(false);
   const [inboxOpen, setInboxOpen]             = useState(false);
   const [backroomOpen, setBackroomOpen]       = useState(false);
   const [learningOpen, setLearningOpen]       = useState(false);
@@ -54,7 +52,7 @@ export function CommandCentre({ state, events, dispatch, isLoading }: CommandCen
   );
 
   return (
-    <div className="flex flex-col h-screen overflow-hidden">
+    <div className="flex flex-col flex-1 overflow-hidden">
 
       {/* ── Live News Ticker (very top) ───────────────────────────────────── */}
       <NewsTicker
@@ -63,31 +61,10 @@ export function CommandCentre({ state, events, dispatch, isLoading }: CommandCen
         leagueEntries={state.league.entries}
       />
 
-      {/* ── Header ───────────────────────────────────────────────────────── */}
-      <div className="flex items-center justify-between px-4 pt-2 pb-1">
-        <div>
-          <h1 className="text-lg font-bold text-txt-primary tracking-tight">
-            {state.club.name}
-          </h1>
-          <p className="text-xs text-txt-muted">
-            Season {state.season} · Week {state.currentWeek} ·{' '}
-            <span className="capitalize">{state.phase.replace('_', ' ').toLowerCase()}</span>
-          </p>
-        </div>
-        <WeekAdvanceButton
-          pendingEvents={state.pendingEvents}
-          currentWeek={state.currentWeek}
-          season={state.season}
-          isLoading={isLoading}
-          dispatch={dispatch}
-          onError={setError}
-        />
-      </div>
-
       {/* ── Error toast ──────────────────────────────────────────────────── */}
       {error && (
         <div
-          className="mx-4 bg-alert-red/10 border border-alert-red/40 rounded-card px-4 py-2
+          className="mx-4 mt-2 bg-alert-red/10 border border-alert-red/40 rounded-card px-4 py-2
                      text-sm text-alert-red flex items-center justify-between"
         >
           <span>{error}</span>
@@ -133,7 +110,7 @@ export function CommandCentre({ state, events, dispatch, isLoading }: CommandCen
               label="Stadium & Facilities"
               sub={canUpgrade ? 'Upgrade available' : `Facilities Lv${maxFacilityLevel}`}
               hasEvent={canUpgrade}
-              onClick={() => setIsometricOpen(true)}
+              onClick={onNavigateToStadium}
             />
             <HubTile
               icon="💬"
@@ -210,15 +187,6 @@ export function CommandCentre({ state, events, dispatch, isLoading }: CommandCen
         )}
       </SlideOver>
 
-      {/* ── Isometric Blueprint slide-over ───────────────────────────────── */}
-      <SlideOver
-        isOpen={isometricOpen}
-        onClose={() => setIsometricOpen(false)}
-        title="Stadium &amp; Facilities"
-      >
-        <IsometricBlueprint state={state} dispatch={dispatch} onError={setError} />
-      </SlideOver>
-
       {/* ── Backroom Team slide-over ──────────────────────────────────────── */}
       <SlideOver
         isOpen={backroomOpen}
@@ -241,15 +209,6 @@ export function CommandCentre({ state, events, dispatch, isLoading }: CommandCen
         )}
       </SlideOver>
 
-      {/* ── Loading overlay ───────────────────────────────────────────────── */}
-      {isLoading && (
-        <div className="fixed inset-0 bg-bg-deep/60 flex items-center justify-center z-50">
-          <div className="card flex items-center gap-3 text-sm text-txt-primary">
-            <div className="w-4 h-4 rounded-full border-2 border-data-blue border-t-transparent animate-spin" />
-            Simulating week…
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/packages/frontend/src/components/isometric/IsometricBlueprint.tsx
+++ b/packages/frontend/src/components/isometric/IsometricBlueprint.tsx
@@ -1,141 +1,10 @@
-import { GameState, GameCommand, formatMoney } from '@calculating-glory/domain';
-import { Facility, FacilityType } from '@calculating-glory/domain';
+import { GameState, GameCommand, FacilityType, FACILITY_CONFIG, formatMoney } from '@calculating-glory/domain';
+import { FacilityCard } from '../shared/FacilityCard';
 
 interface IsometricBlueprintProps {
   state: GameState;
   dispatch: (cmd: GameCommand) => { error?: string };
   onError: (msg: string) => void;
-}
-
-const FACILITY_META: Record<FacilityType, { icon: string; label: string; description: string }> = {
-  TRAINING_GROUND: {
-    icon: '⚽',
-    label: 'Training Ground',
-    description: 'Improves squad performance week-on-week.',
-  },
-  MEDICAL_CENTER: {
-    icon: '🏥',
-    label: 'Medical Centre',
-    description: 'Reduces injury risk and speeds recovery.',
-  },
-  YOUTH_ACADEMY: {
-    icon: '🎓',
-    label: 'Youth Academy',
-    description: 'Produces better young players each season.',
-  },
-  STADIUM: {
-    icon: '🏟',
-    label: 'Stadium',
-    description: 'Boosts matchday revenue and atmosphere.',
-  },
-};
-
-const LEVEL_LABELS = ['Derelict', 'Basic', 'Decent', 'Good', 'Excellent', 'World-Class'];
-
-function LevelPips({ level }: { level: number }) {
-  return (
-    <div className="flex gap-1">
-      {Array.from({ length: 5 }).map((_, i) => (
-        <div
-          key={i}
-          className={[
-            'w-2 h-2 rounded-full',
-            i < level ? 'bg-pitch-green' : 'bg-bg-raised',
-          ].join(' ')}
-        />
-      ))}
-    </div>
-  );
-}
-
-function FacilityCard({
-  facility,
-  budget,
-  onUpgrade,
-}: {
-  facility: Facility;
-  budget: number;
-  onUpgrade: () => void;
-}) {
-  const meta = FACILITY_META[facility.type];
-  const isMaxLevel = facility.level >= 5;
-  const canAfford = facility.upgradeCost <= budget;
-  const canUpgrade = !isMaxLevel && canAfford;
-
-  return (
-    <div
-      className={[
-        'card flex flex-col gap-3 border',
-        isMaxLevel
-          ? 'border-pitch-green/30'
-          : canAfford
-          ? 'border-data-blue/30 hover:border-data-blue/60 transition-colors'
-          : 'border-transparent',
-      ].join(' ')}
-    >
-      {/* Header */}
-      <div className="flex items-start gap-3">
-        <span className="text-3xl">{meta.icon}</span>
-        <div className="flex-1">
-          <h3 className="text-sm font-semibold text-txt-primary">{meta.label}</h3>
-          <p className="text-xs2 text-txt-muted mt-0.5">{meta.description}</p>
-        </div>
-        {isMaxLevel && (
-          <span className="badge bg-pitch-green/20 text-pitch-green text-xs2">MAX</span>
-        )}
-      </div>
-
-      {/* Level */}
-      <div className="flex items-center justify-between">
-        <div className="flex flex-col gap-1">
-          <span className="text-xs2 text-txt-muted uppercase tracking-wide">Level</span>
-          <span className="text-sm font-semibold text-txt-primary data-font">
-            {facility.level} — {LEVEL_LABELS[facility.level]}
-          </span>
-        </div>
-        <LevelPips level={facility.level} />
-      </div>
-
-      {/* Benefit */}
-      <div className="flex items-center gap-2 bg-bg-raised rounded-tag px-2 py-1">
-        <span className="text-xs2 text-txt-muted">Benefit:</span>
-        <span className="text-xs2 text-data-blue">
-          +{facility.benefit.improvement}% {facility.benefit.type.replace('_', ' ')} per level
-        </span>
-      </div>
-
-      {/* Upgrade section */}
-      {!isMaxLevel && (
-        <div className="flex items-center justify-between pt-1 border-t border-bg-raised">
-          <div>
-            <span className="text-xs2 text-txt-muted">Upgrade cost: </span>
-            <span
-              className={`text-xs font-semibold data-font ${
-                canAfford ? 'text-txt-primary' : 'text-alert-red'
-              }`}
-            >
-              {formatMoney(facility.upgradeCost)}
-            </span>
-            {!canAfford && (
-              <span className="text-xs2 text-alert-red ml-1">(insufficient funds)</span>
-            )}
-          </div>
-          <button
-            onClick={onUpgrade}
-            disabled={!canUpgrade}
-            className={[
-              'px-3 py-1 rounded-tag text-xs font-semibold transition-all duration-150',
-              canUpgrade
-                ? 'bg-data-blue text-white hover:bg-data-blue/80 active:scale-95'
-                : 'bg-bg-raised text-txt-muted cursor-not-allowed',
-            ].join(' ')}
-          >
-            Upgrade →
-          </button>
-        </div>
-      )}
-    </div>
-  );
 }
 
 export function IsometricBlueprint({ state, dispatch, onError }: IsometricBlueprintProps) {
@@ -150,13 +19,12 @@ export function IsometricBlueprint({ state, dispatch, onError }: IsometricBluepr
     if (result.error) onError(result.error);
   }
 
-  // Isometric "stadium" SVG placeholder — simple isometric box grid
   return (
     <div className="flex flex-col gap-4 p-4">
       {/* Isometric header art */}
       <div className="card flex flex-col items-center justify-center py-6 gap-2 bg-pitch-green/5 border border-pitch-green/20">
         <div className="flex gap-2 text-4xl">
-          {club.facilities.map(f => FACILITY_META[f.type]?.icon ?? '🏗').join('')}
+          {club.facilities.map(f => FACILITY_CONFIG[f.type]?.icon ?? '🏗').join('')}
         </div>
         <p className="text-sm font-semibold text-txt-primary">{club.stadium.name}</p>
         <p className="text-xs2 text-txt-muted">

--- a/packages/frontend/src/components/shared/FacilityCard.tsx
+++ b/packages/frontend/src/components/shared/FacilityCard.tsx
@@ -1,0 +1,109 @@
+import { Facility, FacilityType, FACILITY_CONFIG, formatMoney } from '@calculating-glory/domain';
+
+const LEVEL_LABELS = ['Derelict', 'Basic', 'Decent', 'Good', 'Excellent', 'World-Class'];
+
+export function LevelPips({ level }: { level: number }) {
+  return (
+    <div className="flex gap-1">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div
+          key={i}
+          className={[
+            'w-2 h-2 rounded-full',
+            i < level ? 'bg-pitch-green' : 'bg-bg-raised',
+          ].join(' ')}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function FacilityCard({
+  facility,
+  budget,
+  onUpgrade,
+}: {
+  facility: Facility;
+  budget: number;
+  onUpgrade: () => void;
+}) {
+  const meta = FACILITY_CONFIG[facility.type];
+  const isMaxLevel = facility.level >= 5;
+  const canAfford = facility.upgradeCost <= budget;
+  const canUpgrade = !isMaxLevel && canAfford;
+
+  return (
+    <div
+      className={[
+        'card flex flex-col gap-3 border',
+        isMaxLevel
+          ? 'border-pitch-green/30'
+          : canAfford
+          ? 'border-data-blue/30 hover:border-data-blue/60 transition-colors'
+          : 'border-transparent',
+      ].join(' ')}
+    >
+      {/* Header */}
+      <div className="flex items-start gap-3">
+        <span className="text-3xl">{meta.icon}</span>
+        <div className="flex-1">
+          <h3 className="text-sm font-semibold text-txt-primary">{meta.label}</h3>
+          <p className="text-xs2 text-txt-muted mt-0.5">{meta.description}</p>
+        </div>
+        {isMaxLevel && (
+          <span className="badge bg-pitch-green/20 text-pitch-green text-xs2">MAX</span>
+        )}
+      </div>
+
+      {/* Level */}
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-1">
+          <span className="text-xs2 text-txt-muted uppercase tracking-wide">Level</span>
+          <span className="text-sm font-semibold text-txt-primary data-font">
+            {facility.level} — {LEVEL_LABELS[facility.level]}
+          </span>
+        </div>
+        <LevelPips level={facility.level} />
+      </div>
+
+      {/* Benefit */}
+      <div className="flex items-center gap-2 bg-bg-raised rounded-tag px-2 py-1">
+        <span className="text-xs2 text-txt-muted">Benefit:</span>
+        <span className="text-xs2 text-data-blue">
+          +{facility.benefit.improvement}% {facility.benefit.type.replace('_', ' ')} per level
+        </span>
+      </div>
+
+      {/* Upgrade section */}
+      {!isMaxLevel && (
+        <div className="flex items-center justify-between pt-1 border-t border-bg-raised">
+          <div>
+            <span className="text-xs2 text-txt-muted">Upgrade cost: </span>
+            <span
+              className={`text-xs font-semibold data-font ${
+                canAfford ? 'text-txt-primary' : 'text-alert-red'
+              }`}
+            >
+              {formatMoney(facility.upgradeCost)}
+            </span>
+            {!canAfford && (
+              <span className="text-xs2 text-alert-red ml-1">(insufficient funds)</span>
+            )}
+          </div>
+          <button
+            onClick={onUpgrade}
+            disabled={!canUpgrade}
+            className={[
+              'px-3 py-1 rounded-tag text-xs font-semibold transition-all duration-150',
+              canUpgrade
+                ? 'bg-data-blue text-white hover:bg-data-blue/80 active:scale-95'
+                : 'bg-bg-raised text-txt-muted cursor-not-allowed',
+            ].join(' ')}
+          >
+            Upgrade
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/shared/ViewToggle.tsx
+++ b/packages/frontend/src/components/shared/ViewToggle.tsx
@@ -1,0 +1,75 @@
+import { GameState, GameCommand, PendingClubEvent } from '@calculating-glory/domain';
+import { WeekAdvanceButton } from '../command-centre/WeekAdvanceButton';
+
+export type ActiveView = 'command' | 'stadium';
+
+interface ViewToggleProps {
+  activeView: ActiveView;
+  onViewChange: (view: ActiveView) => void;
+  state: GameState;
+  isLoading: boolean;
+  dispatch: (command: GameCommand) => { error?: string };
+  onError: (msg: string) => void;
+}
+
+export function ViewToggle({
+  activeView,
+  onViewChange,
+  state,
+  isLoading,
+  dispatch,
+  onError,
+}: ViewToggleProps) {
+  return (
+    <div className="flex items-center justify-between px-4 py-2 border-b border-bg-raised bg-bg-surface">
+      {/* Left: Club info */}
+      <div className="flex items-center gap-4">
+        <div>
+          <h1 className="text-lg font-bold text-txt-primary tracking-tight">
+            {state.club.name}
+          </h1>
+          <p className="text-xs text-txt-muted">
+            Season {state.season} · Week {state.currentWeek} ·{' '}
+            <span className="capitalize">{state.phase.replace('_', ' ').toLowerCase()}</span>
+          </p>
+        </div>
+      </div>
+
+      {/* Centre: View toggle */}
+      <div className="flex items-center gap-1 bg-bg-raised rounded-card p-1">
+        <button
+          onClick={() => onViewChange('command')}
+          className={[
+            'px-3 py-1.5 rounded-tag text-xs font-semibold transition-all duration-150',
+            activeView === 'command'
+              ? 'bg-bg-surface text-txt-primary shadow-sm'
+              : 'text-txt-muted hover:text-txt-primary',
+          ].join(' ')}
+        >
+          Command Centre
+        </button>
+        <button
+          onClick={() => onViewChange('stadium')}
+          className={[
+            'px-3 py-1.5 rounded-tag text-xs font-semibold transition-all duration-150',
+            activeView === 'stadium'
+              ? 'bg-bg-surface text-txt-primary shadow-sm'
+              : 'text-txt-muted hover:text-txt-primary',
+          ].join(' ')}
+        >
+          Stadium View
+        </button>
+      </div>
+
+      {/* Right: Week advance */}
+      <WeekAdvanceButton
+        pendingEvents={state.pendingEvents}
+        currentWeek={state.currentWeek}
+        season={state.season}
+        isLoading={isLoading}
+        dispatch={dispatch}
+        onError={onError}
+      />
+    </div>
+  );
+}

--- a/packages/frontend/src/components/stadium-view/StadiumView.tsx
+++ b/packages/frontend/src/components/stadium-view/StadiumView.tsx
@@ -1,0 +1,54 @@
+import { GameState, GameCommand, FacilityType, formatMoney } from '@calculating-glory/domain';
+import { FacilityCard } from '../shared/FacilityCard';
+
+interface StadiumViewProps {
+  state: GameState;
+  dispatch: (cmd: GameCommand) => { error?: string };
+  onError: (msg: string) => void;
+}
+
+export function StadiumView({ state, dispatch, onError }: StadiumViewProps) {
+  const { club } = state;
+
+  function handleUpgrade(facilityType: FacilityType) {
+    const result = dispatch({
+      type: 'UPGRADE_FACILITY',
+      clubId: club.id,
+      facilityType,
+    });
+    if (result.error) onError(result.error);
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-4 flex-1 overflow-y-auto">
+      {/* Stadium header */}
+      <div className="card flex items-center justify-between py-3 bg-pitch-green/5 border border-pitch-green/20">
+        <div>
+          <p className="text-sm font-semibold text-txt-primary">{club.stadium.name}</p>
+          <p className="text-xs2 text-txt-muted">
+            Capacity: {club.stadium.capacity.toLocaleString()} ·
+            Avg attendance: {club.stadium.averageAttendance.toLocaleString()}
+          </p>
+        </div>
+        <div className="text-right">
+          <span className="text-xs text-txt-muted">Transfer Budget</span>
+          <p className="data-font text-sm font-semibold text-pitch-green">
+            {formatMoney(club.transferBudget)}
+          </p>
+        </div>
+      </div>
+
+      {/* Facility cards — 2-col grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {club.facilities.map(facility => (
+          <FacilityCard
+            key={facility.type}
+            facility={facility}
+            budget={club.transferBudget}
+            onUpgrade={() => handleUpgrade(facility.type)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **9 facility types** with FACILITY_CONFIG as single source of truth (added FAN_ZONE, GROUNDS_SECURITY, CLUB_OFFICE, CLUB_COMMERCIAL, FOOD_AND_BEVERAGE)
- **Persistent ViewToggle** top bar with Command Centre / Stadium View toggle and week advance button
- **StadiumView** full-screen facility management with budget banner and 2-column card grid
- **Weekly revenue system** from CLUB_COMMERCIAL + FOOD_AND_BEVERAGE facilities
- **Shared FacilityCard** component extracted for reuse across views

Implements PR 1 (domain foundation) + PR 2 (app shell) from the Stadium View plan (#21).

## Test plan

- [ ] `cd packages/domain && npm test` — 245 tests pass
- [ ] `cd packages/domain && npm run build && cd ../frontend && npx tsc --noEmit` — no type errors
- [ ] Dev server: Command Centre renders correctly with ViewToggle bar
- [ ] Click "Stadium View" toggle — all 9 facility cards visible
- [ ] Click "Stadium & Facilities" HubTile — navigates to Stadium View
- [ ] Toggle back to Command Centre — no state loss
- [ ] Week advance button works from both views

🤖 Generated with [Claude Code](https://claude.com/claude-code)