### PR TITLE
Phase 5.4: NPC poaching — clubs can bid for your players (#36)

### DIFF
--- a/packages/domain/src/__tests__/poaching.test.ts
+++ b/packages/domain/src/__tests__/poaching.test.ts
@@ -1,0 +1,343 @@
+/**
+ * NPC Poaching Tests — Phase 5.4
+ *
+ * Tests for:
+ *   - generatePoachAttempts: correct generation, rate gating, cooldown
+ *   - Resolve 'accept':  player removed from squad, budget increases, rep +3
+ *   - Resolve 'reject':  player stays, morale drops -15
+ *   - Resolve 'counter': player removed, budget increases by 1.5× fee, rep +5
+ *   - Resolve 'ignore':  player stays, morale drops -25, rep -5
+ */
+
+import { buildState, reduceEvent } from '../reducers';
+import { handleCommand } from '../commands/handlers';
+import { GameState, PendingClubEvent } from '../types/game-state-updated';
+import { GameStartedEvent, ClubEventOccurredEvent } from '../events/types';
+import { generatePoachAttempts } from '../simulation/events';
+import { Player } from '../types/player';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeStartedState(seed = 'test-seed'): GameState {
+  return buildState([
+    {
+      type: 'GAME_STARTED',
+      timestamp: Date.now(),
+      clubId: 'test-club',
+      clubName: 'Test FC',
+      initialBudget: 500_000_000,
+      difficulty: 'MEDIUM',
+      seed,
+    } as GameStartedEvent,
+  ]);
+}
+
+/** Build a Player with the given overrides. */
+function makePlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    id: 'p1',
+    name: 'Test Player',
+    overallRating: 65,
+    position: 'MID',
+    wage: 100_000,
+    transferValue: 1_000_000,
+    age: 24,
+    morale: 75,
+    stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 65 },
+    attributes: { attack: 60, defence: 55, teamwork: 70, charisma: 50, publicPotential: 65 },
+    truePotential: 68,
+    contractExpiresWeek: 46,
+    ...overrides,
+  };
+}
+
+/** Inject state with an in-season phase and a custom squad. */
+function withSquad(state: GameState, squad: Player[]): GameState {
+  return {
+    ...state,
+    phase: 'EARLY_SEASON',
+    club: { ...state.club, squad },
+  };
+}
+
+/** Inject a poach PendingClubEvent into state. */
+function withPoachEvent(
+  state: GameState,
+  target: Player,
+  offeredFee: number,
+  eventId = 'evt-S1-W3-poach'
+): GameState {
+  const pendingEvent: PendingClubEvent = {
+    id: eventId,
+    templateId: 'npc-poach',
+    week: 3,
+    title: `Swinton Town want ${target.name}`,
+    description: `Bid of £${(offeredFee / 100).toLocaleString()} received.`,
+    severity: 'major',
+    metadata: {
+      poachTargetPlayerId: target.id,
+      npcClubId: 'swinton',
+      npcClubName: 'Swinton Town',
+      offeredFee,
+    },
+    choices: [
+      {
+        id: 'accept',
+        label: 'Accept the bid',
+        description: 'Sell.',
+        budgetEffect: offeredFee,
+        reputationEffect: 3,
+        playerLeaves: true,
+      },
+      {
+        id: 'reject',
+        label: 'Reject the bid',
+        description: 'Keep player.',
+        moraleEffect: -15,
+      },
+      {
+        id: 'counter',
+        label: 'Counter at 1.5×',
+        description: 'Sell for more.',
+        budgetEffect: Math.round(offeredFee * 1.5),
+        reputationEffect: 5,
+        playerLeaves: true,
+      },
+      {
+        id: 'ignore',
+        label: 'Say nothing',
+        description: 'Ghost the bid.',
+        moraleEffect: -25,
+        reputationEffect: -5,
+      },
+    ],
+    resolved: false,
+  };
+
+  const occurred: ClubEventOccurredEvent = {
+    type: 'CLUB_EVENT_OCCURRED',
+    timestamp: Date.now(),
+    eventId,
+    templateId: 'npc-poach',
+    week: 3,
+    clubId: state.club.id,
+    pendingEvent,
+  };
+
+  return reduceEvent(state, occurred);
+}
+
+// ── generatePoachAttempts ────────────────────────────────────────────────────
+
+describe('generatePoachAttempts', () => {
+  it('returns empty array during PRE_SEASON', () => {
+    const state = makeStartedState();
+    // PRE_SEASON is the default phase after GAME_STARTED
+    const result = generatePoachAttempts(state, 1, 1, 'test-seed');
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns empty array when no squad player is rated >= 55', () => {
+    const base = makeStartedState();
+    const state = withSquad(base, [
+      makePlayer({ id: 'p1', overallRating: 50 }),
+      makePlayer({ id: 'p2', overallRating: 48 }),
+    ]);
+    const result = generatePoachAttempts(state, 1, 1, 'test-seed');
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns at most 1 event per week', () => {
+    const base = makeStartedState();
+    // Put a high-rated player to maximise poach chance
+    const state = withSquad(base, [
+      makePlayer({ id: 'p1', overallRating: 80 }),
+      makePlayer({ id: 'p2', overallRating: 75 }),
+      makePlayer({ id: 'p3', overallRating: 70 }),
+    ]);
+    // Run across many seeds; never more than 1
+    for (let w = 1; w <= 20; w++) {
+      const result = generatePoachAttempts(state, w, 1, `seed-${w}`);
+      expect(result.length).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('returns empty if a poach event is already pending', () => {
+    const base = makeStartedState();
+    const target = makePlayer({ id: 'p1', overallRating: 80 });
+    let state = withSquad(base, [target]);
+    state = withPoachEvent(state, target, 800_000);
+
+    // Find a seed that would normally fire
+    const firingSeed = findFiringSeed(state, 5, 1);
+    if (firingSeed) {
+      const result = generatePoachAttempts(state, 5, 1, firingSeed);
+      expect(result).toHaveLength(0);
+    }
+  });
+
+  it('generated event has correct templateId and metadata', () => {
+    const base = makeStartedState();
+    const target = makePlayer({ id: 'star', overallRating: 80, wage: 200_000 });
+    const state = withSquad(base, [target]);
+    const firingSeed = findFiringSeed(state, 3, 1);
+    if (!firingSeed) return; // skip if no seed fires (probabilistic)
+
+    const [event] = generatePoachAttempts(state, 3, 1, firingSeed);
+    expect(event.templateId).toBe('npc-poach');
+    expect(event.metadata?.poachTargetPlayerId).toBe('star');
+    expect(event.metadata?.offeredFee).toBeGreaterThan(0);
+    expect(event.choices).toHaveLength(4);
+    expect(event.choices.map(c => c.id)).toEqual(['accept', 'reject', 'counter', 'ignore']);
+  });
+
+  it('counter choice budget is 1.5× the accept choice budget', () => {
+    const base = makeStartedState();
+    const target = makePlayer({ id: 'star', overallRating: 80, wage: 200_000 });
+    const state = withSquad(base, [target]);
+    const firingSeed = findFiringSeed(state, 3, 1);
+    if (!firingSeed) return;
+
+    const [event] = generatePoachAttempts(state, 3, 1, firingSeed);
+    const accept = event.choices.find(c => c.id === 'accept')!;
+    const counter = event.choices.find(c => c.id === 'counter')!;
+    expect(counter.budgetEffect).toBe(Math.round(accept.budgetEffect! * 1.5));
+  });
+});
+
+// ── Resolution: accept ───────────────────────────────────────────────────────
+
+describe('resolve poach — accept', () => {
+  it('removes player from squad', () => {
+    const target = makePlayer({ id: 'p1', overallRating: 65 });
+    const fee = 800_000;
+    let state = withSquad(makeStartedState(), [target]);
+    state = withPoachEvent(state, target, fee);
+    const budgetBefore = state.club.transferBudget;
+
+    const result = handleCommand(
+      { type: 'RESOLVE_CLUB_EVENT', eventId: 'evt-S1-W3-poach', choiceId: 'accept' },
+      state
+    );
+    expect(result.error).toBeUndefined();
+    const newState = result.events!.reduce(reduceEvent, state);
+
+    expect(newState.club.squad.find(p => p.id === 'p1')).toBeUndefined();
+    expect(newState.club.transferBudget).toBe(budgetBefore + fee);
+    expect(newState.club.reputation).toBe(state.club.reputation + 3);
+  });
+});
+
+// ── Resolution: reject ───────────────────────────────────────────────────────
+
+describe('resolve poach — reject', () => {
+  it('keeps player in squad and reduces morale by 15', () => {
+    const target = makePlayer({ id: 'p1', overallRating: 65, morale: 75 });
+    let state = withSquad(makeStartedState(), [target]);
+    state = withPoachEvent(state, target, 800_000);
+
+    const result = handleCommand(
+      { type: 'RESOLVE_CLUB_EVENT', eventId: 'evt-S1-W3-poach', choiceId: 'reject' },
+      state
+    );
+    expect(result.error).toBeUndefined();
+    const newState = result.events!.reduce(reduceEvent, state);
+
+    const player = newState.club.squad.find(p => p.id === 'p1')!;
+    expect(player).toBeDefined();
+    expect(player.morale).toBe(60); // 75 - 15
+  });
+
+  it('does not change the budget', () => {
+    const target = makePlayer({ id: 'p1' });
+    let state = withSquad(makeStartedState(), [target]);
+    state = withPoachEvent(state, target, 800_000);
+    const budgetBefore = state.club.transferBudget;
+
+    const result = handleCommand(
+      { type: 'RESOLVE_CLUB_EVENT', eventId: 'evt-S1-W3-poach', choiceId: 'reject' },
+      state
+    );
+    const newState = result.events!.reduce(reduceEvent, state);
+    expect(newState.club.transferBudget).toBe(budgetBefore);
+  });
+});
+
+// ── Resolution: counter ──────────────────────────────────────────────────────
+
+describe('resolve poach — counter', () => {
+  it('removes player and awards 1.5× fee', () => {
+    const target = makePlayer({ id: 'p1', overallRating: 65 });
+    const fee = 800_000;
+    const counterFee = Math.round(fee * 1.5);
+    let state = withSquad(makeStartedState(), [target]);
+    state = withPoachEvent(state, target, fee);
+    const budgetBefore = state.club.transferBudget;
+
+    const result = handleCommand(
+      { type: 'RESOLVE_CLUB_EVENT', eventId: 'evt-S1-W3-poach', choiceId: 'counter' },
+      state
+    );
+    expect(result.error).toBeUndefined();
+    const newState = result.events!.reduce(reduceEvent, state);
+
+    expect(newState.club.squad.find(p => p.id === 'p1')).toBeUndefined();
+    expect(newState.club.transferBudget).toBe(budgetBefore + counterFee);
+    expect(newState.club.reputation).toBe(state.club.reputation + 5);
+  });
+});
+
+// ── Resolution: ignore ───────────────────────────────────────────────────────
+
+describe('resolve poach — ignore', () => {
+  it('keeps player but drops morale by 25 and rep by 5', () => {
+    const target = makePlayer({ id: 'p1', overallRating: 65, morale: 75 });
+    let state = withSquad(makeStartedState(), [target]);
+    state = withPoachEvent(state, target, 800_000);
+
+    const result = handleCommand(
+      { type: 'RESOLVE_CLUB_EVENT', eventId: 'evt-S1-W3-poach', choiceId: 'ignore' },
+      state
+    );
+    expect(result.error).toBeUndefined();
+    const newState = result.events!.reduce(reduceEvent, state);
+
+    const player = newState.club.squad.find(p => p.id === 'p1')!;
+    expect(player).toBeDefined();
+    expect(player.morale).toBe(50); // 75 - 25
+    expect(newState.club.reputation).toBe(Math.max(0, state.club.reputation - 5));
+  });
+});
+
+// ── Morale clamping ──────────────────────────────────────────────────────────
+
+describe('morale clamping', () => {
+  it('morale cannot drop below 0', () => {
+    const target = makePlayer({ id: 'p1', morale: 10 });
+    let state = withSquad(makeStartedState(), [target]);
+    state = withPoachEvent(state, target, 800_000);
+
+    const result = handleCommand(
+      { type: 'RESOLVE_CLUB_EVENT', eventId: 'evt-S1-W3-poach', choiceId: 'ignore' },
+      state
+    );
+    const newState = result.events!.reduce(reduceEvent, state);
+    const player = newState.club.squad.find(p => p.id === 'p1')!;
+    expect(player.morale).toBe(0);
+  });
+});
+
+// ── Utility ──────────────────────────────────────────────────────────────────
+
+/**
+ * Brute-force find a seed that causes generatePoachAttempts to fire.
+ * Used to avoid brittle exact-seed tests. Returns null if none found in range.
+ */
+function findFiringSeed(state: GameState, week: number, season: number): string | null {
+  for (let i = 0; i < 50; i++) {
+    const seed = `fire-seed-${i}`;
+    const result = generatePoachAttempts(state, week, season, seed);
+    if (result.length > 0) return seed;
+  }
+  return null;
+}

--- a/packages/domain/src/commands/handlers.ts
+++ b/packages/domain/src/commands/handlers.ts
@@ -11,7 +11,7 @@ import { validateTransfer, validateFacilityUpgrade, validateStaffHire } from '..
 import { simulateMatch, clubToTeam, generateAITeam, Team } from '../simulation/match';
 import { generateSeasonFixtures, getWeekFixtures, matchSeed } from '../simulation/season';
 import { createRng } from '../simulation/rng';
-import { generateWeekEvents } from '../simulation/events';
+import { generateWeekEvents, generatePoachAttempts } from '../simulation/events';
 import { LEAGUE_TWO_TEAMS } from '../data/league-two-teams';
 import { Player } from '../types/player';
 
@@ -273,6 +273,20 @@ function handleSimulateWeek(command: any, state: GameState): CommandResult {
     });
   }
 
+  // Generate NPC poach attempts (0 or 1 per week)
+  const poachEvents = generatePoachAttempts(state, week, season, baseSeed);
+  for (const pendingEvent of poachEvents) {
+    events.push({
+      type: 'CLUB_EVENT_OCCURRED',
+      timestamp: now,
+      eventId: pendingEvent.id,
+      templateId: pendingEvent.templateId,
+      week,
+      clubId: state.club.id,
+      pendingEvent
+    });
+  }
+
   // Advance the week after all matches and events
   events.push({
     type: 'WEEK_ADVANCED',
@@ -336,6 +350,11 @@ function handleResolveClubEvent(command: any, state: GameState): CommandResult {
     };
   }
 
+  // Propagate poach-specific fields from choice + event metadata
+  const poachTargetId = pendingEvent.metadata?.poachTargetPlayerId;
+  const playerRemovedId = choice.playerLeaves ? poachTargetId : undefined;
+  const moraleTargetId = choice.moraleEffect !== undefined ? poachTargetId : undefined;
+
   const events: GameEvent[] = [
     {
       type: 'CLUB_EVENT_RESOLVED',
@@ -344,7 +363,10 @@ function handleResolveClubEvent(command: any, state: GameState): CommandResult {
       choiceId,
       clubId: state.club.id,
       budgetEffect: choice.budgetEffect,
-      reputationEffect: choice.reputationEffect
+      reputationEffect: choice.reputationEffect,
+      playerRemovedId,
+      moraleTargetId,
+      moraleEffect: choice.moraleEffect,
     }
   ];
 

--- a/packages/domain/src/events/types.ts
+++ b/packages/domain/src/events/types.ts
@@ -149,6 +149,12 @@ export interface ClubEventResolvedEvent {
   clubId: string;
   budgetEffect?: number;
   reputationEffect?: number;
+  /** Poaching: player ID to remove from squad (accept/counter choices) */
+  playerRemovedId?: string;
+  /** Poaching: player ID whose morale should change (reject/ignore choices) */
+  moraleTargetId?: string;
+  /** Poaching: morale delta to apply to moraleTargetId */
+  moraleEffect?: number;
 }
 
 export interface SeasonStartedEvent {

--- a/packages/domain/src/reducers/index.ts
+++ b/packages/domain/src/reducers/index.ts
@@ -433,12 +433,28 @@ function handleClubEventResolved(state: GameState, event: ClubEventResolvedEvent
   // Remove resolved events from pendingEvents
   const newPendingEvents = state.pendingEvents.filter(e => e.id !== event.eventId);
 
+  // Poaching: remove player from squad if accepted
+  let squad = state.club.squad;
+  if (event.playerRemovedId) {
+    squad = squad.filter(p => p.id !== event.playerRemovedId);
+  }
+
+  // Poaching: apply morale delta to target player (clamped 0-100)
+  if (event.moraleTargetId && event.moraleEffect !== undefined) {
+    squad = squad.map(p =>
+      p.id === event.moraleTargetId
+        ? { ...p, morale: Math.max(0, Math.min(100, p.morale + event.moraleEffect!)) }
+        : p
+    );
+  }
+
   return {
     ...state,
     club: {
       ...state.club,
       transferBudget: newBudget,
-      reputation: newReputation
+      reputation: newReputation,
+      squad,
     },
     pendingEvents: newPendingEvents,
     resolvedEventHistory: newHistory

--- a/packages/domain/src/simulation/events.ts
+++ b/packages/domain/src/simulation/events.ts
@@ -14,6 +14,7 @@
 import { GameState, PendingClubEvent } from '../types/game-state-updated';
 import { CLUB_EVENT_TEMPLATES, ClubEventTemplate } from '../data/club-events';
 import { createRng } from './rng';
+import { LEAGUE_TWO_TEAMS } from '../data/league-two-teams';
 
 /**
  * Check whether a template's prerequisite has been met in the resolved history.
@@ -203,4 +204,136 @@ export function generateWeekEvents(
     resolved: false
     });
   });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NPC Poaching
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Per-week chance of an NPC approaching each squad player.
+ * Rate scales with player quality: a 70-rated player has twice the chance of a 50-rated one.
+ */
+const POACH_BASE_RATE = 0.06; // 6% base per player per week for a 50-OVR player
+const POACH_RATING_SCALE = 0.004; // +0.4% per rating point above 50
+
+function poachChance(overallRating: number): number {
+  return POACH_BASE_RATE + Math.max(0, overallRating - 50) * POACH_RATING_SCALE;
+}
+
+/**
+ * Offered fee is 8–12 weeks' wages, scaled by player rating.
+ * Higher-rated players attract bigger bids.
+ */
+function offeredFee(wage: number, overallRating: number): number {
+  const weekMultiplier = 8 + Math.floor((overallRating - 40) / 10);
+  return Math.round(wage * Math.min(weekMultiplier, 16));
+}
+
+/**
+ * Generate 0–1 NPC poach attempt for this week (deterministic).
+ * At most one poach event fires per week to avoid inbox overload.
+ *
+ * Targeting logic:
+ * - Only players with overallRating >= 55 can be approached
+ * - Strongest NPC club (not already in state as player's club) makes the bid
+ * - The specific player is chosen probabilistically (higher rating = higher weight)
+ */
+export function generatePoachAttempts(
+  state: GameState,
+  week: number,
+  season: number,
+  seed: string
+): PendingClubEvent[] {
+  const rng = createRng(`${seed}-S${season}-W${week}-poach`);
+
+  // Only fire during the season, not pre-season
+  if (state.phase === 'PRE_SEASON' || state.phase === 'SEASON_END') return [];
+
+  // Squad must have at least one attractive player (OVR ≥ 55)
+  const targets = state.club.squad.filter(p => p.overallRating >= 55);
+  if (targets.length === 0) return [];
+
+  // Check if a poach event is already pending (one at a time)
+  const poachPending = state.pendingEvents.some(
+    e => e.templateId === 'npc-poach' && !e.resolved
+  );
+  if (poachPending) return [];
+
+  // Pick a random target, weighted by overallRating
+  const totalWeight = targets.reduce((sum, p) => sum + p.overallRating, 0);
+  let pick = rng.next() * totalWeight;
+  const target = targets.find(p => {
+    pick -= p.overallRating;
+    return pick <= 0;
+  }) ?? targets[targets.length - 1];
+
+  // Roll per-player chance
+  if (rng.next() > poachChance(target.overallRating)) return [];
+
+  // Pick a random NPC club (not the player's own club)
+  const npcClubs = LEAGUE_TWO_TEAMS.filter(t => t.id !== state.club.id);
+  const npcClub = npcClubs[rng.nextInt(0, npcClubs.length - 1)];
+
+  const fee = offeredFee(target.wage, target.overallRating);
+  const feeStr = (fee / 100).toLocaleString('en-GB', {
+    style: 'currency',
+    currency: 'GBP',
+    maximumFractionDigits: 0,
+  });
+  const counterFee = Math.round(fee * 1.5);
+  const counterFeeStr = (counterFee / 100).toLocaleString('en-GB', {
+    style: 'currency',
+    currency: 'GBP',
+    maximumFractionDigits: 0,
+  });
+
+  const poachEvent: PendingClubEvent = {
+    id: `evt-S${season}-W${week}-poach`,
+    templateId: 'npc-poach',
+    week,
+    title: `${npcClub.name} want ${target.name}`,
+    description: `${npcClub.name} have submitted a formal bid of ${feeStr} for ${target.name}. How do you respond?`,
+    severity: 'major',
+    metadata: {
+      poachTargetPlayerId: target.id,
+      npcClubId: npcClub.id,
+      npcClubName: npcClub.name,
+      offeredFee: fee,
+    },
+    choices: [
+      {
+        id: 'accept',
+        label: 'Accept the bid',
+        description: `Sell ${target.name} to ${npcClub.name} for ${feeStr}. The funds land immediately.`,
+        budgetEffect: fee,
+        reputationEffect: 3,
+        playerLeaves: true,
+      },
+      {
+        id: 'reject',
+        label: 'Reject the bid',
+        description: `Turn down the offer. ${target.name} stays — but may be unsettled.`,
+        moraleEffect: -15,
+      },
+      {
+        id: 'counter',
+        label: `Counter at ${counterFeeStr}`,
+        description: `Demand 50% more. ${npcClub.name} agrees — ${target.name} moves on for a premium fee.`,
+        budgetEffect: counterFee,
+        reputationEffect: 5,
+        playerLeaves: true,
+      },
+      {
+        id: 'ignore',
+        label: 'Say nothing',
+        description: `Don't respond at all. The bid lapses, but ${target.name} is left in the dark and is very unhappy.`,
+        moraleEffect: -25,
+        reputationEffect: -5,
+      },
+    ],
+    resolved: false,
+  };
+
+  return [poachEvent];
 }

--- a/packages/domain/src/types/game-state-updated.ts
+++ b/packages/domain/src/types/game-state-updated.ts
@@ -23,6 +23,10 @@ export interface ClubEventChoice {
   reputationEffect?: number;
   performanceEffect?: number;
   requiresMath?: boolean;
+  /** Poaching: if true, the poach target leaves the squad (transfer fee is in budgetEffect) */
+  playerLeaves?: boolean;
+  /** Poaching: morale delta applied to the poach target player (negative = unhappy) */
+  moraleEffect?: number;
 }
 
 /**
@@ -37,6 +41,16 @@ export interface PendingClubEvent {
   severity: 'minor' | 'major';
   choices: ClubEventChoice[];
   resolved: boolean;
+  /**
+   * Optional metadata for specialised event types (e.g. NPC poaching).
+   * Not present on standard club events.
+   */
+  metadata?: {
+    poachTargetPlayerId?: string;
+    npcClubId?: string;
+    npcClubName?: string;
+    offeredFee?: number;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- NPCs can now approach players from your squad with a formal transfer bid, surfacing as a **MAJOR** inbox event
- Four response choices: **Accept** (sell at fee), **Reject** (player unhappy, morale −15), **Counter** (sell at 1.5× fee), **Ignore** (morale −25, rep −5)
- Morale drops feed directly into the existing match sim teamwork/morale wiring from Phase 5.3 — no extra plumbing needed
- Poach rate scales with player OVR (≥55 threshold); at most one poach event per week; blocked if one is already pending

## Domain changes

| File | Change |
|------|--------|
| `types/game-state-updated.ts` | `ClubEventChoice` + `playerLeaves?`, `moraleEffect?`; `PendingClubEvent` + `metadata?` |
| `events/types.ts` | `ClubEventResolvedEvent` + `playerRemovedId?`, `moraleTargetId?`, `moraleEffect?` |
| `commands/handlers.ts` | `handleResolveClubEvent` propagates poach fields; `handleSimulateWeek` wires `generatePoachAttempts` |
| `reducers/index.ts` | `handleClubEventResolved` removes player and clamps morale on resolution |
| `simulation/events.ts` | `generatePoachAttempts()` — deterministic, rate-scaled, cooldown-aware |
| `__tests__/poaching.test.ts` | 12 new tests covering all 4 choices + edge cases |

## Test plan

- [x] 281/281 domain tests green
- [x] TypeScript clean (domain + frontend)
- [x] Dev server: pre-season → command centre → week sim runs cleanly
- [x] No poach event on week 1 with inherited squad (all OVR ≤43, below ≥55 threshold) ✓
- [ ] Manual: sign a ≥55 OVR free agent, simulate several weeks until poach fires; verify all 4 choices work

🤖 Generated with [Claude Code](https://claude.com/claude-code)