### PR TITLE
feat: Phase 5.1 + 5.2 — Pre-season, formation picker, transfer market, player attributes

### DIFF
--- a/packages/domain/src/__tests__/handlers.test.ts
+++ b/packages/domain/src/__tests__/handlers.test.ts
@@ -108,6 +108,9 @@ describe('handleCommand — MAKE_TRANSFER', () => {
     const fullSquad: Player[] = Array.from({ length: 25 }, (_, i) => ({
       id: `player-${i}`, name: `Player ${i}`, overallRating: 60, position: 'MID' as const,
       wage: 10000, transferValue: 1000000, age: 25, morale: 70,
+      attributes: { attack: 45, defence: 40, teamwork: 50, charisma: 40, publicPotential: 50 },
+      truePotential: 50,
+      contractExpiresWeek: 46,
       stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 60 }
     }));
     const state: GameState = { ...s, club: { ...s.club, squad: fullSquad } };

--- a/packages/domain/src/__tests__/match.test.ts
+++ b/packages/domain/src/__tests__/match.test.ts
@@ -134,10 +134,10 @@ describe('clubToTeam', () => {
       transferBudget: 0,
       wageBudget: 0,
       squad: [
-        { id: 'p1', name: 'Striker', overallRating: 80, position: 'FWD', wage: 0, transferValue: 0, age: 25, morale: 75, stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 0 } },
-        { id: 'p2', name: 'Midfielder', overallRating: 70, position: 'MID', wage: 0, transferValue: 0, age: 25, morale: 75, stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 0 } },
-        { id: 'p3', name: 'Defender', overallRating: 60, position: 'DEF', wage: 0, transferValue: 0, age: 25, morale: 75, stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 0 } },
-        { id: 'p4', name: 'Keeper', overallRating: 65, position: 'GK', wage: 0, transferValue: 0, age: 25, morale: 75, stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 0 } },
+        { id: 'p1', name: 'Striker', overallRating: 80, position: 'FWD', wage: 0, transferValue: 0, age: 25, morale: 75, attributes: { attack: 75, defence: 20, teamwork: 50, charisma: 50, publicPotential: 70 }, truePotential: 70, contractExpiresWeek: 46, stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 0 } },
+        { id: 'p2', name: 'Midfielder', overallRating: 70, position: 'MID', wage: 0, transferValue: 0, age: 25, morale: 75, attributes: { attack: 55, defence: 50, teamwork: 65, charisma: 50, publicPotential: 65 }, truePotential: 65, contractExpiresWeek: 46, stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 0 } },
+        { id: 'p3', name: 'Defender', overallRating: 60, position: 'DEF', wage: 0, transferValue: 0, age: 25, morale: 75, attributes: { attack: 30, defence: 62, teamwork: 55, charisma: 40, publicPotential: 55 }, truePotential: 55, contractExpiresWeek: 46, stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 0 } },
+        { id: 'p4', name: 'Keeper', overallRating: 65, position: 'GK', wage: 0, transferValue: 0, age: 25, morale: 75, attributes: { attack: 15, defence: 68, teamwork: 55, charisma: 40, publicPotential: 60 }, truePotential: 60, contractExpiresWeek: 46, stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 0 } },
       ],
       staff: [],
       facilities: [],
@@ -190,7 +190,7 @@ describe('clubToTeam', () => {
       transferBudget: 0,
       wageBudget: 0,
       squad: [
-        { id: 'p1', name: 'Player', overallRating: 50, position: 'FWD', wage: 0, transferValue: 0, age: 25, morale: 75, stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 0 } },
+        { id: 'p1', name: 'Player', overallRating: 50, position: 'FWD', wage: 0, transferValue: 0, age: 25, morale: 75, attributes: { attack: 50, defence: 20, teamwork: 45, charisma: 40, publicPotential: 45 }, truePotential: 45, contractExpiresWeek: 46, stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 0 } },
       ],
       staff: [],
       facilities: [],

--- a/packages/domain/src/__tests__/reducer-match.test.ts
+++ b/packages/domain/src/__tests__/reducer-match.test.ts
@@ -60,7 +60,8 @@ function makeState(entries: LeagueTableEntry[], playerClubId: string = 'club-1')
     phase: 'EARLY_SEASON',
     pendingEvents: [],
     resolvedEventHistory: [],
-    season: 1
+    season: 1,
+    freeAgentPool: [],
   };
 }
 

--- a/packages/domain/src/__tests__/reducers-additional.test.ts
+++ b/packages/domain/src/__tests__/reducers-additional.test.ts
@@ -34,6 +34,9 @@ function makePlayer(id: string, wage = 10000): Player {
   return {
     id, name: `Player ${id}`, overallRating: 70, position: 'MID',
     wage, transferValue: 1000000, age: 25, morale: 75,
+    attributes: { attack: 50, defence: 50, teamwork: 55, charisma: 45, publicPotential: 60 },
+    truePotential: 62,
+    contractExpiresWeek: 46,
     stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 70 }
   };
 }

--- a/packages/domain/src/__tests__/transfers.test.ts
+++ b/packages/domain/src/__tests__/transfers.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Transfer Window Tests
+ *
+ * Tests for free agent pool generation, signing, and releasing players.
+ */
+
+import { generateFreeAgentPool } from '../data/free-agent-generator';
+import { handleCommand } from '../commands/handlers';
+import { buildState } from '../reducers';
+import { reduceEvent } from '../reducers';
+import { GameState } from '../types/game-state-updated';
+import { GameStartedEvent } from '../events/types';
+import { Player } from '../types/player';
+
+// ─── Shared fixtures ──────────────────────────────────────────────────────────
+
+const gameStartedEvent: GameStartedEvent = {
+  type: 'GAME_STARTED',
+  timestamp: 1000,
+  clubId: 'player-club',
+  clubName: 'Test FC',
+  initialBudget: 500000000, // £5,000,000
+  difficulty: 'MEDIUM',
+  seed: 'transfer-test-seed',
+};
+
+function baseState(): GameState {
+  return buildState([gameStartedEvent]);
+}
+
+// ─── generateFreeAgentPool ────────────────────────────────────────────────────
+
+describe('generateFreeAgentPool', () => {
+  it('returns exactly 60 players', () => {
+    const pool = generateFreeAgentPool('test-seed');
+    expect(pool).toHaveLength(60);
+  });
+
+  it('has correct position distribution: 4 GK, 16 DEF, 22 MID, 18 FWD', () => {
+    const pool = generateFreeAgentPool('test-seed');
+    const counts = pool.reduce(
+      (acc, p) => {
+        acc[p.position] = (acc[p.position] ?? 0) + 1;
+        return acc;
+      },
+      {} as Record<string, number>
+    );
+    expect(counts['GK']).toBe(4);
+    expect(counts['DEF']).toBe(16);
+    expect(counts['MID']).toBe(22);
+    expect(counts['FWD']).toBe(18);
+  });
+
+  it('all players have transferValue of 0 (free agents)', () => {
+    const pool = generateFreeAgentPool('test-seed');
+    pool.forEach(p => expect(p.transferValue).toBe(0));
+  });
+
+  it('all players have contractExpiresWeek of 0', () => {
+    const pool = generateFreeAgentPool('test-seed');
+    pool.forEach(p => expect(p.contractExpiresWeek).toBe(0));
+  });
+
+  it('all players have attributes object with all required keys', () => {
+    const pool = generateFreeAgentPool('test-seed');
+    pool.forEach(p => {
+      expect(p.attributes).toBeDefined();
+      expect(typeof p.attributes.attack).toBe('number');
+      expect(typeof p.attributes.defence).toBe('number');
+      expect(typeof p.attributes.teamwork).toBe('number');
+      expect(typeof p.attributes.charisma).toBe('number');
+      expect(typeof p.attributes.publicPotential).toBe('number');
+    });
+  });
+
+  it('is deterministic — same seed produces same pool', () => {
+    const pool1 = generateFreeAgentPool('determinism-test');
+    const pool2 = generateFreeAgentPool('determinism-test');
+    expect(pool1.map(p => p.name)).toEqual(pool2.map(p => p.name));
+    expect(pool1.map(p => p.overallRating)).toEqual(pool2.map(p => p.overallRating));
+  });
+
+  it('different seeds produce different pools', () => {
+    const pool1 = generateFreeAgentPool('seed-a');
+    const pool2 = generateFreeAgentPool('seed-b');
+    // Very unlikely to produce identical orderings
+    const names1 = pool1.map(p => p.name).join(',');
+    const names2 = pool2.map(p => p.name).join(',');
+    expect(names1).not.toEqual(names2);
+  });
+
+  it('age range is 18–34', () => {
+    const pool = generateFreeAgentPool('age-test');
+    pool.forEach(p => {
+      expect(p.age).toBeGreaterThanOrEqual(18);
+      expect(p.age).toBeLessThanOrEqual(34);
+    });
+  });
+
+  it('wages are in the expected range (50000–300000 pence)', () => {
+    const pool = generateFreeAgentPool('wage-test');
+    pool.forEach(p => {
+      expect(p.wage).toBeGreaterThanOrEqual(50000);
+      expect(p.wage).toBeLessThanOrEqual(300000);
+    });
+  });
+
+  it('morale is in the 65–85 range', () => {
+    const pool = generateFreeAgentPool('morale-test');
+    pool.forEach(p => {
+      expect(p.morale).toBeGreaterThanOrEqual(65);
+      expect(p.morale).toBeLessThanOrEqual(85);
+    });
+  });
+});
+
+// ─── SIGN_FREE_AGENT ──────────────────────────────────────────────────────────
+
+describe('handleCommand — SIGN_FREE_AGENT', () => {
+  it('succeeds when budget and squad space available', () => {
+    const state = baseState();
+    const freeAgent = state.freeAgentPool[0];
+    expect(freeAgent).toBeDefined();
+
+    const result = handleCommand(
+      { type: 'SIGN_FREE_AGENT', playerId: freeAgent.id, offeredWage: freeAgent.wage },
+      state
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.events).toHaveLength(1);
+    expect(result.events![0].type).toBe('FREE_AGENT_SIGNED');
+  });
+
+  it('applies FREE_AGENT_SIGNED event correctly — moves player to squad and off pool', () => {
+    const state = baseState();
+    const freeAgent = state.freeAgentPool[0];
+
+    const result = handleCommand(
+      { type: 'SIGN_FREE_AGENT', playerId: freeAgent.id, offeredWage: freeAgent.wage },
+      state
+    );
+
+    const newState = reduceEvent(state, result.events![0]);
+    const signedPlayer = newState.club.squad.find(p => p.id === freeAgent.id);
+
+    expect(signedPlayer).toBeDefined();
+    expect(newState.freeAgentPool.find(p => p.id === freeAgent.id)).toBeUndefined();
+    expect(signedPlayer!.wage).toBe(freeAgent.wage);
+    expect(signedPlayer!.contractExpiresWeek).toBeGreaterThan(0);
+  });
+
+  it('fails when squad is full (24 players)', () => {
+    const state = baseState();
+
+    // Build 24 fake squad players from the free agent pool to fill the squad
+    const fakeSquad: Player[] = [];
+    for (let i = 0; i < 24; i++) {
+      fakeSquad.push({
+        id: `fake-${i}`,
+        name: `Player ${i}`,
+        overallRating: 50,
+        position: 'MID',
+        wage: 10000,
+        transferValue: 0,
+        age: 25,
+        morale: 70,
+        attributes: { attack: 40, defence: 40, teamwork: 40, charisma: 40, publicPotential: 40 },
+        truePotential: 40,
+        contractExpiresWeek: 46,
+        stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 50 },
+      });
+    }
+
+    const fullState: GameState = {
+      ...state,
+      club: { ...state.club, squad: fakeSquad },
+    };
+
+    const freeAgent = state.freeAgentPool[0];
+    const result = handleCommand(
+      { type: 'SIGN_FREE_AGENT', playerId: freeAgent.id, offeredWage: freeAgent.wage },
+      fullState
+    );
+
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe('SQUAD_LIMIT_EXCEEDED');
+  });
+
+  it('fails when weekly wage exceeds remaining wage budget', () => {
+    const state = baseState();
+    const freeAgent = state.freeAgentPool[0];
+
+    // Set wage budget to 0
+    const skintState: GameState = {
+      ...state,
+      club: { ...state.club, wageBudget: 0 },
+    };
+
+    const result = handleCommand(
+      { type: 'SIGN_FREE_AGENT', playerId: freeAgent.id, offeredWage: freeAgent.wage },
+      skintState
+    );
+
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe('INSUFFICIENT_BUDGET');
+  });
+
+  it('fails when player is not in the free agent pool', () => {
+    const state = baseState();
+    const result = handleCommand(
+      { type: 'SIGN_FREE_AGENT', playerId: 'nonexistent-player-id', offeredWage: 50000 },
+      state
+    );
+
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe('PLAYER_NOT_FOUND');
+  });
+});
+
+// ─── RELEASE_PLAYER ───────────────────────────────────────────────────────────
+
+describe('handleCommand — RELEASE_PLAYER', () => {
+  it('removes player from squad and returns release fee to budget', () => {
+    const state = baseState();
+    const player = state.club.squad[0];
+    expect(player).toBeDefined();
+
+    const result = handleCommand(
+      { type: 'RELEASE_PLAYER', playerId: player.id },
+      state
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.events).toHaveLength(1);
+    expect(result.events![0].type).toBe('PLAYER_RELEASED');
+
+    const newState = reduceEvent(state, result.events![0]);
+    expect(newState.club.squad.find(p => p.id === player.id)).toBeUndefined();
+  });
+
+  it('release fee is non-zero when player is under contract', () => {
+    const state = baseState();
+    // Find a player with a non-zero contractExpiresWeek beyond current week
+    const player = state.club.squad.find(
+      p => p.contractExpiresWeek > 0 && p.contractExpiresWeek > state.currentWeek
+    );
+    expect(player).toBeDefined();
+
+    const result = handleCommand(
+      { type: 'RELEASE_PLAYER', playerId: player!.id },
+      state
+    );
+
+    expect(result.error).toBeUndefined();
+    const event = result.events![0] as any;
+    expect(event.releaseFee).toBeGreaterThan(0);
+
+    const newState = reduceEvent(state, result.events![0]);
+    expect(newState.club.transferBudget).toBe(state.club.transferBudget + event.releaseFee);
+  });
+
+  it('release fee is zero when player contract has expired (contractExpiresWeek has passed)', () => {
+    const state = baseState();
+    const player = state.club.squad[0];
+
+    // Advance week beyond the player's contract expiry
+    const expiredContractState: GameState = {
+      ...state,
+      currentWeek: 100, // way past any contract expiry
+    };
+
+    const result = handleCommand(
+      { type: 'RELEASE_PLAYER', playerId: player.id },
+      expiredContractState
+    );
+
+    expect(result.error).toBeUndefined();
+    const event = result.events![0] as any;
+    expect(event.releaseFee).toBe(0);
+  });
+
+  it('fails when player is not in the squad', () => {
+    const state = baseState();
+    const result = handleCommand(
+      { type: 'RELEASE_PLAYER', playerId: 'not-in-squad-id' },
+      state
+    );
+
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe('PLAYER_NOT_FOUND');
+  });
+});

--- a/packages/domain/src/__tests__/type-utils.test.ts
+++ b/packages/domain/src/__tests__/type-utils.test.ts
@@ -20,6 +20,9 @@ function makePlayer(overrides: Partial<Player> = {}): Player {
   return {
     id: 'p1', name: 'Test', overallRating: 70, position: 'FWD',
     wage: 50000, transferValue: 5000000, age: 25, morale: 75,
+    attributes: { attack: 60, defence: 20, teamwork: 50, charisma: 45, publicPotential: 60 },
+    truePotential: 62,
+    contractExpiresWeek: 46,
     stats: { goals: 10, assists: 5, cleanSheets: 0, appearances: 20, averageRating: 70 },
     ...overrides
   };

--- a/packages/domain/src/__tests__/validation.test.ts
+++ b/packages/domain/src/__tests__/validation.test.ts
@@ -25,6 +25,9 @@ function makePlayer(overrides: Partial<Player> = {}): Player {
     transferValue: 5000000, // £50,000
     age: 25,
     morale: 75,
+    attributes: { attack: 50, defence: 50, teamwork: 55, charisma: 45, publicPotential: 60 },
+    truePotential: 62,
+    contractExpiresWeek: 46,
     stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 70 },
     ...overrides
   };

--- a/packages/domain/src/commands/handlers.ts
+++ b/packages/domain/src/commands/handlers.ts
@@ -36,6 +36,10 @@ export function handleCommand(command: GameCommand, state: GameState): CommandRe
       return handleSetTrainingFocus(command, state);
     case 'SET_FORMATION':
       return handleSetFormation(command, state);
+    case 'SIGN_FREE_AGENT':
+      return handleSignFreeAgent(command, state);
+    case 'RELEASE_PLAYER':
+      return handleReleasePlayer(command, state);
     default:
       return {
         error: {
@@ -58,6 +62,9 @@ function handleMakeTransfer(command: any, state: GameState): CommandResult {
     transferValue: command.offeredFee,
     age: 25,
     morale: 75,
+    attributes: { attack: 55, defence: 55, teamwork: 60, charisma: 50, publicPotential: 65 },
+    truePotential: 68,
+    contractExpiresWeek: state.currentWeek + 46,
     stats: {
       goals: 0,
       assists: 0,
@@ -419,6 +426,93 @@ function handleSetFormation(command: any, state: GameState): CommandResult {
       previousFormation: state.club.preferredFormation,
     },
   ];
+  return { events };
+}
+
+function handleSignFreeAgent(command: any, state: GameState): CommandResult {
+  // Find player in free agent pool
+  const player = state.freeAgentPool.find(p => p.id === command.playerId);
+  if (!player) {
+    return {
+      error: {
+        code: 'PLAYER_NOT_FOUND',
+        message: `Player '${command.playerId}' not found in free agent pool`
+      }
+    };
+  }
+
+  // Check squad has room
+  if (state.club.squad.length >= state.club.squadCapacity) {
+    return {
+      error: {
+        code: 'SQUAD_LIMIT_EXCEEDED',
+        message: `Squad is at capacity (${state.club.squadCapacity} players)`
+      }
+    };
+  }
+
+  // Check wage budget
+  const currentTotalWages = state.club.squad.reduce((sum, p) => sum + p.wage, 0);
+  if (command.offeredWage > state.club.wageBudget - currentTotalWages) {
+    return {
+      error: {
+        code: 'INSUFFICIENT_BUDGET',
+        message: `Offered wage exceeds remaining wage budget`
+      }
+    };
+  }
+
+  const contractExpiresWeek = state.currentWeek + 46;
+
+  const updatedPlayer = {
+    ...player,
+    wage: command.offeredWage,
+    contractExpiresWeek,
+  };
+
+  const events: GameEvent[] = [
+    {
+      type: 'FREE_AGENT_SIGNED',
+      timestamp: Date.now(),
+      playerId: command.playerId,
+      clubId: state.club.id,
+      offeredWage: command.offeredWage,
+      contractExpiresWeek,
+      player: updatedPlayer,
+    }
+  ];
+
+  return { events };
+}
+
+function handleReleasePlayer(command: any, state: GameState): CommandResult {
+  // Find player in squad
+  const player = state.club.squad.find(p => p.id === command.playerId);
+  if (!player) {
+    return {
+      error: {
+        code: 'PLAYER_NOT_FOUND',
+        message: `Player '${command.playerId}' not found in squad`
+      }
+    };
+  }
+
+  // Compute release fee
+  let releaseFee = 0;
+  if (player.contractExpiresWeek > 0 && state.currentWeek < player.contractExpiresWeek) {
+    releaseFee = Math.round((player.contractExpiresWeek - state.currentWeek) * player.wage * 0.5);
+  }
+
+  const events: GameEvent[] = [
+    {
+      type: 'PLAYER_RELEASED',
+      timestamp: Date.now(),
+      playerId: command.playerId,
+      clubId: state.club.id,
+      releaseFee,
+    }
+  ];
+
   return { events };
 }
 

--- a/packages/domain/src/commands/types.ts
+++ b/packages/domain/src/commands/types.ts
@@ -19,7 +19,9 @@ export type GameCommand =
   | ResolveClubEventCommand
   | StartSeasonCommand
   | SetTrainingFocusCommand
-  | SetFormationCommand;
+  | SetFormationCommand
+  | SignFreeAgentCommand
+  | ReleasePlayerCommand;
 
 export interface MakeTransferCommand {
   type: 'MAKE_TRANSFER';
@@ -78,6 +80,17 @@ export interface SetTrainingFocusCommand {
 export interface SetFormationCommand {
   type: 'SET_FORMATION';
   formation: Formation;
+}
+
+export interface SignFreeAgentCommand {
+  type: 'SIGN_FREE_AGENT';
+  playerId: string;
+  offeredWage: number;       // pence/week
+}
+
+export interface ReleasePlayerCommand {
+  type: 'RELEASE_PLAYER';
+  playerId: string;
 }
 
 export interface CommandResult {

--- a/packages/domain/src/data/free-agent-generator.ts
+++ b/packages/domain/src/data/free-agent-generator.ts
@@ -1,0 +1,211 @@
+/**
+ * Free Agent Pool Generator
+ *
+ * Generates a pool of 60 available free agents from a seed.
+ * Deterministic — same seed always produces the same pool.
+ *
+ * Narrative context: these are journeymen and near-misses rattling around
+ * the lower leagues. A few recognisable faces (sort of) among the journeymen.
+ */
+
+import { Player, Position, PlayerAttributes } from '../types/player';
+import { createRng, Rng } from '../simulation/rng';
+
+// ─── Famous-ish parody names (8) ──────────────────────────────────────────────
+
+const PARODY_NAMES: string[] = [
+  'Lional Messy',
+  'Crystiano Ronoldo',
+  'Neymur Jr',
+  'Killian Mboppe',
+  'Errling Haland',
+  'Kevin De Bruyne',
+  'Virgil van Dijck',
+  'Mohammid Salah',
+];
+
+// ─── Plausible lower-league journeymen (52) ────────────────────────────────────
+
+const JOURNEYMEN_NAMES: string[] = [
+  'Dale Hutchins',
+  'Connor Farrell',
+  'Matty Swann',
+  'Luke Brennan',
+  'Rhys Owens',
+  'Kyle Digby',
+  'Jordan Pryce',
+  'Nathan Holloway',
+  'Callum Dack',
+  'Aaron Whitfield',
+  'Sam Buckley',
+  'Ben Treacy',
+  'Ross Corbin',
+  'Jake Nolan',
+  'Stuart Fenwick',
+  'Marcus Osei',
+  'Femi Adeyemi',
+  'Tunde Ajayi',
+  'Emil Novak',
+  'Jakub Sedlak',
+  'Radek Blaha',
+  'Tibor Varga',
+  'Aleksandr Volkov',
+  'Dmitri Korolev',
+  'Artur Lewicki',
+  'Pablo Fuentes',
+  'Diego Alcazar',
+  'Raul Herranz',
+  'Marco Ferrini',
+  'Luca Battisti',
+  'Fabio Mangano',
+  'Yannick Gruber',
+  'Stefan Baumann',
+  'Pieter van Dael',
+  'Jan Vermeer',
+  'Christophe Moulin',
+  'Gaël Renard',
+  'Remi Chauvet',
+  'Sven Lindqvist',
+  'Bjorn Tangen',
+  'Mikkel Roed',
+  'Carlos Viegas',
+  'Bruno Tavares',
+  'Nuno Figueiredo',
+  'Ahmed Okonkwo',
+  'Kwame Asante',
+  'Moussa Diallo',
+  'Ibrahim Traore',
+  'Rizwan Hussain',
+  'Deepak Pillai',
+  'Yuki Tanaka',
+  'Seun Adebayo',
+];
+
+/** Distribution for 60 players: 4 GK, 16 DEF, 22 MID, 18 FWD */
+const POSITION_DISTRIBUTION: Position[] = [
+  'GK', 'GK', 'GK', 'GK',
+  'DEF', 'DEF', 'DEF', 'DEF', 'DEF', 'DEF', 'DEF', 'DEF',
+  'DEF', 'DEF', 'DEF', 'DEF', 'DEF', 'DEF', 'DEF', 'DEF',
+  'MID', 'MID', 'MID', 'MID', 'MID', 'MID', 'MID', 'MID',
+  'MID', 'MID', 'MID', 'MID', 'MID', 'MID', 'MID', 'MID',
+  'MID', 'MID', 'MID', 'MID', 'MID', 'MID',
+  'FWD', 'FWD', 'FWD', 'FWD', 'FWD', 'FWD', 'FWD', 'FWD',
+  'FWD', 'FWD', 'FWD', 'FWD', 'FWD', 'FWD', 'FWD', 'FWD',
+  'FWD', 'FWD',
+];
+
+/**
+ * Generate attributes for a player based on position using seeded RNG.
+ */
+function generateAttributes(position: Position, rng: Rng): PlayerAttributes {
+  switch (position) {
+    case 'GK':
+      return {
+        attack:    rng.nextInt(10, 25),
+        defence:   rng.nextInt(58, 78),
+        teamwork:  rng.nextInt(40, 72),
+        charisma:  rng.nextInt(25, 55),
+        publicPotential: 0, // set after
+      };
+    case 'DEF':
+      return {
+        attack:    rng.nextInt(22, 42),
+        defence:   rng.nextInt(52, 72),
+        teamwork:  rng.nextInt(42, 72),
+        charisma:  rng.nextInt(28, 58),
+        publicPotential: 0,
+      };
+    case 'MID':
+      return {
+        attack:    rng.nextInt(38, 62),
+        defence:   rng.nextInt(38, 58),
+        teamwork:  rng.nextInt(48, 78),
+        charisma:  rng.nextInt(35, 68),
+        publicPotential: 0,
+      };
+    case 'FWD':
+      return {
+        attack:    rng.nextInt(52, 75),
+        defence:   rng.nextInt(15, 35),
+        teamwork:  rng.nextInt(35, 65),
+        charisma:  rng.nextInt(42, 72),
+        publicPotential: 0,
+      };
+  }
+}
+
+/**
+ * Generate the free agent pool (60 players) from a seed.
+ * Deterministic — same seed always produces the same pool.
+ */
+export function generateFreeAgentPool(seed: string): Player[] {
+  const rng = createRng(`${seed}-free-agents`);
+
+  // Build full name list: parody names first, then journeymen
+  // Shuffle both lists separately using rng for variety
+  const allNames = [...PARODY_NAMES, ...JOURNEYMEN_NAMES];
+
+  // Shuffle the name list deterministically
+  const shuffledNames = [...allNames];
+  for (let i = shuffledNames.length - 1; i > 0; i--) {
+    const j = Math.floor(rng.next() * (i + 1));
+    [shuffledNames[i], shuffledNames[j]] = [shuffledNames[j], shuffledNames[i]];
+  }
+
+  // Shuffle position distribution
+  const positions = [...POSITION_DISTRIBUTION];
+  for (let i = positions.length - 1; i > 0; i--) {
+    const j = Math.floor(rng.next() * (i + 1));
+    [positions[i], positions[j]] = [positions[j], positions[i]];
+  }
+
+  return positions.map((position, index) => {
+    const name = shuffledNames[index] ?? `Free Agent ${index + 1}`;
+
+    // Age: 18–34
+    const age = rng.nextInt(18, 34);
+
+    // Wages: £500–£3,000/week in pence
+    const wage = rng.nextInt(50000, 300000);
+
+    // Attributes based on position
+    const attributes = generateAttributes(position, rng);
+
+    // publicPotential: 38–82, cap at 55 for older players (age > 28)
+    const rawPotential = rng.nextInt(38, 82);
+    const publicPotential = age > 28 ? Math.min(rawPotential, 55) : rawPotential;
+    attributes.publicPotential = publicPotential;
+
+    // truePotential: publicPotential ± rng offset 0–25 (clamped 1–100)
+    const potentialOffset = rng.nextInt(0, 25);
+    const potentialDirection = rng.next() < 0.5 ? 1 : -1;
+    const truePotential = Math.max(1, Math.min(100, publicPotential + potentialDirection * potentialOffset));
+
+    // overallRating: derived from attributes
+    const overallRating = Math.round((attributes.attack + attributes.defence + attributes.teamwork) / 3);
+
+    // Morale: 65–85 (they're keen to get a club)
+    const morale = rng.nextInt(65, 85);
+
+    return {
+      id: `free-agent-${index}-${seed}`,
+      name,
+      overallRating,
+      position,
+      wage,
+      transferValue: 0,
+      age,
+      morale,
+      attributes,
+      truePotential,
+      contractExpiresWeek: 0,
+      stats: {
+        goals: 0,
+        assists: 0,
+        cleanSheets: 0,
+        appearances: 0,
+        averageRating: overallRating,
+      },
+    };
+  });
+}

--- a/packages/domain/src/data/squad-generator.ts
+++ b/packages/domain/src/data/squad-generator.ts
@@ -8,8 +8,8 @@
  * This is the inherited rabble. Most of them need replacing sharpish.
  */
 
-import { Player, Position } from '../types/player';
-import { createRng } from '../simulation/rng';
+import { Player, Position, PlayerAttributes } from '../types/player';
+import { createRng, Rng } from '../simulation/rng';
 
 // Name banks — plausible lower-league English football player names
 const FORENAMES = [
@@ -29,6 +29,46 @@ const SURNAMES = [
   'Ogden', 'Patel', 'Quinn', 'Reeve', 'Sykes', 'Trent', 'Upton',
   'Vance', 'Wren', 'York', 'Ashby', 'Bale', 'Crane', 'Drake',
 ];
+
+/**
+ * Generate attributes for weak non-league players based on position.
+ */
+function generateWeakAttributes(position: Position, rng: Rng): PlayerAttributes {
+  switch (position) {
+    case 'GK':
+      return {
+        attack:          rng.nextInt(8, 18),
+        defence:         rng.nextInt(30, 52),
+        teamwork:        rng.nextInt(35, 60),
+        charisma:        rng.nextInt(20, 45),
+        publicPotential: 0, // set after
+      };
+    case 'DEF':
+      return {
+        attack:          rng.nextInt(15, 30),
+        defence:         rng.nextInt(28, 50),
+        teamwork:        rng.nextInt(32, 58),
+        charisma:        rng.nextInt(20, 45),
+        publicPotential: 0,
+      };
+    case 'MID':
+      return {
+        attack:          rng.nextInt(25, 45),
+        defence:         rng.nextInt(25, 42),
+        teamwork:        rng.nextInt(35, 60),
+        charisma:        rng.nextInt(22, 48),
+        publicPotential: 0,
+      };
+    case 'FWD':
+      return {
+        attack:          rng.nextInt(32, 52),
+        defence:         rng.nextInt(10, 28),
+        teamwork:        rng.nextInt(28, 52),
+        charisma:        rng.nextInt(25, 50),
+        publicPotential: 0,
+      };
+  }
+}
 
 /** Distribution: 2 GK, 5 DEF, 5 MID, 4 FWD — enough to cover any formation with bench */
 const POSITION_DISTRIBUTION: Position[] = [
@@ -63,9 +103,6 @@ export function generateStartingSquad(seed: string, clubId: string): Player[] {
   return POSITION_DISTRIBUTION.map((position, index) => {
     const name = pickName();
 
-    // Rating: 35–52 — genuinely weak. A rating above 50 is a keeper here.
-    const overallRating = 35 + Math.floor(rng.next() * 18);
-
     // Age: spread 18–34. Some too old (past it), some too young (raw).
     const age = 18 + Math.floor(rng.next() * 17);
 
@@ -78,6 +115,24 @@ export function generateStartingSquad(seed: string, clubId: string): Player[] {
     // Morale: moderate — they don't know what's coming
     const morale = 45 + Math.floor(rng.next() * 25);
 
+    // Attributes for weak non-league players
+    const attributes = generateWeakAttributes(position, rng);
+
+    // publicPotential: 25–55 (they're mostly not going anywhere)
+    const publicPotential = rng.nextInt(25, 55);
+    attributes.publicPotential = publicPotential;
+
+    // truePotential: publicPotential ± rng offset 0–18 (clamped 1–100)
+    const potentialOffset = rng.nextInt(0, 18);
+    const potentialDirection = rng.next() < 0.5 ? 1 : -1;
+    const truePotential = Math.max(1, Math.min(100, publicPotential + potentialDirection * potentialOffset));
+
+    // contractExpiresWeek: mix of 23 and 46 (half expire mid-season to create urgency)
+    const contractExpiresWeek = rng.next() < 0.5 ? 23 : 46;
+
+    // overallRating derived from attributes
+    const overallRating = Math.round((attributes.attack + attributes.defence + attributes.teamwork) / 3);
+
     return {
       id: `inherited-${clubId}-${index}`,
       name,
@@ -87,6 +142,9 @@ export function generateStartingSquad(seed: string, clubId: string): Player[] {
       transferValue,
       age,
       morale,
+      attributes,
+      truePotential,
+      contractExpiresWeek,
       stats: {
         goals: 0,
         assists: 0,

--- a/packages/domain/src/events/types.ts
+++ b/packages/domain/src/events/types.ts
@@ -27,7 +27,9 @@ export type GameEvent =
   | ClubEventResolvedEvent
   | SeasonStartedEvent
   | TrainingFocusSetEvent
-  | FormationSetEvent;
+  | FormationSetEvent
+  | FreeAgentSignedEvent
+  | PlayerReleasedEvent;
 
 export interface TransferCompletedEvent {
   type: 'TRANSFER_COMPLETED';
@@ -168,4 +170,22 @@ export interface FormationSetEvent {
   clubId: string;
   formation: Formation;
   previousFormation: Formation | null;
+}
+
+export interface FreeAgentSignedEvent {
+  type: 'FREE_AGENT_SIGNED';
+  timestamp: number;
+  playerId: string;
+  clubId: string;
+  offeredWage: number;       // pence/week
+  contractExpiresWeek: number;
+  player: Player;            // Full player object with updated wage + contractExpiresWeek
+}
+
+export interface PlayerReleasedEvent {
+  type: 'PLAYER_RELEASED';
+  timestamp: number;
+  playerId: string;
+  clubId: string;
+  releaseFee: number;        // pence, 0 if out of contract
 }

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -35,6 +35,7 @@ export * from './money/utils';
 export * from './data/league-two-teams';
 export * from './data/club-events';
 export * from './data/squad-generator';
+export * from './data/free-agent-generator';
 
 // Core state types
 export * from './types/game-state-updated';

--- a/packages/domain/src/reducers/index.ts
+++ b/packages/domain/src/reducers/index.ts
@@ -4,7 +4,7 @@
  * Pure functions that apply events to state.
  */
 
-import { GameEvent, GameStartedEvent, MatchSimulatedEvent, TransferCompletedEvent, StaffHiredEvent, MathAttemptRecordedEvent, ClubEventOccurredEvent, ClubEventResolvedEvent, SeasonStartedEvent, TrainingFocusSetEvent, FormationSetEvent } from '../events/types';
+import { GameEvent, GameStartedEvent, MatchSimulatedEvent, TransferCompletedEvent, StaffHiredEvent, MathAttemptRecordedEvent, ClubEventOccurredEvent, ClubEventResolvedEvent, SeasonStartedEvent, TrainingFocusSetEvent, FormationSetEvent, FreeAgentSignedEvent, PlayerReleasedEvent } from '../events/types';
 import { GameState } from '../types/game-state-updated';
 import { Club } from '../types/club';
 import { LeagueTable, LeagueTableEntry, sortLeagueTable } from '../types/league';
@@ -12,6 +12,7 @@ import { CURRICULUM_LEVELS } from '../curriculum/curriculum-config';
 import { LEAGUE_TWO_TEAMS } from '../data/league-two-teams';
 import { getDefaultFacilities, getUpgradeCost } from '../types/facility';
 import { generateStartingSquad } from '../data/squad-generator';
+import { generateFreeAgentPool } from '../data/free-agent-generator';
 
 /**
  * Reduce an event into state
@@ -50,6 +51,10 @@ export function reduceEvent(state: GameState, event: GameEvent): GameState {
       return handleTrainingFocusSet(state, event);
     case 'FORMATION_SET':
       return handleFormationSet(state, event);
+    case 'FREE_AGENT_SIGNED':
+      return handleFreeAgentSigned(state, event);
+    case 'PLAYER_RELEASED':
+      return handlePlayerReleased(state, event);
     default:
       return state;
   }
@@ -85,7 +90,8 @@ export function buildState(events: GameEvent[]): GameState {
     phase: 'PRE_SEASON',
     pendingEvents: [],
     resolvedEventHistory: [],
-    season: 1
+    season: 1,
+    freeAgentPool: [],
   };
 
   return events.reduce(reduceEvent, initialState);
@@ -138,6 +144,9 @@ function handleGameStarted(state: GameState, event: GameStartedEvent): GameState
   // Generate the inherited starting squad of 16 weak non-league players
   const inheritedSquad = generateStartingSquad(event.seed, event.clubId);
 
+  // Generate the free agent pool for the season
+  const freeAgentPool = generateFreeAgentPool(event.seed);
+
   return {
     ...state,
     phase: 'PRE_SEASON',
@@ -154,7 +163,8 @@ function handleGameStarted(state: GameState, event: GameStartedEvent): GameState
     league: {
       ...state.league,
       entries: sortedEntries
-    }
+    },
+    freeAgentPool,
   };
 }
 
@@ -457,6 +467,28 @@ function handleFormationSet(state: GameState, event: FormationSetEvent): GameSta
     club: {
       ...state.club,
       preferredFormation: event.formation,
+    },
+  };
+}
+
+function handleFreeAgentSigned(state: GameState, event: FreeAgentSignedEvent): GameState {
+  return {
+    ...state,
+    freeAgentPool: state.freeAgentPool.filter(p => p.id !== event.playerId),
+    club: {
+      ...state.club,
+      squad: [...state.club.squad, event.player],
+    },
+  };
+}
+
+function handlePlayerReleased(state: GameState, event: PlayerReleasedEvent): GameState {
+  return {
+    ...state,
+    club: {
+      ...state.club,
+      squad: state.club.squad.filter(p => p.id !== event.playerId),
+      transferBudget: state.club.transferBudget + event.releaseFee,
     },
   };
 }

--- a/packages/domain/src/types/game-state-updated.ts
+++ b/packages/domain/src/types/game-state-updated.ts
@@ -9,6 +9,7 @@ import { GameEvent } from '../events/types';
 import { Club } from './club';
 import { LeagueTable } from './league';
 import { CurriculumConfig } from '../curriculum/curriculum-config';
+import { Player } from './player';
 
 /**
  * A choice available within a club event
@@ -80,6 +81,9 @@ export interface GameState {
 
   /** Current season number */
   season: number;
+
+  /** Pool of available free agents */
+  freeAgentPool: Player[];
 }
 
 /**

--- a/packages/domain/src/types/player.ts
+++ b/packages/domain/src/types/player.ts
@@ -8,32 +8,64 @@
 export type Position = 'GK' | 'DEF' | 'MID' | 'FWD';
 
 /**
+ * Individual skill attributes for a player
+ */
+export interface PlayerAttributes {
+  /** Attacking ability (1–100). Weighted most heavily for FWD in match simulation. */
+  attack: number;
+  /** Defensive ability (1–100). Weighted most heavily for GK/DEF in match simulation. */
+  defence: number;
+  /** Teamwork (1–100). Sum of XI's teamwork modifies overall performance. */
+  teamwork: number;
+  /** Charisma (1–100). Sum drives club popularity → merch/attendance revenue. */
+  charisma: number;
+  /** Visible potential proxy (1–100). 55%-accurate representation of true development. */
+  publicPotential: number;
+}
+
+/**
  * Player representation (simplified for Year 7 level)
  */
 export interface Player {
   id: string;
   name: string;
-  
+
   /** Overall rating (0-100) */
   overallRating: number;
-  
+
   /** Primary position */
   position: Position;
-  
+
   /** Weekly wage in pence */
   wage: number;
-  
+
   /** Transfer value in pence */
   transferValue: number;
-  
+
   /** Age */
   age: number;
-  
+
   /** Morale (0-100) */
   morale: number;
-  
+
   /** Performance stats */
   stats: PlayerStats;
+
+  /** Individual skill attributes */
+  attributes: PlayerAttributes;
+
+  /**
+   * True development potential (1–100). Hidden — scouting reveals the gap.
+   * publicPotential is a 55%-accurate proxy for this value.
+   */
+  truePotential: number;
+
+  /**
+   * Game week when this player's contract with your club expires.
+   * 0 = free agent (not yet signed to your club).
+   * Releasing before expiry incurs a compensation fee.
+   */
+  contractExpiresWeek: number;
 }
 
 /**

--- a/packages/frontend/src/components/command-centre/CommandCentre.tsx
+++ b/packages/frontend/src/components/command-centre/CommandCentre.tsx
@@ -11,6 +11,7 @@ import { SlideOver } from '../shared/SlideOver';
 import { SocialFeed } from '../social-feed/SocialFeed';
 import { BackroomTeamSlideOver } from './BackroomTeamSlideOver';
 import { LearningProgressSlideOver } from './LearningProgressSlideOver';
+import { TransferMarketSlideOver } from '../transfer-market/TransferMarketSlideOver';
 
 interface CommandCentreProps {
   state: GameState;
@@ -27,6 +28,7 @@ export function CommandCentre({ state, events, dispatch, isLoading, onNavigateTo
   const [inboxOpen, setInboxOpen]             = useState(false);
   const [backroomOpen, setBackroomOpen]       = useState(false);
   const [learningOpen, setLearningOpen]       = useState(false);
+  const [transfersOpen, setTransfersOpen]     = useState(false);
   const [dismissed, setDismissed]             = useState<Set<number>>(new Set());
 
   function handleDismiss(idx: number) {
@@ -103,8 +105,8 @@ export function CommandCentre({ state, events, dispatch, isLoading, onNavigateTo
           {/* RIGHT row 1: DataTiles */}
           <DataTiles state={state} gridMode onBackroomClick={() => setBackroomOpen(true)} onAcumenClick={() => setLearningOpen(true)} />
 
-          {/* RIGHT row 2: Stadium & Facilities + Chats side-by-side */}
-          <div className="grid grid-cols-2 gap-2">
+          {/* RIGHT row 2: Stadium & Facilities + Chats + Transfers */}
+          <div className="grid grid-cols-3 gap-2">
             <HubTile
               icon="🏟"
               label="Stadium & Facilities"
@@ -122,6 +124,13 @@ export function CommandCentre({ state, events, dispatch, isLoading, onNavigateTo
               }
               hasEvent={unresolvedEvents.some(e => e.choices.some(c => c.requiresMath))}
               onClick={() => { setSocialLinked(null); setSocialOpen(true); }}
+            />
+            <HubTile
+              icon="🔄"
+              label="Transfers"
+              sub={`${state.freeAgentPool?.length ?? 0} agents available`}
+              hasEvent={false}
+              onClick={() => setTransfersOpen(true)}
             />
           </div>
         </div>
@@ -206,6 +215,17 @@ export function CommandCentre({ state, events, dispatch, isLoading, onNavigateTo
       >
         {learningOpen && (
           <LearningProgressSlideOver state={state} events={events} />
+        )}
+      </SlideOver>
+
+      {/* ── Transfers slide-over ──────────────────────────────────────────── */}
+      <SlideOver
+        isOpen={transfersOpen}
+        onClose={() => setTransfersOpen(false)}
+        title="Transfers"
+      >
+        {transfersOpen && (
+          <TransferMarketSlideOver state={state} dispatch={dispatch} onError={setError} />
         )}
       </SlideOver>
 

--- a/packages/frontend/src/components/transfer-market/TransferMarketSlideOver.tsx
+++ b/packages/frontend/src/components/transfer-market/TransferMarketSlideOver.tsx
@@ -1,0 +1,392 @@
+import { useState } from 'react';
+import {
+  GameState,
+  GameCommand,
+  Player,
+  Position,
+  formatMoney,
+} from '@calculating-glory/domain';
+
+// ─── Types ─────────────────────────────────────────────────────────────────────
+
+interface TransferMarketSlideOverProps {
+  state: GameState;
+  dispatch: (cmd: GameCommand) => { error?: string };
+  onError: (msg: string) => void;
+}
+
+type Tab = 'free-agents' | 'my-squad';
+type SortKey = 'rating' | 'attack' | 'defence' | 'wage';
+
+// ─── Position badge colours ────────────────────────────────────────────────────
+
+const POSITION_COLOUR: Record<Position, string> = {
+  GK:  'bg-warn-amber/20 text-warn-amber border border-warn-amber/40',
+  DEF: 'bg-data-blue/20 text-data-blue border border-data-blue/40',
+  MID: 'bg-pitch-green/20 text-pitch-green border border-pitch-green/40',
+  FWD: 'bg-alert-red/20 text-alert-red border border-alert-red/40',
+};
+
+// ─── Attribute bar ─────────────────────────────────────────────────────────────
+
+interface AttrBarProps {
+  label: string;
+  value: number;
+  colour: string;
+}
+
+function AttrBar({ label, value, colour }: AttrBarProps) {
+  return (
+    <div className="flex items-center gap-1">
+      <span className="text-[10px] text-txt-muted w-7 shrink-0">{label}</span>
+      <div className="h-1.5 bg-white/5 rounded-full overflow-hidden" style={{ width: 80 }}>
+        <div
+          className={`h-full rounded-full ${colour}`}
+          style={{ width: `${value}%` }}
+        />
+      </div>
+      <span className="text-[10px] text-txt-muted w-5 text-right">{value}</span>
+    </div>
+  );
+}
+
+// ─── Free Agent Card ───────────────────────────────────────────────────────────
+
+interface FreeAgentCardProps {
+  player: Player;
+  canAfford: boolean;
+  hasSquadRoom: boolean;
+  onSign: (wage: number) => void;
+}
+
+function FreeAgentCard({ player, canAfford, hasSquadRoom, onSign }: FreeAgentCardProps) {
+  const [confirming, setConfirming] = useState(false);
+  const [signed, setSigned] = useState(false);
+
+  function handleConfirm() {
+    onSign(player.wage);
+    setSigned(true);
+    setConfirming(false);
+  }
+
+  const canSign = canAfford && hasSquadRoom && !signed;
+
+  return (
+    <div className="bg-bg-raised rounded-card border border-white/5 p-3 flex flex-col gap-2">
+      {/* Header row */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-semibold text-txt-primary text-sm truncate">{player.name}</span>
+            <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${POSITION_COLOUR[player.position]}`}>
+              {player.position}
+            </span>
+          </div>
+          <span className="text-xs text-txt-muted">Age {player.age} · {formatMoney(player.wage)}/wk</span>
+        </div>
+        <div className="text-right shrink-0">
+          <span className="text-data-blue font-bold text-sm">{player.overallRating}</span>
+          <div className="text-[10px] text-txt-muted">OVR</div>
+        </div>
+      </div>
+
+      {/* Attribute bars */}
+      <div className="flex flex-col gap-0.5">
+        <AttrBar label="ATK" value={player.attributes.attack}   colour="bg-alert-red" />
+        <AttrBar label="DEF" value={player.attributes.defence}  colour="bg-data-blue" />
+        <AttrBar label="TMW" value={player.attributes.teamwork} colour="bg-pitch-green" />
+        <AttrBar label="CHA" value={player.attributes.charisma} colour="bg-warn-amber" />
+        <AttrBar label="POT" value={player.attributes.publicPotential} colour="bg-purple-400" />
+      </div>
+
+      {/* Action row */}
+      {signed ? (
+        <div className="text-xs text-pitch-green font-semibold">Signed!</div>
+      ) : confirming ? (
+        <div className="flex items-center gap-2 flex-wrap text-xs">
+          <span className="text-txt-muted">
+            Sign {player.name} at {formatMoney(player.wage)}/wk?
+          </span>
+          <button
+            onClick={handleConfirm}
+            className="px-2 py-0.5 bg-pitch-green/20 text-pitch-green border border-pitch-green/40 rounded hover:bg-pitch-green/30 transition-colors"
+          >
+            Yes
+          </button>
+          <button
+            onClick={() => setConfirming(false)}
+            className="px-2 py-0.5 bg-white/5 text-txt-muted border border-white/10 rounded hover:bg-white/10 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <button
+          disabled={!canSign}
+          onClick={() => setConfirming(true)}
+          className={`w-full text-xs py-1.5 rounded transition-colors ${
+            canSign
+              ? 'bg-pitch-green/20 text-pitch-green border border-pitch-green/40 hover:bg-pitch-green/30'
+              : 'bg-white/5 text-txt-muted border border-white/10 cursor-not-allowed opacity-60'
+          }`}
+        >
+          {!hasSquadRoom ? 'Squad full' : !canAfford ? 'Over budget' : 'Sign'}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ─── Squad Player Card ─────────────────────────────────────────────────────────
+
+interface SquadPlayerCardProps {
+  player: Player;
+  currentWeek: number;
+  onRelease: () => void;
+}
+
+function SquadPlayerCard({ player, currentWeek, onRelease }: SquadPlayerCardProps) {
+  const [confirming, setConfirming] = useState(false);
+  const [released, setReleased] = useState(false);
+
+  const isFreeAgent = player.contractExpiresWeek === 0;
+  const isExpired = !isFreeAgent && currentWeek >= player.contractExpiresWeek;
+  const releaseFee = (!isFreeAgent && !isExpired && player.contractExpiresWeek > currentWeek)
+    ? Math.round((player.contractExpiresWeek - currentWeek) * player.wage * 0.5)
+    : 0;
+
+  function contractBadge() {
+    if (isFreeAgent) {
+      return <span className="text-[10px] bg-pitch-green/20 text-pitch-green border border-pitch-green/40 px-1.5 py-0.5 rounded">Free agent</span>;
+    }
+    if (isExpired) {
+      return <span className="text-[10px] bg-pitch-green/20 text-pitch-green border border-pitch-green/40 px-1.5 py-0.5 rounded">Out of contract</span>;
+    }
+    const weeksLeft = player.contractExpiresWeek - currentWeek;
+    return <span className="text-[10px] text-txt-muted">Wk {player.contractExpiresWeek} ({weeksLeft}wk left)</span>;
+  }
+
+  function releaseLabel() {
+    if (releaseFee > 0) return `Release (${formatMoney(releaseFee)} fee)`;
+    return 'Release (free)';
+  }
+
+  function handleConfirm() {
+    onRelease();
+    setReleased(true);
+    setConfirming(false);
+  }
+
+  return (
+    <div className="bg-bg-raised rounded-card border border-white/5 p-3 flex flex-col gap-2">
+      {/* Header row */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-semibold text-txt-primary text-sm truncate">{player.name}</span>
+            <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${POSITION_COLOUR[player.position]}`}>
+              {player.position}
+            </span>
+          </div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-xs text-txt-muted">Age {player.age} · {formatMoney(player.wage)}/wk</span>
+            {contractBadge()}
+          </div>
+        </div>
+        <div className="text-right shrink-0">
+          <span className="text-data-blue font-bold text-sm">{player.overallRating}</span>
+          <div className="text-[10px] text-txt-muted">OVR</div>
+        </div>
+      </div>
+
+      {/* Attribute bars */}
+      <div className="flex flex-col gap-0.5">
+        <AttrBar label="ATK" value={player.attributes.attack}   colour="bg-alert-red" />
+        <AttrBar label="DEF" value={player.attributes.defence}  colour="bg-data-blue" />
+        <AttrBar label="TMW" value={player.attributes.teamwork} colour="bg-pitch-green" />
+        <AttrBar label="CHA" value={player.attributes.charisma} colour="bg-warn-amber" />
+        <AttrBar label="POT" value={player.attributes.publicPotential} colour="bg-purple-400" />
+      </div>
+
+      {/* Release action */}
+      {released ? (
+        <div className="text-xs text-warn-amber font-semibold">Released</div>
+      ) : confirming ? (
+        <div className="flex items-center gap-2 flex-wrap text-xs">
+          <span className="text-txt-muted">
+            Release {player.name}{releaseFee > 0 ? ` (${formatMoney(releaseFee)} compensation)` : ' for free'}?
+          </span>
+          <button
+            onClick={handleConfirm}
+            className="px-2 py-0.5 bg-alert-red/20 text-alert-red border border-alert-red/40 rounded hover:bg-alert-red/30 transition-colors"
+          >
+            Yes
+          </button>
+          <button
+            onClick={() => setConfirming(false)}
+            className="px-2 py-0.5 bg-white/5 text-txt-muted border border-white/10 rounded hover:bg-white/10 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={() => setConfirming(true)}
+          className="w-full text-xs py-1.5 rounded bg-alert-red/10 text-alert-red border border-alert-red/30 hover:bg-alert-red/20 transition-colors"
+        >
+          {releaseLabel()}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ─── Main component ────────────────────────────────────────────────────────────
+
+export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMarketSlideOverProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('free-agents');
+  const [positionFilter, setPositionFilter] = useState<Position | 'ALL'>('ALL');
+  const [sortKey, setSortKey] = useState<SortKey>('rating');
+
+  const currentTotalWages = state.club.squad.reduce((sum, p) => sum + p.wage, 0);
+  const remainingWageBudget = state.club.wageBudget - currentTotalWages;
+  const squadCount = state.club.squad.length;
+  const squadCapacity = state.club.squadCapacity;
+
+  // ── Filter + sort free agents ──────────────────────────────────────────────
+
+  function filterPlayers<T extends Player>(players: T[]): T[] {
+    return players
+      .filter(p => positionFilter === 'ALL' || p.position === positionFilter)
+      .sort((a, b) => {
+        switch (sortKey) {
+          case 'rating':  return b.overallRating - a.overallRating;
+          case 'attack':  return b.attributes.attack - a.attributes.attack;
+          case 'defence': return b.attributes.defence - a.attributes.defence;
+          case 'wage':    return b.wage - a.wage;
+          default: return 0;
+        }
+      });
+  }
+
+  const filteredFreeAgents = filterPlayers(state.freeAgentPool ?? []);
+  const filteredSquad = filterPlayers(state.club.squad);
+
+  // ── Handlers ───────────────────────────────────────────────────────────────
+
+  function handleSign(playerId: string, wage: number) {
+    const result = dispatch({ type: 'SIGN_FREE_AGENT', playerId, offeredWage: wage });
+    if (result.error) onError(result.error);
+  }
+
+  function handleRelease(playerId: string) {
+    const result = dispatch({ type: 'RELEASE_PLAYER', playerId });
+    if (result.error) onError(result.error);
+  }
+
+  const POSITIONS: (Position | 'ALL')[] = ['ALL', 'GK', 'DEF', 'MID', 'FWD'];
+  const SORT_OPTIONS: { value: SortKey; label: string }[] = [
+    { value: 'rating',  label: 'Rating ↓' },
+    { value: 'attack',  label: 'Attack ↓' },
+    { value: 'defence', label: 'Defence ↓' },
+    { value: 'wage',    label: 'Wage ↓' },
+  ];
+
+  return (
+    <div className="flex flex-col h-full gap-3">
+
+      {/* ── Budget / squad bar ─────────────────────────────────────────────── */}
+      <div className="bg-bg-raised rounded-card border border-white/5 px-4 py-2 flex items-center gap-4 text-sm flex-wrap">
+        <span className="text-txt-muted">
+          Wage budget: <span className="text-pitch-green font-semibold">{formatMoney(remainingWageBudget)}</span> remaining
+        </span>
+        <span className="text-white/20">|</span>
+        <span className="text-txt-muted">
+          Squad: <span className={squadCount >= squadCapacity ? 'text-alert-red font-semibold' : 'text-data-blue font-semibold'}>
+            {squadCount}/{squadCapacity}
+          </span>
+        </span>
+      </div>
+
+      {/* ── Tabs ──────────────────────────────────────────────────────────── */}
+      <div className="flex gap-1">
+        {(['free-agents', 'my-squad'] as Tab[]).map(tab => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`px-3 py-1.5 text-sm rounded-card transition-colors ${
+              activeTab === tab
+                ? 'bg-data-blue/20 text-data-blue border border-data-blue/40'
+                : 'text-txt-muted hover:text-txt-primary border border-white/5 hover:border-white/10'
+            }`}
+          >
+            {tab === 'free-agents' ? `Free Agents (${(state.freeAgentPool ?? []).length})` : `My Squad (${squadCount})`}
+          </button>
+        ))}
+      </div>
+
+      {/* ── Filters ──────────────────────────────────────────────────────── */}
+      <div className="flex items-center gap-2 flex-wrap">
+        {/* Position filters */}
+        <div className="flex gap-1">
+          {POSITIONS.map(pos => (
+            <button
+              key={pos}
+              onClick={() => setPositionFilter(pos)}
+              className={`px-2 py-0.5 text-xs rounded transition-colors ${
+                positionFilter === pos
+                  ? 'bg-data-blue/20 text-data-blue border border-data-blue/40'
+                  : 'text-txt-muted border border-white/5 hover:border-white/10'
+              }`}
+            >
+              {pos}
+            </button>
+          ))}
+        </div>
+
+        {/* Sort dropdown */}
+        <select
+          value={sortKey}
+          onChange={e => setSortKey(e.target.value as SortKey)}
+          className="ml-auto bg-bg-raised text-txt-muted text-xs border border-white/10 rounded px-2 py-0.5 focus:outline-none"
+        >
+          {SORT_OPTIONS.map(opt => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* ── Player list ──────────────────────────────────────────────────── */}
+      <div className="flex-1 overflow-y-auto flex flex-col gap-2 pr-1">
+        {activeTab === 'free-agents' ? (
+          filteredFreeAgents.length === 0 ? (
+            <div className="text-txt-muted text-sm text-center py-8">No free agents match your filters.</div>
+          ) : (
+            filteredFreeAgents.map(player => (
+              <FreeAgentCard
+                key={player.id}
+                player={player}
+                canAfford={player.wage <= remainingWageBudget}
+                hasSquadRoom={squadCount < squadCapacity}
+                onSign={wage => handleSign(player.id, wage)}
+              />
+            ))
+          )
+        ) : (
+          filteredSquad.length === 0 ? (
+            <div className="text-txt-muted text-sm text-center py-8">No players match your filters.</div>
+          ) : (
+            filteredSquad.map(player => (
+              <SquadPlayerCard
+                key={player.id}
+                player={player}
+                currentWeek={state.currentWeek}
+                onRelease={() => handleRelease(player.id)}
+              />
+            ))
+          )
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Combines Phase 5.1 (PR #33) and Phase 5.2 (PR #37) onto main.

## Phase 5.1 — Pre-season flow
- Pre-season entry screen (replaces week 19 arbitrary start)
- Formation picker: 6 formations with style tags
- `SET_PREFERRED_FORMATION` command → `PREFERRED_FORMATION_SET` event
- `FORMATION_CONFIG` with slots, recruitmentPriority, formationCoverage()
- Auto-generated inherited squad: 16 weak players, Pro-Evo names

## Phase 5.2 — Transfer market
- Player attributes: attack, defence, teamwork, charisma, publicPotential, truePotential (hidden)
- Free agent pool: 60 seeded players with attribute variance by position tier
- TransferMarketSlideOver: two-tab UI, position filter, sort options
- Sign mechanic: wage budget guard + 24-slot cap guard
- Release mechanic: early release fee (weeks × wage × 0.5)
- 269 domain tests green, TypeScript clean