### PR TITLE
feat: Phase 5.1 — Pre-season flow, formation picker, inherited squad

### DIFF
--- a/packages/domain/src/__tests__/match.test.ts
+++ b/packages/domain/src/__tests__/match.test.ts
@@ -145,6 +145,8 @@ describe('clubToTeam', () => {
       stadium: { name: 'Test Arena', capacity: 5000, averageAttendance: 3000, ticketPrice: 2000 },
       form: [],
       trainingFocus: null,
+      preferredFormation: null,
+      squadCapacity: 24,
     };
 
     const team = clubToTeam(club);
@@ -172,6 +174,8 @@ describe('clubToTeam', () => {
       stadium: { name: '', capacity: 0, averageAttendance: 0, ticketPrice: 0 },
       form: [],
       trainingFocus: null,
+      preferredFormation: null,
+      squadCapacity: 24,
     };
 
     const team = clubToTeam(club);
@@ -194,6 +198,8 @@ describe('clubToTeam', () => {
       stadium: { name: '', capacity: 0, averageAttendance: 0, ticketPrice: 0 },
       form: [],
       trainingFocus: null,
+      preferredFormation: null,
+      squadCapacity: 24,
     };
 
     const winningClub: Club = { ...baseClub, form: ['W', 'W', 'W', 'W', 'W'] };

--- a/packages/domain/src/__tests__/reducer-match.test.ts
+++ b/packages/domain/src/__tests__/reducer-match.test.ts
@@ -41,6 +41,8 @@ function makeState(entries: LeagueTableEntry[], playerClubId: string = 'club-1')
       stadium: { name: 'Test', capacity: 5000, averageAttendance: 3000, ticketPrice: 2000 },
       form: [],
       trainingFocus: null,
+      preferredFormation: null,
+      squadCapacity: 24,
     },
     league: {
       entries,

--- a/packages/domain/src/__tests__/type-utils.test.ts
+++ b/packages/domain/src/__tests__/type-utils.test.ts
@@ -93,6 +93,8 @@ describe('calculateClubStrength', () => {
       stadium: { name: '', capacity: 0, averageAttendance: 0, ticketPrice: 0 },
       form: [],
       trainingFocus: null,
+      preferredFormation: null,
+      squadCapacity: 24,
     };
     // No squad → calculateSquadStrength crashes on division by zero? Let me check...
     // Actually: totalRating / squad.length = 0/0 = NaN → Math.floor(NaN * 100) = NaN
@@ -117,6 +119,8 @@ describe('calculateClubStrength', () => {
       stadium: { name: '', capacity: 0, averageAttendance: 0, ticketPrice: 0 },
       form: [],
       trainingFocus: null,
+      preferredFormation: null,
+      squadCapacity: 24,
     };
     const strength = calculateClubStrength(club);
     // squadStrength = floor(70 * 100) = 7000
@@ -138,6 +142,8 @@ describe('calculateClubStrength', () => {
       stadium: { name: '', capacity: 0, averageAttendance: 0, ticketPrice: 0 },
       form: [],
       trainingFocus: null,
+      preferredFormation: null,
+      squadCapacity: 24,
     };
     const strength = calculateClubStrength(club);
     // squadStrength = 7000, staffBonus = 0, facilityBonus = 3 * 50 = 150, reputationBonus = 0

--- a/packages/domain/src/commands/handlers.ts
+++ b/packages/domain/src/commands/handlers.ts
@@ -34,6 +34,8 @@ export function handleCommand(command: GameCommand, state: GameState): CommandRe
       return handleStartSeason(command, state);
     case 'SET_TRAINING_FOCUS':
       return handleSetTrainingFocus(command, state);
+    case 'SET_FORMATION':
+      return handleSetFormation(command, state);
     default:
       return {
         error: {
@@ -402,6 +404,19 @@ function handleSetTrainingFocus(command: any, state: GameState): CommandResult {
       clubId: state.club.id,
       focus: command.focus,
       previousFocus: state.club.trainingFocus,
+    },
+  ];
+  return { events };
+}
+
+function handleSetFormation(command: any, state: GameState): CommandResult {
+  const events: GameEvent[] = [
+    {
+      type: 'FORMATION_SET',
+      timestamp: Date.now(),
+      clubId: state.club.id,
+      formation: command.formation,
+      previousFormation: state.club.preferredFormation,
     },
   ];
   return { events };

--- a/packages/domain/src/commands/types.ts
+++ b/packages/domain/src/commands/types.ts
@@ -8,6 +8,7 @@
 import { GameEvent } from '../events/types';
 import { CommandError } from '../types/game-state-updated';
 import { TrainingFocus } from '../types/facility';
+import { Formation } from '../types/formation';
 
 export type GameCommand =
   | MakeTransferCommand
@@ -17,7 +18,8 @@ export type GameCommand =
   | RecordMathAttemptCommand
   | ResolveClubEventCommand
   | StartSeasonCommand
-  | SetTrainingFocusCommand;
+  | SetTrainingFocusCommand
+  | SetFormationCommand;
 
 export interface MakeTransferCommand {
   type: 'MAKE_TRANSFER';
@@ -71,6 +73,11 @@ export interface StartSeasonCommand {
 export interface SetTrainingFocusCommand {
   type: 'SET_TRAINING_FOCUS';
   focus: TrainingFocus;
+}
+
+export interface SetFormationCommand {
+  type: 'SET_FORMATION';
+  formation: Formation;
 }
 
 export interface CommandResult {

--- a/packages/domain/src/data/league-two-teams.ts
+++ b/packages/domain/src/data/league-two-teams.ts
@@ -1,8 +1,9 @@
 /**
  * League Two Teams Data
  *
- * Real English League Two clubs with base strength ratings (35-65).
- * These are used to populate the league when a new game starts.
+ * Fictional Pro-Evo style clubs — clearly recognisable analogues of real lower-league
+ * sides, slightly tweaked to sidestep licensing. Strength ratings reflect rough real-world
+ * standing at League Two level (35–65).
  */
 
 export interface LeagueTwoTeam {
@@ -12,28 +13,28 @@ export interface LeagueTwoTeam {
 }
 
 export const LEAGUE_TWO_TEAMS: LeagueTwoTeam[] = [
-  { id: 'swindon', name: 'Swindon Town', baseStrength: 62 },
-  { id: 'bradford', name: 'Bradford City', baseStrength: 60 },
-  { id: 'doncaster', name: 'Doncaster Rovers', baseStrength: 58 },
-  { id: 'gillingham', name: 'Gillingham', baseStrength: 56 },
-  { id: 'crewe', name: 'Crewe Alexandra', baseStrength: 55 },
-  { id: 'crawley', name: 'Crawley Town', baseStrength: 54 },
-  { id: 'salford', name: 'Salford City', baseStrength: 53 },
-  { id: 'newport', name: 'Newport County', baseStrength: 52 },
-  { id: 'colchester', name: 'Colchester United', baseStrength: 51 },
-  { id: 'tranmere', name: 'Tranmere Rovers', baseStrength: 50 },
-  { id: 'walsall', name: 'Walsall', baseStrength: 49 },
-  { id: 'harrogate', name: 'Harrogate Town', baseStrength: 48 },
-  { id: 'barrow', name: 'Barrow', baseStrength: 47 },
-  { id: 'grimsby', name: 'Grimsby Town', baseStrength: 46 },
-  { id: 'mansfield', name: 'Mansfield Town', baseStrength: 45 },
-  { id: 'sutton', name: 'Sutton United', baseStrength: 44 },
-  { id: 'rochdale', name: 'Rochdale', baseStrength: 43 },
-  { id: 'carlisle', name: 'Carlisle United', baseStrength: 42 },
-  { id: 'stevenage', name: 'Stevenage', baseStrength: 41 },
-  { id: 'hartlepool', name: 'Hartlepool United', baseStrength: 40 },
-  { id: 'leyton', name: 'Leyton Orient', baseStrength: 39 },
-  { id: 'scunthorpe', name: 'Scunthorpe United', baseStrength: 38 },
-  { id: 'oldham', name: 'Oldham Athletic', baseStrength: 37 },
-  { id: 'port-vale', name: 'Port Vale', baseStrength: 36 },
+  { id: 'swinton', name: 'Swinton Town', baseStrength: 62 },
+  { id: 'bradfield', name: 'Bradfield City', baseStrength: 60 },
+  { id: 'doncaster', name: 'Doncaster Ramblers', baseStrength: 58 },
+  { id: 'gillingsham', name: 'Gillingsham FC', baseStrength: 56 },
+  { id: 'crewe', name: 'Crewe Alexandros', baseStrength: 55 },
+  { id: 'crowley', name: 'Crowley Town', baseStrength: 54 },
+  { id: 'salchester', name: 'Salchester City', baseStrength: 53 },
+  { id: 'newport', name: 'Newport Athletic', baseStrength: 52 },
+  { id: 'coldale', name: 'Coldale United', baseStrength: 51 },
+  { id: 'tranmore', name: 'Tranmore Rovers', baseStrength: 50 },
+  { id: 'walshall', name: 'Walshall FC', baseStrength: 49 },
+  { id: 'harrowgate', name: 'Harrowgate Town', baseStrength: 48 },
+  { id: 'barrow-vale', name: 'Barrow Vale', baseStrength: 47 },
+  { id: 'grimstone', name: 'Grimstone Town', baseStrength: 46 },
+  { id: 'manyfield', name: 'Manyfield Town', baseStrength: 45 },
+  { id: 'sutbourne', name: 'Sutbourne United', baseStrength: 44 },
+  { id: 'rochford', name: 'Rochford FC', baseStrength: 43 },
+  { id: 'carlford', name: 'Carlford United', baseStrength: 42 },
+  { id: 'stevenham', name: 'Stevenham FC', baseStrength: 41 },
+  { id: 'hartpool', name: 'Hartpool United', baseStrength: 40 },
+  { id: 'layton', name: 'Layton Orient', baseStrength: 39 },
+  { id: 'scunbridge', name: 'Scunbridge United', baseStrength: 38 },
+  { id: 'oldfield', name: 'Oldfield Athletic', baseStrength: 37 },
+  { id: 'port-hill', name: 'Port Hill FC', baseStrength: 36 },
 ];

--- a/packages/domain/src/data/squad-generator.ts
+++ b/packages/domain/src/data/squad-generator.ts
@@ -1,0 +1,99 @@
+/**
+ * Squad Generator
+ *
+ * Generates a starting squad of 16 weak, unknown non-league players.
+ * Deterministic from seed — same seed always produces the same squad.
+ *
+ * Narrative context: the player has just been promoted from the non-leagues.
+ * This is the inherited rabble. Most of them need replacing sharpish.
+ */
+
+import { Player, Position } from '../types/player';
+import { createRng } from '../simulation/rng';
+
+// Name banks — plausible lower-league English football player names
+const FORENAMES = [
+  'Terry', 'Dave', 'Glen', 'Craig', 'Jamie', 'Lee', 'Chris', 'Mark',
+  'Steve', 'Paul', 'Andy', 'Phil', 'Rob', 'John', 'Wayne', 'Darren',
+  'Scott', 'Shane', 'Kevin', 'Tony', 'Dan', 'Gary', 'Nicky', 'Barry',
+  'Carl', 'Dean', 'Graham', 'Keith', 'Mick', 'Neil', 'Pete', 'Ryan',
+  'Shaun', 'Tom', 'Vic', 'Will', 'Ade', 'Brad', 'Clive', 'Doug',
+];
+
+const SURNAMES = [
+  'Perkins', 'Gould', 'Marsh', 'Stubbs', 'Denton', 'Holt', 'Firth',
+  'Neale', 'Briggs', 'Towers', 'Grimes', 'Hackett', 'Doyle', 'Watts',
+  'Sayers', 'Daly', 'Birch', 'Nolan', 'Poole', 'Cross', 'Hunter',
+  'Payne', 'Webb', 'Booth', 'Curry', 'Elson', 'Frost', 'Gale',
+  'Haines', 'Ivory', 'Jarvis', 'Keane', 'Lodge', 'Munro', 'Norris',
+  'Ogden', 'Patel', 'Quinn', 'Reeve', 'Sykes', 'Trent', 'Upton',
+  'Vance', 'Wren', 'York', 'Ashby', 'Bale', 'Crane', 'Drake',
+];
+
+/** Distribution: 2 GK, 5 DEF, 5 MID, 4 FWD — enough to cover any formation with bench */
+const POSITION_DISTRIBUTION: Position[] = [
+  'GK', 'GK',
+  'DEF', 'DEF', 'DEF', 'DEF', 'DEF',
+  'MID', 'MID', 'MID', 'MID', 'MID',
+  'FWD', 'FWD', 'FWD', 'FWD',
+];
+
+/**
+ * Generate a starting squad of 16 weak non-league players.
+ * All are genuinely bad — the player needs to replace most of them.
+ */
+export function generateStartingSquad(seed: string, clubId: string): Player[] {
+  const rng = createRng(`${seed}-squad-${clubId}`);
+
+  const usedNames = new Set<string>();
+
+  function pickName(): string {
+    let name: string;
+    let attempts = 0;
+    do {
+      const forename = FORENAMES[Math.floor(rng.next() * FORENAMES.length)];
+      const surname = SURNAMES[Math.floor(rng.next() * SURNAMES.length)];
+      name = `${forename} ${surname}`;
+      attempts++;
+    } while (usedNames.has(name) && attempts < 100);
+    usedNames.add(name);
+    return name;
+  }
+
+  return POSITION_DISTRIBUTION.map((position, index) => {
+    const name = pickName();
+
+    // Rating: 35–52 — genuinely weak. A rating above 50 is a keeper here.
+    const overallRating = 35 + Math.floor(rng.next() * 18);
+
+    // Age: spread 18–34. Some too old (past it), some too young (raw).
+    const age = 18 + Math.floor(rng.next() * 17);
+
+    // Wages: £150–£350/week (non-league rates)
+    const wage = (150 + Math.floor(rng.next() * 200)) * 100; // in pence
+
+    // Transfer value: £3k–£20k — very low
+    const transferValue = (3000 + Math.floor(rng.next() * 17000)) * 100; // in pence
+
+    // Morale: moderate — they don't know what's coming
+    const morale = 45 + Math.floor(rng.next() * 25);
+
+    return {
+      id: `inherited-${clubId}-${index}`,
+      name,
+      overallRating,
+      position,
+      wage,
+      transferValue,
+      age,
+      morale,
+      stats: {
+        goals: 0,
+        assists: 0,
+        cleanSheets: 0,
+        appearances: 0,
+        averageRating: overallRating,
+      },
+    };
+  });
+}

--- a/packages/domain/src/events/types.ts
+++ b/packages/domain/src/events/types.ts
@@ -9,6 +9,7 @@ import { Player } from '../types/player';
 import { Staff } from '../types/staff';
 import { PendingClubEvent } from '../types/game-state-updated';
 import { TrainingFocus } from '../types/facility';
+import { Formation } from '../types/formation';
 
 export type GameEvent =
   | GameStartedEvent
@@ -25,7 +26,8 @@ export type GameEvent =
   | ClubEventOccurredEvent
   | ClubEventResolvedEvent
   | SeasonStartedEvent
-  | TrainingFocusSetEvent;
+  | TrainingFocusSetEvent
+  | FormationSetEvent;
 
 export interface TransferCompletedEvent {
   type: 'TRANSFER_COMPLETED';
@@ -158,4 +160,12 @@ export interface TrainingFocusSetEvent {
   clubId: string;
   focus: TrainingFocus;
   previousFocus: TrainingFocus | null;
+}
+
+export interface FormationSetEvent {
+  type: 'FORMATION_SET';
+  timestamp: number;
+  clubId: string;
+  formation: Formation;
+  previousFormation: Formation | null;
 }

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -34,6 +34,7 @@ export * from './money/utils';
 // Data
 export * from './data/league-two-teams';
 export * from './data/club-events';
+export * from './data/squad-generator';
 
 // Core state types
 export * from './types/game-state-updated';
@@ -43,3 +44,4 @@ export * from './types/match';
 export * from './types/staff';
 export * from './types/facility';
 export * from './types/league';
+export * from './types/formation';

--- a/packages/domain/src/reducers/index.ts
+++ b/packages/domain/src/reducers/index.ts
@@ -4,13 +4,14 @@
  * Pure functions that apply events to state.
  */
 
-import { GameEvent, GameStartedEvent, MatchSimulatedEvent, TransferCompletedEvent, StaffHiredEvent, MathAttemptRecordedEvent, ClubEventOccurredEvent, ClubEventResolvedEvent, SeasonStartedEvent, TrainingFocusSetEvent } from '../events/types';
+import { GameEvent, GameStartedEvent, MatchSimulatedEvent, TransferCompletedEvent, StaffHiredEvent, MathAttemptRecordedEvent, ClubEventOccurredEvent, ClubEventResolvedEvent, SeasonStartedEvent, TrainingFocusSetEvent, FormationSetEvent } from '../events/types';
 import { GameState } from '../types/game-state-updated';
 import { Club } from '../types/club';
 import { LeagueTable, LeagueTableEntry, sortLeagueTable } from '../types/league';
 import { CURRICULUM_LEVELS } from '../curriculum/curriculum-config';
 import { LEAGUE_TWO_TEAMS } from '../data/league-two-teams';
 import { getDefaultFacilities, getUpgradeCost } from '../types/facility';
+import { generateStartingSquad } from '../data/squad-generator';
 
 /**
  * Reduce an event into state
@@ -47,6 +48,8 @@ export function reduceEvent(state: GameState, event: GameEvent): GameState {
       return handleSeasonStarted(state, event);
     case 'TRAINING_FOCUS_SET':
       return handleTrainingFocusSet(state, event);
+    case 'FORMATION_SET':
+      return handleFormationSet(state, event);
     default:
       return state;
   }
@@ -132,15 +135,21 @@ function handleGameStarted(state: GameState, event: GameStartedEvent): GameState
     position: index + 1
   }));
 
+  // Generate the inherited starting squad of 16 weak non-league players
+  const inheritedSquad = generateStartingSquad(event.seed, event.clubId);
+
   return {
     ...state,
+    phase: 'PRE_SEASON',
     club: {
       ...state.club,
       id: event.clubId,
       name: event.clubName,
       transferBudget: event.initialBudget,
-      wageBudget: event.initialBudget / 10, // 10% of budget for weekly wages
-      facilities: getDefaultFacilities()
+      wageBudget: event.initialBudget / 10,
+      facilities: getDefaultFacilities(),
+      squad: inheritedSquad,
+      squadCapacity: 24,
     },
     league: {
       ...state.league,
@@ -442,6 +451,16 @@ function handleTrainingFocusSet(state: GameState, event: TrainingFocusSetEvent):
   };
 }
 
+function handleFormationSet(state: GameState, event: FormationSetEvent): GameState {
+  return {
+    ...state,
+    club: {
+      ...state.club,
+      preferredFormation: event.formation,
+    },
+  };
+}
+
 // Utility functions
 
 function createEmptyClub(): Club {
@@ -462,6 +481,8 @@ function createEmptyClub(): Club {
     },
     form: [],
     trainingFocus: null,
+    preferredFormation: null,
+    squadCapacity: 24,
   };
 }
 

--- a/packages/domain/src/types/club.ts
+++ b/packages/domain/src/types/club.ts
@@ -5,6 +5,7 @@
 import { Player } from './player';
 import { Facility, TrainingFocus } from './facility';
 import { Staff } from './staff';
+import { Formation } from './formation';
 
 /**
  * Football club representation
@@ -39,6 +40,12 @@ export interface Club {
 
   /** Weekly training focus chosen by the manager (null = not yet set) */
   trainingFocus: TrainingFocus | null;
+
+  /** Owner's preferred formation — governs recruitment strategy */
+  preferredFormation: Formation | null;
+
+  /** Total squad slots available (capped at 24) */
+  squadCapacity: number;
 }
 
 /**

--- a/packages/domain/src/types/formation.ts
+++ b/packages/domain/src/types/formation.ts
@@ -1,0 +1,117 @@
+/**
+ * Formation types and configuration
+ *
+ * The player (as owner/CEO) picks a preferred formation which sets the
+ * club's recruitment strategy — how many of each position to target.
+ * The manager then picks the actual XI within that shape.
+ */
+
+import { Position } from './player';
+
+/**
+ * Supported formations
+ */
+export type Formation =
+  | '4-4-2'
+  | '4-3-3'
+  | '4-2-3-1'
+  | '3-5-2'
+  | '5-3-2'
+  | '4-5-1';
+
+/**
+ * How many players of each position a formation ideally fields
+ */
+export interface FormationSlots {
+  GK: number;
+  DEF: number;
+  MID: number;
+  FWD: number;
+}
+
+/**
+ * Full config for a formation
+ */
+export interface FormationConfig {
+  id: Formation;
+  label: string;
+  description: string;
+  style: string;
+  /** Ideal XI composition */
+  slots: FormationSlots;
+  /** Positions to prioritise when recruiting */
+  recruitmentPriority: Position[];
+}
+
+export const FORMATION_CONFIG: Record<Formation, FormationConfig> = {
+  '4-4-2': {
+    id: '4-4-2',
+    label: '4-4-2',
+    description: 'Two banks of four with a strike partnership. Solid, predictable, hard to break down.',
+    style: 'Balanced',
+    slots: { GK: 1, DEF: 4, MID: 4, FWD: 2 },
+    recruitmentPriority: ['MID', 'DEF', 'FWD', 'GK'],
+  },
+  '4-3-3': {
+    id: '4-3-3',
+    label: '4-3-3',
+    description: 'Three forwards pressing high with a midfield triangle. Attacking and energetic.',
+    style: 'Attacking',
+    slots: { GK: 1, DEF: 4, MID: 3, FWD: 3 },
+    recruitmentPriority: ['FWD', 'MID', 'DEF', 'GK'],
+  },
+  '4-2-3-1': {
+    id: '4-2-3-1',
+    label: '4-2-3-1',
+    description: 'Double pivot protects the back four, ten behind the striker. Controlled and possession-based.',
+    style: 'Controlled',
+    slots: { GK: 1, DEF: 4, MID: 5, FWD: 1 },
+    recruitmentPriority: ['MID', 'DEF', 'FWD', 'GK'],
+  },
+  '3-5-2': {
+    id: '3-5-2',
+    label: '3-5-2',
+    description: 'Three centre-backs, wing-backs bombing on. Aggressive out wide, direct.',
+    style: 'Wing Play',
+    slots: { GK: 1, DEF: 3, MID: 5, FWD: 2 },
+    recruitmentPriority: ['DEF', 'MID', 'FWD', 'GK'],
+  },
+  '5-3-2': {
+    id: '5-3-2',
+    label: '5-3-2',
+    description: 'Solid defensive block, hit on the counter. Hard to score against.',
+    style: 'Defensive',
+    slots: { GK: 1, DEF: 5, MID: 3, FWD: 2 },
+    recruitmentPriority: ['DEF', 'FWD', 'MID', 'GK'],
+  },
+  '4-5-1': {
+    id: '4-5-1',
+    label: '4-5-1',
+    description: 'Deep midfield bank, lone striker to hold up. Grind results, absorb pressure.',
+    style: 'Counter',
+    slots: { GK: 1, DEF: 4, MID: 5, FWD: 1 },
+    recruitmentPriority: ['MID', 'FWD', 'DEF', 'GK'],
+  },
+};
+
+/**
+ * How well does the current squad cover this formation's ideal slots?
+ * Returns a 0-100 coverage score.
+ */
+export function formationCoverage(
+  squadByPosition: Record<Position, number>,
+  formation: Formation
+): number {
+  const slots = FORMATION_CONFIG[formation].slots;
+  const needed = slots.GK + slots.DEF + slots.MID + slots.FWD;
+  let filled = 0;
+
+  const positions: Position[] = ['GK', 'DEF', 'MID', 'FWD'];
+  for (const pos of positions) {
+    const want = slots[pos];
+    const have = squadByPosition[pos] ?? 0;
+    filled += Math.min(have, want);
+  }
+
+  return Math.round((filled / needed) * 100);
+}

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -3,11 +3,16 @@ import { useGameState } from './hooks/useGameState';
 import { CommandCentre } from './components/command-centre/CommandCentre';
 import { StadiumView } from './components/stadium-view/StadiumView';
 import { ViewToggle, ActiveView } from './components/shared/ViewToggle';
+import { PreSeasonScreen } from './components/pre-season/PreSeasonScreen';
 
 export default function App() {
   const { state, events, dispatch, isLoading } = useGameState();
   const [activeView, setActiveView] = useState<ActiveView>('command');
   const [error, setError] = useState<string | null>(null);
+
+  if (state.phase === 'PRE_SEASON') {
+    return <PreSeasonScreen state={state} dispatch={dispatch} />;
+  }
 
   return (
     <div className="min-h-screen bg-bg-deep text-txt-primary flex flex-col">

--- a/packages/frontend/src/components/pre-season/FormationPicker.tsx
+++ b/packages/frontend/src/components/pre-season/FormationPicker.tsx
@@ -1,0 +1,80 @@
+import { Formation, FORMATION_CONFIG, FormationConfig } from '@calculating-glory/domain';
+
+interface FormationPickerProps {
+  selected: Formation | null;
+  onSelect: (f: Formation) => void;
+}
+
+const STYLE_BADGE: Record<string, string> = {
+  Balanced:   'bg-data-blue/15 text-data-blue',
+  Attacking:  'bg-pitch-green/15 text-pitch-green',
+  Controlled: 'bg-warn-amber/15 text-warn-amber',
+  'Wing Play':'bg-[#CE93D8]/15 text-[#CE93D8]',
+  Defensive:  'bg-txt-muted/15 text-txt-muted',
+  Counter:    'bg-alert-red/15 text-alert-red',
+};
+
+const FORMATIONS: Formation[] = ['4-4-2', '4-3-3', '4-2-3-1', '3-5-2', '5-3-2', '4-5-1'];
+
+function SlotDots({ slots }: { slots: FormationConfig['slots'] }) {
+  return (
+    <div className="flex items-center gap-2 mt-3">
+      {(['GK', 'DEF', 'MID', 'FWD'] as const).map(pos => (
+        <div key={pos} className="flex flex-col items-center gap-0.5">
+          <div className="flex gap-0.5">
+            {Array.from({ length: slots[pos] }).map((_, i) => (
+              <div
+                key={i}
+                className="w-2 h-2 rounded-full bg-txt-muted/40"
+              />
+            ))}
+          </div>
+          <span className="text-xs2 text-txt-muted/60">{pos}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function FormationPicker({ selected, onSelect }: FormationPickerProps) {
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-txt-primary mb-1">Preferred Formation</h3>
+      <p className="text-xs text-txt-muted mb-4">
+        Sets your recruitment strategy. Your manager picks the XI — this tells them what shape you want to play.
+      </p>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        {FORMATIONS.map(id => {
+          const cfg = FORMATION_CONFIG[id];
+          const isSelected = selected === id;
+          return (
+            <button
+              key={id}
+              onClick={() => onSelect(id)}
+              className={[
+                'text-left rounded-card p-4 border transition-all',
+                isSelected
+                  ? 'bg-data-blue/10 border-data-blue shadow-[0_0_0_1px_rgba(68,138,255,0.4)]'
+                  : 'bg-bg-raised border-white/5 hover:border-white/20',
+              ].join(' ')}
+            >
+              <div className="flex items-center justify-between mb-1">
+                <span className="text-lg font-bold text-txt-primary font-mono">{cfg.label}</span>
+                {isSelected && (
+                  <span className="text-xs text-data-blue font-semibold">✓</span>
+                )}
+              </div>
+              <span className={`text-xs2 font-medium px-1.5 py-0.5 rounded-tag ${STYLE_BADGE[cfg.style] ?? 'bg-txt-muted/15 text-txt-muted'}`}>
+                {cfg.style}
+              </span>
+              <p className="text-xs text-txt-muted mt-2 leading-relaxed line-clamp-3">
+                {cfg.description}
+              </p>
+              <SlotDots slots={cfg.slots} />
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/pre-season/InheritedSquad.tsx
+++ b/packages/frontend/src/components/pre-season/InheritedSquad.tsx
@@ -1,0 +1,98 @@
+import { Player, Position, Formation, FORMATION_CONFIG, formatMoney } from '@calculating-glory/domain';
+
+interface InheritedSquadProps {
+  squad: Player[];
+  formation: Formation | null;
+}
+
+const POSITION_ORDER: Position[] = ['GK', 'DEF', 'MID', 'FWD'];
+const POSITION_COLOUR: Record<Position, string> = {
+  GK:  'bg-warn-amber/20 text-warn-amber',
+  DEF: 'bg-data-blue/20 text-data-blue',
+  MID: 'bg-pitch-green/20 text-pitch-green',
+  FWD: 'bg-alert-red/20 text-alert-red',
+};
+
+function ratingColour(r: number): string {
+  if (r >= 60) return 'text-pitch-green';
+  if (r >= 50) return 'text-warn-amber';
+  return 'text-alert-red';
+}
+
+function RatingBar({ rating }: { rating: number }) {
+  const pct = Math.round((rating / 100) * 100);
+  return (
+    <div className="flex items-center gap-2">
+      <span className={`text-xs font-mono font-bold w-6 ${ratingColour(rating)}`}>{rating}</span>
+      <div className="flex-1 h-1.5 bg-bg-deep rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full ${rating >= 60 ? 'bg-pitch-green' : rating >= 50 ? 'bg-warn-amber' : 'bg-alert-red'}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function InheritedSquad({ squad, formation }: InheritedSquadProps) {
+  const sorted = [...squad].sort(
+    (a, b) => POSITION_ORDER.indexOf(a.position) - POSITION_ORDER.indexOf(b.position)
+  );
+
+  // How many of each position the formation wants
+  const targets = formation ? FORMATION_CONFIG[formation].slots : null;
+  const counts: Record<Position, number> = { GK: 0, DEF: 0, MID: 0, FWD: 0 };
+  for (const p of squad) counts[p.position]++;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <h3 className="text-sm font-semibold text-txt-primary">Inherited Squad</h3>
+        <span className="text-xs text-txt-muted">{squad.length} / 24 slots</span>
+      </div>
+      <p className="text-xs text-txt-muted mb-3">
+        Promoted from non-league. Most of these lads need replacing before you're relegated on day one.
+      </p>
+
+      {/* Position coverage vs formation */}
+      {targets && (
+        <div className="grid grid-cols-4 gap-2 mb-4">
+          {POSITION_ORDER.map(pos => {
+            const have = counts[pos];
+            const want = targets[pos];
+            const ok = have >= want;
+            return (
+              <div key={pos} className="bg-bg-deep rounded-card p-2 text-center">
+                <div className={`text-lg font-bold font-mono ${ok ? 'text-pitch-green' : 'text-alert-red'}`}>
+                  {have}/{want}
+                </div>
+                <div className="text-xs2 text-txt-muted">{pos}</div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="space-y-1">
+        {sorted.map(player => (
+          <div
+            key={player.id}
+            className="flex items-center gap-3 bg-bg-raised rounded-lg px-3 py-2"
+          >
+            <span className={`text-xs2 font-bold px-1.5 py-0.5 rounded-tag w-8 text-center ${POSITION_COLOUR[player.position]}`}>
+              {player.position}
+            </span>
+            <span className="flex-1 text-sm text-txt-primary truncate">{player.name}</span>
+            <span className="text-xs text-txt-muted w-6 text-center">{player.age}</span>
+            <div className="w-28">
+              <RatingBar rating={player.overallRating} />
+            </div>
+            <span className="text-xs text-txt-muted w-16 text-right font-mono">
+              {formatMoney(player.wage)}<span className="text-xs2">/wk</span>
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/pre-season/PreSeasonScreen.tsx
+++ b/packages/frontend/src/components/pre-season/PreSeasonScreen.tsx
@@ -1,0 +1,164 @@
+import { useState } from 'react';
+import { GameState, GameCommand, Formation, formatMoney } from '@calculating-glory/domain';
+import { FormationPicker } from './FormationPicker';
+import { InheritedSquad } from './InheritedSquad';
+
+interface PreSeasonScreenProps {
+  state: GameState;
+  dispatch: (command: GameCommand) => { error?: string };
+}
+
+type Step = 'formation' | 'squad';
+
+export function PreSeasonScreen({ state, dispatch }: PreSeasonScreenProps) {
+  const [step, setStep] = useState<Step>('formation');
+  const [pendingFormation, setPendingFormation] = useState<Formation | null>(
+    state.club.preferredFormation
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const { club } = state;
+  const totalWages = club.squad.reduce((s, p) => s + p.wage, 0);
+
+  function confirmFormation() {
+    if (!pendingFormation) return;
+    const result = dispatch({ type: 'SET_FORMATION', formation: pendingFormation });
+    if (result.error) {
+      setError(result.error);
+    } else {
+      setStep('squad');
+    }
+  }
+
+  function beginSeason() {
+    const result = dispatch({ type: 'START_SEASON', season: 1 });
+    if (result.error) setError(result.error);
+  }
+
+  return (
+    <div className="min-h-screen bg-bg-deep flex flex-col">
+      {/* Header */}
+      <div className="bg-bg-surface border-b border-white/5 px-4 py-4">
+        <div className="max-w-2xl mx-auto">
+          <div className="flex items-center gap-3 mb-1">
+            <div className="w-2 h-2 rounded-full bg-warn-amber animate-pulse" />
+            <span className="text-xs font-semibold text-warn-amber uppercase tracking-widest">
+              Pre-Season
+            </span>
+          </div>
+          <h1 className="text-xl font-bold text-txt-primary">{club.name}</h1>
+          <p className="text-sm text-txt-muted mt-0.5">
+            Budget: <span className="text-txt-primary font-mono">{formatMoney(club.transferBudget)}</span>
+            <span className="mx-2 text-white/10">|</span>
+            Weekly wages: <span className="text-txt-primary font-mono">{formatMoney(totalWages)}/wk</span>
+          </p>
+        </div>
+      </div>
+
+      {/* Step indicator */}
+      <div className="bg-bg-surface border-b border-white/5 px-4 py-2">
+        <div className="max-w-2xl mx-auto flex gap-1">
+          {(['formation', 'squad'] as Step[]).map((s, i) => (
+            <button
+              key={s}
+              onClick={() => step === 'squad' && s === 'formation' ? setStep(s) : undefined}
+              className={[
+                'flex items-center gap-2 px-3 py-1.5 rounded-tag text-xs font-medium transition-colors',
+                step === s
+                  ? 'bg-data-blue/20 text-data-blue'
+                  : i < (['formation', 'squad'] as Step[]).indexOf(step)
+                    ? 'text-txt-muted hover:text-txt-primary cursor-pointer'
+                    : 'text-txt-muted/40 cursor-default',
+              ].join(' ')}
+            >
+              <span className="w-4 h-4 rounded-full border flex items-center justify-center text-xs2 border-current">
+                {i + 1}
+              </span>
+              {s === 'formation' ? 'Formation' : 'Your Squad'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="max-w-2xl mx-auto px-4 py-6 space-y-6">
+
+          {step === 'formation' && (
+            <>
+              {/* Narrative */}
+              <div className="bg-bg-surface rounded-card p-5 border border-white/5">
+                <div className="flex items-start gap-3">
+                  <div className="text-2xl mt-0.5">🏟️</div>
+                  <div>
+                    <h2 className="text-base font-bold text-txt-primary mb-2">
+                      Welcome to the Football League
+                    </h2>
+                    <p className="text-sm text-txt-muted leading-relaxed">
+                      You've just been promoted from the non-leagues. The club's been on a shoestring
+                      for years — the squad you've inherited is the proof. Most of them are too old,
+                      too raw, or just not good enough for League Two.
+                    </p>
+                    <p className="text-sm text-txt-muted leading-relaxed mt-2">
+                      You've got <span className="text-txt-primary font-medium">{formatMoney(club.transferBudget)}</span> to
+                      spend and 8 empty squad slots. Use them wisely. The drop back down is only 46 games away.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <FormationPicker
+                selected={pendingFormation}
+                onSelect={setPendingFormation}
+              />
+
+              {error && (
+                <p className="text-sm text-alert-red bg-alert-red/10 rounded-card px-4 py-2">{error}</p>
+              )}
+
+              <button
+                onClick={confirmFormation}
+                disabled={!pendingFormation}
+                className={[
+                  'w-full py-3 rounded-card font-semibold text-sm transition-all',
+                  pendingFormation
+                    ? 'bg-data-blue text-white hover:bg-data-blue/90'
+                    : 'bg-bg-raised text-txt-muted/40 cursor-not-allowed',
+                ].join(' ')}
+              >
+                {pendingFormation ? `Confirm ${pendingFormation} →` : 'Pick a formation to continue'}
+              </button>
+            </>
+          )}
+
+          {step === 'squad' && (
+            <>
+              <InheritedSquad
+                squad={club.squad}
+                formation={club.preferredFormation}
+              />
+
+              {error && (
+                <p className="text-sm text-alert-red bg-alert-red/10 rounded-card px-4 py-2">{error}</p>
+              )}
+
+              <div className="bg-bg-surface rounded-card p-4 border border-white/5 text-sm text-txt-muted">
+                <p>
+                  Transfers open once the season kicks off. For now — take a good look at what you're working with.
+                </p>
+              </div>
+
+              <button
+                onClick={beginSeason}
+                className="w-full py-3 rounded-card font-semibold text-sm bg-pitch-green text-white hover:bg-pitch-green/90 transition-all"
+              >
+                Begin Season →
+              </button>
+            </>
+          )}
+
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/lib/initialGame.ts
+++ b/packages/frontend/src/lib/initialGame.ts
@@ -1,10 +1,9 @@
 /**
- * Bootstrap a mid-season game state for the MVP demo.
- * Starts at Week 20 with a realistic mid-table position.
+ * Bootstrap a new game state.
+ * Starts in PRE_SEASON — the player must pick a formation before the season begins.
  */
 import {
   buildState,
-  handleCommand,
   GameEvent,
   GameState,
 } from '@calculating-glory/domain';
@@ -15,43 +14,17 @@ const SEED = 'calculating-glory-mvp-v1';
 const START_BUDGET = 50000000; // £500,000
 
 export function createInitialGameState(): { state: GameState; events: GameEvent[] } {
-  const events: GameEvent[] = [];
-
-  // 1. Start the game
-  const startEvent: GameEvent = {
-    type: 'GAME_STARTED',
-    timestamp: Date.now(),
-    clubId: CLUB_ID,
-    clubName: CLUB_NAME,
-    initialBudget: START_BUDGET,
-    difficulty: 'MEDIUM',
-    seed: SEED,
-  };
-  events.push(startEvent);
-
-  // 2. Start the season
-  const seasonCmd = handleCommand({ type: 'START_SEASON', season: 1 }, buildState(events));
-  if (seasonCmd.events) events.push(...seasonCmd.events);
-
-  // 3. Simulate weeks 1-19 to reach mid-season
-  for (let week = 1; week <= 19; week++) {
-    const state = buildState(events);
-
-    // Resolve any pending events automatically (pick first choice)
-    for (const pending of state.pendingEvents.filter(e => !e.resolved)) {
-      const resolveCmd = handleCommand(
-        { type: 'RESOLVE_CLUB_EVENT', eventId: pending.id, choiceId: pending.choices[0].id },
-        buildState(events)
-      );
-      if (resolveCmd.events) events.push(...resolveCmd.events);
-    }
-
-    const simCmd = handleCommand(
-      { type: 'SIMULATE_WEEK', week, season: 1, seed: SEED },
-      buildState(events)
-    );
-    if (simCmd.events) events.push(...simCmd.events);
-  }
+  const events: GameEvent[] = [
+    {
+      type: 'GAME_STARTED',
+      timestamp: Date.now(),
+      clubId: CLUB_ID,
+      clubName: CLUB_NAME,
+      initialBudget: START_BUDGET,
+      difficulty: 'MEDIUM',
+      seed: SEED,
+    },
+  ];
 
   return { state: buildState(events), events };
 }


### PR DESCRIPTION
## Summary
- Pre-season screen replaces the mid-season week 19 entry point — new game now starts at week 0
- Formation picker (6 options: 4-4-2, 4-3-3, 4-2-3-1, 3-5-2, 5-3-2, 4-5-1) sets the club's preferred shape and recruitment priority
- Auto-generated inherited squad of 16 weak non-league players (Pro-Evo style English football names) — the player needs to replace most of them
- Squad has 24 total slots; 16 filled, 8 open for incoming transfers
- Domain: `Formation` type, `FORMATION_CONFIG`, `SET_FORMATION` command, `formationCoverage()` util, `generateStartingSquad()` seeded generator
- Narrative context baked in: just promoted from non-leagues, don't get relegated

## Test plan
- [ ] Pre-season screen loads on new game (not week 19 drop-in)
- [ ] All 6 formations selectable; selection persists in game state
- [ ] Formation description and style tag visible per option
- [ ] Inherited squad shows 16 players with position, rating, wage
- [ ] 250 domain tests still passing, TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)