### PR TITLE
feat: Navigation wiring — core unit clicks open slide-overs

### DIFF
--- a/packages/frontend/src/components/stadium-view/BoardConfidenceSlideOver.tsx
+++ b/packages/frontend/src/components/stadium-view/BoardConfidenceSlideOver.tsx
@@ -1,0 +1,133 @@
+/**
+ * BoardConfidenceSlideOver — board confidence and business acumen panel.
+ * Opened when the player clicks the Club Office core unit (level 1+).
+ *
+ * Shows: board confidence bar, acumen star ratings, season context,
+ * and guidance on what affects each metric.
+ */
+
+import { GameState } from '@calculating-glory/domain';
+import { SlideOver } from '../shared/SlideOver';
+
+interface BoardConfidenceSlideOverProps {
+  isOpen:  boolean;
+  onClose: () => void;
+  state:   GameState;
+}
+
+function StarRow({ label, value }: { label: string; value: number }) {
+  const stars = Math.min(5, Math.max(0, Math.round(value)));
+  return (
+    <div className="flex items-center justify-between py-2 border-b border-bg-raised last:border-0">
+      <span className="text-xs text-txt-muted">{label}</span>
+      <span className="text-warn-amber data-font tracking-wider text-sm">
+        {'★'.repeat(stars)}
+        <span className="opacity-25">{'★'.repeat(5 - stars)}</span>
+      </span>
+    </div>
+  );
+}
+
+function ConfidenceBar({ value }: { value: number }) {
+  const pct   = Math.min(100, Math.max(0, value));
+  const color = pct >= 70 ? 'bg-pitch-green' : pct >= 40 ? 'bg-warn-amber' : 'bg-alert-red';
+  const label = pct >= 70 ? 'Confident' : pct >= 40 ? 'Cautious' : 'Concerned';
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-end justify-between">
+        <span className="text-xs text-txt-muted uppercase tracking-wide">Board Confidence</span>
+        <span className="text-2xl font-black data-font text-txt-primary">{pct}</span>
+      </div>
+      <div className="h-2.5 bg-bg-raised rounded-full overflow-hidden">
+        <div
+          className={`h-full ${color} rounded-full transition-all duration-500`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <p className={`text-xs font-semibold ${
+        pct >= 70 ? 'text-pitch-green' : pct >= 40 ? 'text-warn-amber' : 'text-alert-red'
+      }`}>
+        {label} — {label === 'Confident' ? 'Board is backing your decisions.' : label === 'Cautious' ? 'Results expected soon.' : 'Board patience is running low.'}
+      </p>
+    </div>
+  );
+}
+
+export function BoardConfidenceSlideOver({ isOpen, onClose, state }: BoardConfidenceSlideOverProps) {
+  const { boardConfidence, businessAcumen, currentWeek, phase, season } = state;
+
+  const myEntry = state.league.entries.find(e => e.clubId === state.club.id);
+
+  const PHASE_LABELS: Record<string, string> = {
+    PRE_SEASON:   'Pre-Season',
+    EARLY_SEASON: 'Early Season',
+    MID_SEASON:   'Mid-Season',
+    LATE_SEASON:  'Late Season',
+    SEASON_END:   'Season End',
+  };
+
+  return (
+    <SlideOver isOpen={isOpen} onClose={onClose} title="🏢 Club Office">
+      <div className="flex flex-col gap-4 p-4">
+
+        {/* Season context */}
+        <div className="flex items-center justify-between text-xs text-txt-muted">
+          <span>Season {season} · Week {currentWeek}</span>
+          <span className="badge bg-bg-raised text-txt-muted">{PHASE_LABELS[phase] ?? phase}</span>
+        </div>
+
+        {/* Board confidence */}
+        <div className="card bg-bg-raised border border-bg-raised/50">
+          <ConfidenceBar value={boardConfidence} />
+        </div>
+
+        {/* League standing summary */}
+        {myEntry && (
+          <div className="card flex items-center justify-between py-2">
+            <div>
+              <p className="text-xs2 text-txt-muted uppercase tracking-wide">League Position</p>
+              <p className="text-2xl font-black data-font text-txt-primary mt-0.5">
+                {myEntry.position}
+                <span className="text-sm text-txt-muted font-normal ml-1">of 24</span>
+              </p>
+            </div>
+            <div className="text-center">
+              <p className="text-xs2 text-txt-muted uppercase tracking-wide">Points</p>
+              <p className="text-xl font-bold data-font text-pitch-green mt-0.5">{myEntry.points}</p>
+            </div>
+            <div className="text-right">
+              <p className="text-xs2 text-txt-muted uppercase tracking-wide">Record</p>
+              <p className="text-sm data-font text-txt-primary mt-0.5">
+                {myEntry.won}W {myEntry.drawn}D {myEntry.lost}L
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Business acumen */}
+        <div>
+          <p className="text-xs text-txt-muted uppercase tracking-wide mb-2">Business Acumen</p>
+          <div className="card">
+            <StarRow label="Financial Decisions"  value={businessAcumen.financial}   />
+            <StarRow label="Statistical Analysis" value={businessAcumen.statistical} />
+            <StarRow label="Strategic Thinking"   value={businessAcumen.strategic}   />
+          </div>
+        </div>
+
+        {/* Guidance */}
+        <div className="card bg-bg-raised border border-bg-raised/50">
+          <p className="text-xs font-semibold text-txt-primary mb-2">What affects board confidence?</p>
+          <ul className="flex flex-col gap-1.5 text-xs2 text-txt-muted list-none">
+            <li>📈 Winning matches raises confidence</li>
+            <li>📉 Losing streaks lower confidence</li>
+            <li>🏟️ Upgrading facilities signals ambition</li>
+            <li>💼 Resolving club events demonstrates leadership</li>
+            <li>🧮 High business acumen builds long-term trust</li>
+          </ul>
+        </div>
+
+      </div>
+    </SlideOver>
+  );
+}

--- a/packages/frontend/src/components/stadium-view/FacilityUpgradeSlideOver.tsx
+++ b/packages/frontend/src/components/stadium-view/FacilityUpgradeSlideOver.tsx
@@ -1,0 +1,74 @@
+/**
+ * FacilityUpgradeSlideOver — shows a single FacilityCard in a slide-over panel.
+ *
+ * Used for:
+ *  - Commercial facilities (CLUB_COMMERCIAL, FOOD_AND_BEVERAGE, FAN_ZONE,
+ *    GROUNDS_SECURITY) which have no dedicated navigation destination
+ *  - Level-0 plots for any facility type (BuildPanel: "Build — £X,XXX" CTA)
+ */
+
+import { FacilityType, GameState, GameCommand, FACILITY_CONFIG } from '@calculating-glory/domain';
+import { SlideOver } from '../shared/SlideOver';
+import { FacilityCard } from '../shared/FacilityCard';
+
+interface FacilityUpgradeSlideOverProps {
+  /** Null = closed */
+  facilityType: FacilityType | null;
+  state:        GameState;
+  dispatch:     (cmd: GameCommand) => { error?: string };
+  onError:      (msg: string) => void;
+  onClose:      () => void;
+}
+
+export function FacilityUpgradeSlideOver({
+  facilityType,
+  state,
+  dispatch,
+  onError,
+  onClose,
+}: FacilityUpgradeSlideOverProps) {
+  const { club } = state;
+  const facility = facilityType ? club.facilities.find(f => f.type === facilityType) ?? null : null;
+  const meta     = facilityType ? FACILITY_CONFIG[facilityType] : null;
+
+  function handleUpgrade() {
+    if (!facilityType) return;
+    const result = dispatch({
+      type:         'UPGRADE_FACILITY',
+      clubId:       club.id,
+      facilityType,
+    });
+    if (result.error) onError(result.error);
+  }
+
+  const isLevel0 = (facility?.level ?? 0) === 0;
+  const title    = meta
+    ? `${meta.icon} ${isLevel0 ? `Build ${meta.label}` : meta.label}`
+    : 'Facility';
+
+  return (
+    <SlideOver isOpen={!!facilityType} onClose={onClose} title={title}>
+      <div className="p-4 flex flex-col gap-4">
+
+        {/* Build context banner (level 0 only) */}
+        {isLevel0 && meta && (
+          <div className="bg-data-blue/10 border border-data-blue/30 rounded-card px-3 py-2">
+            <p className="text-xs2 text-data-blue">
+              This plot is undeveloped. Invest to unlock {meta.label.toLowerCase()} benefits
+              and add it to your stadium.
+            </p>
+          </div>
+        )}
+
+        {facility && (
+          <FacilityCard
+            facility={facility}
+            budget={club.transferBudget}
+            onUpgrade={handleUpgrade}
+          />
+        )}
+
+      </div>
+    </SlideOver>
+  );
+}

--- a/packages/frontend/src/components/stadium-view/FixturesSlideOver.tsx
+++ b/packages/frontend/src/components/stadium-view/FixturesSlideOver.tsx
@@ -1,0 +1,175 @@
+/**
+ * FixturesSlideOver — league standing and recent form panel.
+ * Opened when the player clicks the Stadium / Pitch core unit (level 1+).
+ *
+ * Shows: club's current position, form strip, mini league table.
+ * Full fixture schedule will be wired in a later PR once the season
+ * calendar surface is accessible from game state.
+ */
+
+import { GameState } from '@calculating-glory/domain';
+import { SlideOver } from '../shared/SlideOver';
+
+interface FixturesSlideOverProps {
+  isOpen:  boolean;
+  onClose: () => void;
+  state:   GameState;
+}
+
+const FORM_COLORS: Record<string, string> = {
+  W: 'bg-pitch-green text-white',
+  D: 'bg-warn-amber  text-bg-deep',
+  L: 'bg-alert-red  text-white',
+};
+
+const PHASE_LABELS: Record<string, string> = {
+  PRE_SEASON:    'Pre-Season',
+  EARLY_SEASON:  'Early Season',
+  MID_SEASON:    'Mid-Season',
+  LATE_SEASON:   'Late Season',
+  SEASON_END:    'Season End',
+};
+
+export function FixturesSlideOver({ isOpen, onClose, state }: FixturesSlideOverProps) {
+  const { club, league, currentWeek, phase } = state;
+
+  const myEntry = league.entries.find(e => e.clubId === club.id);
+  const promotion = league.automaticPromotion;   // e.g. 3
+  const playoff   = league.playoffPositions;     // [4,5,6,7]
+  const relZone   = league.relegation;           // [23,24]
+
+  function rowClass(pos: number): string {
+    if (pos <= promotion)              return 'bg-pitch-green/10';
+    if (playoff.includes(pos as never)) return 'bg-data-blue/8';
+    if (relZone.includes(pos as never)) return 'bg-alert-red/10';
+    return '';
+  }
+
+  function positionBadge(pos: number): string {
+    if (pos <= promotion)              return 'text-pitch-green font-bold';
+    if (playoff.includes(pos as never)) return 'text-data-blue  font-semibold';
+    if (relZone.includes(pos as never)) return 'text-alert-red  font-semibold';
+    return 'text-txt-muted';
+  }
+
+  return (
+    <SlideOver isOpen={isOpen} onClose={onClose} title="⚽ Stadium & Fixtures">
+      <div className="flex flex-col gap-4 p-4">
+
+        {/* Season context */}
+        <div className="flex items-center justify-between text-xs text-txt-muted">
+          <span>Season {state.season} · Week {currentWeek} of 46</span>
+          <span className="badge bg-bg-raised text-txt-muted">{PHASE_LABELS[phase] ?? phase}</span>
+        </div>
+
+        {/* Club standing hero card */}
+        {myEntry && (
+          <div className="card bg-bg-raised border border-bg-raised/50">
+            <div className="flex items-center gap-4">
+              <div className="text-center shrink-0">
+                <p className="text-3xl font-black data-font text-txt-primary">
+                  {myEntry.position}
+                </p>
+                <p className="text-xs2 text-txt-muted uppercase tracking-wide">Position</p>
+              </div>
+              <div className="flex-1">
+                <p className="text-sm font-semibold text-txt-primary">{club.name}</p>
+                <p className="text-xs2 text-txt-muted">{club.stadium.name}</p>
+                <p className="text-xs2 text-txt-muted mt-0.5">
+                  {myEntry.played}G · {myEntry.won}W {myEntry.drawn}D {myEntry.lost}L ·
+                  GD {myEntry.goalDifference >= 0 ? '+' : ''}{myEntry.goalDifference}
+                </p>
+              </div>
+              <div className="text-right shrink-0">
+                <p className="text-2xl font-black data-font text-pitch-green">{myEntry.points}</p>
+                <p className="text-xs2 text-txt-muted">pts</p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Form strip */}
+        {club.form.length > 0 && (
+          <div>
+            <p className="text-xs text-txt-muted uppercase tracking-wide mb-2">
+              Recent Form (last {club.form.length})
+            </p>
+            <div className="flex gap-1.5">
+              {club.form.map((r, i) => (
+                <span
+                  key={i}
+                  className={[
+                    'w-7 h-7 rounded-full text-xs font-bold flex items-center justify-center data-font',
+                    FORM_COLORS[r] ?? 'bg-bg-raised text-txt-muted',
+                  ].join(' ')}
+                >
+                  {r}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Mini league table */}
+        <div>
+          <p className="text-xs text-txt-muted uppercase tracking-wide mb-2">League Two</p>
+          <div className="card overflow-hidden p-0">
+            <table className="w-full text-xs data-font">
+              <thead>
+                <tr className="text-txt-muted border-b border-bg-raised text-left">
+                  <th className="px-2 py-1.5 w-6">#</th>
+                  <th className="px-2 py-1.5">Club</th>
+                  <th className="text-right px-2 py-1.5 w-7">P</th>
+                  <th className="text-right px-2 py-1.5 w-7">GD</th>
+                  <th className="text-right px-2 py-1.5 w-7">Pts</th>
+                </tr>
+              </thead>
+              <tbody>
+                {league.entries.map(entry => (
+                  <tr
+                    key={entry.clubId}
+                    className={[
+                      'border-b border-bg-raised/30 last:border-0',
+                      entry.clubId === club.id ? 'bg-data-blue/15 font-semibold' : rowClass(entry.position),
+                    ].join(' ')}
+                  >
+                    <td className={`px-2 py-1 ${positionBadge(entry.position)}`}>
+                      {entry.position}
+                    </td>
+                    <td className={`px-2 py-1 truncate max-w-[140px] ${entry.clubId === club.id ? 'text-txt-primary' : 'text-txt-muted'}`}>
+                      {entry.clubName}
+                    </td>
+                    <td className="text-right px-2 py-1 text-txt-muted">{entry.played}</td>
+                    <td className="text-right px-2 py-1 text-txt-muted">
+                      {entry.goalDifference >= 0 ? '+' : ''}{entry.goalDifference}
+                    </td>
+                    <td className={`text-right px-2 py-1 ${entry.clubId === club.id ? 'text-pitch-green' : 'text-txt-primary'}`}>
+                      {entry.points}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Zone key */}
+          <div className="flex gap-3 mt-2 text-xs2 text-txt-muted">
+            <span className="flex items-center gap-1">
+              <span className="inline-block w-2 h-2 rounded-sm bg-pitch-green/40" />
+              Auto promotion (top {promotion})
+            </span>
+            <span className="flex items-center gap-1">
+              <span className="inline-block w-2 h-2 rounded-sm bg-data-blue/40" />
+              Play-offs
+            </span>
+            <span className="flex items-center gap-1">
+              <span className="inline-block w-2 h-2 rounded-sm bg-alert-red/40" />
+              Relegation
+            </span>
+          </div>
+        </div>
+
+      </div>
+    </SlideOver>
+  );
+}

--- a/packages/frontend/src/components/stadium-view/ScoutingSlideOver.tsx
+++ b/packages/frontend/src/components/stadium-view/ScoutingSlideOver.tsx
@@ -1,0 +1,95 @@
+/**
+ * ScoutingSlideOver — youth academy and scouting stub.
+ * Opened when the player clicks the Youth Academy core unit (level 1+).
+ *
+ * Full transfer market + scouting functionality planned for Phase 5.
+ * This stub teases the future feature and shows current youth prospects.
+ */
+
+import { GameState } from '@calculating-glory/domain';
+import { SlideOver } from '../shared/SlideOver';
+
+interface ScoutingSlideOverProps {
+  isOpen:  boolean;
+  onClose: () => void;
+  state:   GameState;
+}
+
+export function ScoutingSlideOver({ isOpen, onClose, state }: ScoutingSlideOverProps) {
+  const { club } = state;
+
+  // Show youngest players as "youth prospects"
+  const youngsters = [...club.squad]
+    .filter(p => p.age <= 21)
+    .sort((a, b) => a.age - b.age)
+    .slice(0, 6);
+
+  const youthFacility = club.facilities.find(f => f.type === 'YOUTH_ACADEMY');
+  const youthLevel    = youthFacility?.level ?? 0;
+
+  return (
+    <SlideOver isOpen={isOpen} onClose={onClose} title="🌱 Youth Academy">
+      <div className="flex flex-col gap-4 p-4">
+
+        {/* Academy level */}
+        <div className="card bg-bg-raised border border-bg-raised/50 flex items-center justify-between">
+          <div>
+            <p className="text-xs2 text-txt-muted uppercase tracking-wide">Academy Level</p>
+            <p className="text-2xl font-black data-font text-pitch-green">{youthLevel}</p>
+          </div>
+          <div className="text-right">
+            <p className="text-xs2 text-txt-muted uppercase tracking-wide">Young Players</p>
+            <p className="text-2xl font-black data-font text-txt-primary">{youngsters.length}</p>
+          </div>
+        </div>
+
+        {/* Youth prospects */}
+        {youngsters.length > 0 && (
+          <div>
+            <p className="text-xs text-txt-muted uppercase tracking-wide mb-2">
+              Current Prospects (U21)
+            </p>
+            <div className="card flex flex-col divide-y divide-bg-raised/50">
+              {youngsters.map(player => (
+                <div key={player.id} className="flex items-center justify-between py-2">
+                  <div>
+                    <p className="text-sm text-txt-primary font-semibold">{player.name}</p>
+                    <p className="text-xs2 text-txt-muted">
+                      Age {player.age} · {player.position}
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-sm font-bold data-font text-data-blue">
+                      {player.overallRating}
+                    </p>
+                    <p className="text-xs2 text-txt-muted">OVR</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Coming soon banner */}
+        <div className="card border border-dashed border-data-blue/40 bg-data-blue/5">
+          <p className="text-xs font-semibold text-data-blue mb-1">Transfer Market — Coming Soon</p>
+          <p className="text-xs2 text-txt-muted">
+            Scout and sign players from the transfer market in a future update.
+            Upgrade your Youth Academy to improve the quality of prospects generated each season.
+          </p>
+        </div>
+
+        {/* Upgrade prompt if low level */}
+        {youthLevel < 3 && (
+          <div className="card bg-bg-raised border border-warn-amber/20">
+            <p className="text-xs2 text-warn-amber">
+              💡 A higher Youth Academy level generates better prospects and
+              unlocks access to international scouting networks.
+            </p>
+          </div>
+        )}
+
+      </div>
+    </SlideOver>
+  );
+}

--- a/packages/frontend/src/components/stadium-view/SquadAuditSlideOver.tsx
+++ b/packages/frontend/src/components/stadium-view/SquadAuditSlideOver.tsx
@@ -1,0 +1,60 @@
+/**
+ * SquadAuditSlideOver — full squad roster in a slide-over panel.
+ * Opened when the player clicks the Training Ground core unit (level 1+).
+ */
+
+import { GameState } from '@calculating-glory/domain';
+import { SlideOver } from '../shared/SlideOver';
+import { SquadAuditTable } from '../command-centre/SquadAuditTable';
+
+interface SquadAuditSlideOverProps {
+  isOpen:  boolean;
+  onClose: () => void;
+  state:   GameState;
+}
+
+export function SquadAuditSlideOver({ isOpen, onClose, state }: SquadAuditSlideOverProps) {
+  const { club } = state;
+
+  // Squad summary stats
+  const avgRating = club.squad.length
+    ? Math.round(club.squad.reduce((s, p) => s + p.overallRating, 0) / club.squad.length)
+    : 0;
+  const totalWages = club.squad.reduce((s, p) => s + p.wage, 0);
+
+  return (
+    <SlideOver isOpen={isOpen} onClose={onClose} title="🏃 Squad Audit">
+      <div className="flex flex-col h-full">
+
+        {/* Summary bar */}
+        <div className="px-4 py-3 bg-bg-raised border-b border-bg-raised/50 shrink-0">
+          <div className="flex items-center justify-between">
+            <div>
+              <span className="text-xs text-txt-muted uppercase tracking-wide">Players</span>
+              <p className="text-lg font-semibold text-txt-primary data-font">
+                {club.squad.length}
+              </p>
+            </div>
+            <div className="text-center">
+              <span className="text-xs text-txt-muted uppercase tracking-wide">Avg OVR</span>
+              <p className="text-lg font-semibold text-data-blue data-font">{avgRating}</p>
+            </div>
+            <div className="text-right">
+              <span className="text-xs text-txt-muted uppercase tracking-wide">Wage bill</span>
+              <p className="text-lg font-semibold text-warn-amber data-font">
+                £{Math.round(totalWages / 100).toLocaleString()}
+                <span className="text-txt-muted text-sm font-normal">/wk</span>
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Squad table */}
+        <div className="flex-1 overflow-y-auto p-4">
+          <SquadAuditTable state={state} />
+        </div>
+
+      </div>
+    </SlideOver>
+  );
+}

--- a/packages/frontend/src/components/stadium-view/StadiumView.tsx
+++ b/packages/frontend/src/components/stadium-view/StadiumView.tsx
@@ -1,6 +1,40 @@
+/**
+ * StadiumView — full-screen facility management.
+ *
+ * PR 4: Navigation wiring — clicking a core unit opens the appropriate
+ * slide-over based on facility type and current level:
+ *
+ *  Level-0 plots        → FacilityUpgradeSlideOver (BuildPanel)
+ *  STADIUM              → FixturesSlideOver
+ *  TRAINING_GROUND      → SquadAuditSlideOver
+ *  MEDICAL_CENTER       → BackroomTeamSlideOver
+ *  YOUTH_ACADEMY        → ScoutingSlideOver
+ *  CLUB_OFFICE          → BoardConfidenceSlideOver
+ *  CLUB_COMMERCIAL      →
+ *  FOOD_AND_BEVERAGE    → FacilityUpgradeSlideOver (always)
+ *  FAN_ZONE             →
+ *  GROUNDS_SECURITY     →
+ */
+
+import { useState }                         from 'react';
 import { GameState, GameCommand, FacilityType, formatMoney } from '@calculating-glory/domain';
-import { FacilityCard } from '../shared/FacilityCard';
-import { IsometricBlueprint } from '../isometric/IsometricBlueprint';
+import { IsometricBlueprint }               from '../isometric/IsometricBlueprint';
+import { FacilityCard }                     from '../shared/FacilityCard';
+import { SlideOver }                        from '../shared/SlideOver';
+import { BackroomTeamSlideOver }            from '../command-centre/BackroomTeamSlideOver';
+import { FacilityUpgradeSlideOver }         from './FacilityUpgradeSlideOver';
+import { SquadAuditSlideOver }              from './SquadAuditSlideOver';
+import { FixturesSlideOver }                from './FixturesSlideOver';
+import { BoardConfidenceSlideOver }         from './BoardConfidenceSlideOver';
+import { ScoutingSlideOver }                from './ScoutingSlideOver';
+
+// Commercial facilities always open the upgrade panel (no dedicated nav destination)
+const COMMERCIAL_TYPES = new Set<FacilityType>([
+  'CLUB_COMMERCIAL',
+  'FOOD_AND_BEVERAGE',
+  'FAN_ZONE',
+  'GROUNDS_SECURITY',
+]);
 
 interface StadiumViewProps {
   state:    GameState;
@@ -11,6 +45,16 @@ interface StadiumViewProps {
 export function StadiumView({ state, dispatch, onError }: StadiumViewProps) {
   const { club } = state;
 
+  // ── Slide-over open state ──────────────────────────────────────────────────
+  const [upgradeTarget, setUpgradeTarget] = useState<FacilityType | null>(null);
+  const [fixturesOpen,  setFixturesOpen]  = useState(false);
+  const [squadOpen,     setSquadOpen]     = useState(false);
+  const [backroomOpen,  setBackroomOpen]  = useState(false);
+  const [boardOpen,     setBoardOpen]     = useState(false);
+  const [scoutingOpen,  setScoutingOpen]  = useState(false);
+
+  // ── Handlers ──────────────────────────────────────────────────────────────
+
   function handleUpgrade(facilityType: FacilityType) {
     const result = dispatch({
       type:         'UPGRADE_FACILITY',
@@ -20,51 +64,126 @@ export function StadiumView({ state, dispatch, onError }: StadiumViewProps) {
     if (result.error) onError(result.error);
   }
 
-  return (
-    <div className="flex flex-col flex-1 overflow-y-auto">
+  function handleCoreUnitClick(facilityType: FacilityType) {
+    const facility = club.facilities.find(f => f.type === facilityType);
+    const level    = facility?.level ?? 0;
 
-      {/* ── Isometric stadium canvas ──────────────────────────────── */}
-      <IsometricBlueprint
+    // Commercial facilities and unbuilt (level-0) plots → upgrade/build panel
+    if (COMMERCIAL_TYPES.has(facilityType) || level === 0) {
+      setUpgradeTarget(facilityType);
+      return;
+    }
+
+    // Level 1+ navigation facilities → type-specific slide-over
+    switch (facilityType) {
+      case 'STADIUM':         setFixturesOpen(true);  break;
+      case 'TRAINING_GROUND': setSquadOpen(true);     break;
+      case 'MEDICAL_CENTER':  setBackroomOpen(true);  break;
+      case 'YOUTH_ACADEMY':   setScoutingOpen(true);  break;
+      case 'CLUB_OFFICE':     setBoardOpen(true);     break;
+    }
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  return (
+    <>
+      <div className="flex flex-col flex-1 overflow-y-auto">
+
+        {/* ── Isometric stadium canvas ──────────────────────────────── */}
+        <IsometricBlueprint
+          state={state}
+          dispatch={dispatch}
+          onError={onError}
+          onCoreUnitClick={handleCoreUnitClick}
+        />
+
+        {/* ── Below-fold detail panel ───────────────────────────────── */}
+        <div className="flex flex-col gap-4 p-4">
+
+          {/* Stadium header bar */}
+          <div className="card flex items-center justify-between py-3 bg-pitch-green/5 border border-pitch-green/20">
+            <div>
+              <p className="text-sm font-semibold text-txt-primary">{club.stadium.name}</p>
+              <p className="text-xs2 text-txt-muted">
+                Capacity: {club.stadium.capacity.toLocaleString()} ·
+                Avg attendance: {club.stadium.averageAttendance.toLocaleString()}
+              </p>
+            </div>
+            <div className="text-right">
+              <span className="text-xs text-txt-muted">Transfer Budget</span>
+              <p className="data-font text-sm font-semibold text-pitch-green">
+                {formatMoney(club.transferBudget)}
+              </p>
+            </div>
+          </div>
+
+          {/* Facility upgrade cards — 2-col grid */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {club.facilities.map(facility => (
+              <FacilityCard
+                key={facility.type}
+                facility={facility}
+                budget={club.transferBudget}
+                onUpgrade={() => handleUpgrade(facility.type)}
+              />
+            ))}
+          </div>
+
+        </div>
+      </div>
+
+      {/* ── Slide-overs ──────────────────────────────────────────────────── */}
+
+      {/* Upgrade / BuildPanel — commercial facilities + level-0 plots */}
+      <FacilityUpgradeSlideOver
+        facilityType={upgradeTarget}
         state={state}
         dispatch={dispatch}
         onError={onError}
-        // Navigation wiring added in PR 4
-        onCoreUnitClick={undefined}
+        onClose={() => setUpgradeTarget(null)}
       />
 
-      {/* ── Below-fold detail panel ──────────────────────────────── */}
-      <div className="flex flex-col gap-4 p-4">
+      {/* STADIUM → Fixtures & League Standing */}
+      <FixturesSlideOver
+        isOpen={fixturesOpen}
+        onClose={() => setFixturesOpen(false)}
+        state={state}
+      />
 
-        {/* Stadium header bar */}
-        <div className="card flex items-center justify-between py-3 bg-pitch-green/5 border border-pitch-green/20">
-          <div>
-            <p className="text-sm font-semibold text-txt-primary">{club.stadium.name}</p>
-            <p className="text-xs2 text-txt-muted">
-              Capacity: {club.stadium.capacity.toLocaleString()} ·
-              Avg attendance: {club.stadium.averageAttendance.toLocaleString()}
-            </p>
-          </div>
-          <div className="text-right">
-            <span className="text-xs text-txt-muted">Transfer Budget</span>
-            <p className="data-font text-sm font-semibold text-pitch-green">
-              {formatMoney(club.transferBudget)}
-            </p>
-          </div>
-        </div>
+      {/* TRAINING_GROUND → Squad Audit */}
+      <SquadAuditSlideOver
+        isOpen={squadOpen}
+        onClose={() => setSquadOpen(false)}
+        state={state}
+      />
 
-        {/* Facility upgrade cards — 2-col grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {club.facilities.map(facility => (
-            <FacilityCard
-              key={facility.type}
-              facility={facility}
-              budget={club.transferBudget}
-              onUpgrade={() => handleUpgrade(facility.type)}
-            />
-          ))}
-        </div>
+      {/* MEDICAL_CENTER → Backroom Team */}
+      <SlideOver
+        isOpen={backroomOpen}
+        onClose={() => setBackroomOpen(false)}
+        title="🩺 Backroom Team"
+      >
+        <BackroomTeamSlideOver
+          state={state}
+          dispatch={dispatch}
+          onError={onError}
+        />
+      </SlideOver>
 
-      </div>
-    </div>
+      {/* YOUTH_ACADEMY → Scouting */}
+      <ScoutingSlideOver
+        isOpen={scoutingOpen}
+        onClose={() => setScoutingOpen(false)}
+        state={state}
+      />
+
+      {/* CLUB_OFFICE → Board Confidence */}
+      <BoardConfidenceSlideOver
+        isOpen={boardOpen}
+        onClose={() => setBoardOpen(false)}
+        state={state}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- Wires `onCoreUnitClick(facilityType)` in `StadiumView` — clicking any core unit on the isometric canvas now opens an appropriate slide-over
- **6 destinations** implemented across 5 new components + 1 reused existing component:
  - `STADIUM` → `FixturesSlideOver` — league table (all 24 teams, zone-coloured), club standing hero card, form strip
  - `TRAINING_GROUND` → `SquadAuditSlideOver` — full squad roster with summary bar (players, avg OVR, wage bill)
  - `MEDICAL_CENTER` → `BackroomTeamSlideOver` (existing component, now accessible from stadium canvas)
  - `YOUTH_ACADEMY` → `ScoutingSlideOver` — U21 prospects list + transfer market coming-soon stub
  - `CLUB_OFFICE` → `BoardConfidenceSlideOver` — confidence bar, league standing, business acumen stars, guidance tips
  - Commercial facilities (`CLUB_COMMERCIAL`, `FOOD_AND_BEVERAGE`, `FAN_ZONE`, `GROUNDS_SECURITY`) + **any level-0 plot** → `FacilityUpgradeSlideOver` (build/upgrade panel with contextual banner for derelict plots)

## Routing logic

```
handleCoreUnitClick(facilityType):
  if commercial type OR level === 0  → FacilityUpgradeSlideOver
  STADIUM         → FixturesSlideOver
  TRAINING_GROUND → SquadAuditSlideOver
  MEDICAL_CENTER  → BackroomTeamSlideOver (in SlideOver wrapper)
  YOUTH_ACADEMY   → ScoutingSlideOver
  CLUB_OFFICE     → BoardConfidenceSlideOver
```

## Test plan

- [ ] 245 domain tests passing
- [ ] `tsc --noEmit` clean
- [ ] Click each of the 9 core units — correct slide-over opens
- [ ] Click a level-0 facility (e.g. Training Ground at game start) → upgrade panel with "Build" title
- [ ] Click Club Office (level 1) → Board Confidence slide-over
- [ ] Escape key closes any open slide-over
- [ ] Backdrop click closes any open slide-over
- [ ] Card grid upgrade buttons still work independently of slide-overs

🤖 Generated with [Claude Code](https://claude.com/claude-code)