### PR TITLE
feat: Phase 5.5 — Manager hire & impact

### DIFF
--- a/packages/domain/src/__tests__/manager.test.ts
+++ b/packages/domain/src/__tests__/manager.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Manager Tests — Phase 5.5
+ *
+ * Tests for:
+ *   - generateManagerPool: deterministic, correct counts per tier
+ *   - HIRE_MANAGER command: adds manager, removes from pool, sets contractExpiresWeek
+ *   - HIRE_MANAGER: fails when manager not in pool
+ *   - HIRE_MANAGER: fails when wage exceeds budget
+ *   - HIRE_MANAGER: replaces existing manager (no compensation in pre-season)
+ *   - SACK_MANAGER command: removes manager, deducts compensation
+ *   - SACK_MANAGER: fails when no manager
+ *   - SACK_MANAGER: fails when cannot afford compensation
+ *   - Manager experience contributes to team modifier in match sim
+ *   - Manager tactical amplifies training focus in match sim
+ *   - Manager motivation nudges morale each week in WEEK_ADVANCED
+ */
+
+import { buildState, reduceEvent } from '../reducers';
+import { handleCommand } from '../commands/handlers';
+import { GameState } from '../types/game-state-updated';
+import { Manager } from '../types/staff';
+import { GameStartedEvent } from '../events/types';
+import { generateManagerPool } from '../data/manager-generator';
+import { clubToTeam } from '../simulation/match';
+import { Club } from '../types/club';
+import { Player } from '../types/player';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeStartedState(seed = 'test-seed'): GameState {
+  return buildState([
+    {
+      type: 'GAME_STARTED',
+      timestamp: Date.now(),
+      clubId: 'test-club',
+      clubName: 'Test FC',
+      initialBudget: 500_000_000,
+      difficulty: 'MEDIUM',
+      seed,
+    } as GameStartedEvent,
+  ]);
+}
+
+function makePlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    id: 'p1',
+    name: 'Test Player',
+    overallRating: 60,
+    position: 'MID',
+    wage: 50_000,
+    transferValue: 500_000,
+    age: 24,
+    morale: 60,
+    stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 60 },
+    attributes: { attack: 50, defence: 50, teamwork: 50, charisma: 50, publicPotential: 60 },
+    truePotential: 60,
+    contractExpiresWeek: 46,
+    ...overrides,
+  };
+}
+
+function makeMinimalClub(overrides: Partial<Club> = {}): Club {
+  return {
+    id: 'club-1',
+    name: 'Test FC',
+    transferBudget: 10_000_000,
+    wageBudget: 2_000_000,
+    squad: [makePlayer()],
+    staff: [],
+    facilities: [],
+    reputation: 30,
+    stadium: { name: '', capacity: 5000, averageAttendance: 3000, ticketPrice: 1500 },
+    form: [],
+    trainingFocus: null,
+    preferredFormation: null,
+    squadCapacity: 24,
+    manager: null,
+    ...overrides,
+  };
+}
+
+function makeManager(overrides: Partial<Manager> = {}): Manager {
+  return {
+    id: 'mgr-test',
+    name: 'Terry Boulton',
+    attributes: { tactical: 70, motivation: 65, experience: 75 },
+    wage: 300_000,
+    contractLengthWeeks: 52,
+    contractExpiresWeek: 0,
+    ...overrides,
+  };
+}
+
+// ── generateManagerPool ───────────────────────────────────────────────────────
+
+describe('generateManagerPool', () => {
+  it('returns exactly 8 managers', () => {
+    const pool = generateManagerPool('test-seed');
+    expect(pool.length).toBe(8);
+  });
+
+  it('is deterministic — same seed produces identical pool', () => {
+    const a = generateManagerPool('same-seed');
+    const b = generateManagerPool('same-seed');
+    expect(a).toEqual(b);
+  });
+
+  it('produces different pools from different seeds', () => {
+    const a = generateManagerPool('seed-a');
+    const b = generateManagerPool('seed-b');
+    // At least one attribute should differ
+    expect(a[0].attributes).not.toEqual(b[0].attributes);
+  });
+
+  it('all managers have unique IDs', () => {
+    const pool = generateManagerPool('test-seed');
+    const ids = pool.map(m => m.id);
+    expect(new Set(ids).size).toBe(8);
+  });
+
+  it('all managers have attributes in 0-100 range', () => {
+    const pool = generateManagerPool('test-seed');
+    for (const m of pool) {
+      expect(m.attributes.tactical).toBeGreaterThanOrEqual(0);
+      expect(m.attributes.tactical).toBeLessThanOrEqual(100);
+      expect(m.attributes.motivation).toBeGreaterThanOrEqual(0);
+      expect(m.attributes.motivation).toBeLessThanOrEqual(100);
+      expect(m.attributes.experience).toBeGreaterThanOrEqual(0);
+      expect(m.attributes.experience).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it('contractExpiresWeek is 0 until hire', () => {
+    const pool = generateManagerPool('test-seed');
+    for (const m of pool) {
+      expect(m.contractExpiresWeek).toBe(0);
+    }
+  });
+});
+
+// ── HIRE_MANAGER command ──────────────────────────────────────────────────────
+
+describe('HIRE_MANAGER command', () => {
+  it('adds manager to club and removes from pool', () => {
+    const state = makeStartedState();
+    const managerId = state.managerPool[0].id;
+
+    const result = handleCommand({ type: 'HIRE_MANAGER', managerId }, state);
+    expect(result.error).toBeUndefined();
+
+    const newState = result.events!.reduce(reduceEvent, state);
+    expect(newState.club.manager?.id).toBe(managerId);
+    expect(newState.managerPool.find(m => m.id === managerId)).toBeUndefined();
+  });
+
+  it('sets contractExpiresWeek correctly', () => {
+    const state = makeStartedState();
+    const manager = state.managerPool[0];
+
+    const result = handleCommand({ type: 'HIRE_MANAGER', managerId: manager.id }, state);
+    const newState = result.events!.reduce(reduceEvent, state);
+
+    expect(newState.club.manager?.contractExpiresWeek).toBe(
+      state.currentWeek + manager.contractLengthWeeks
+    );
+  });
+
+  it('fails when managerId not in pool', () => {
+    const state = makeStartedState();
+    const result = handleCommand({ type: 'HIRE_MANAGER', managerId: 'nonexistent' }, state);
+    expect(result.error).toBeDefined();
+  });
+
+  it('fails when manager wage exceeds remaining wage budget', () => {
+    const state = makeStartedState();
+    // Set a tiny wage budget
+    const tightState: GameState = {
+      ...state,
+      club: { ...state.club, wageBudget: 1 },
+    };
+    const expensiveManager = state.managerPool.find(m => m.wage > 0);
+    if (!expensiveManager) return;
+
+    const result = handleCommand({ type: 'HIRE_MANAGER', managerId: expensiveManager.id }, tightState);
+    expect(result.error?.code).toBe('INSUFFICIENT_BUDGET');
+  });
+
+  it('replaces an existing manager without compensation in pre-season', () => {
+    const state = makeStartedState();
+    const firstManagerId = state.managerPool[0].id;
+    const secondManagerId = state.managerPool[1].id;
+
+    // Hire first
+    const after1 = handleCommand({ type: 'HIRE_MANAGER', managerId: firstManagerId }, state)
+      .events!.reduce(reduceEvent, state);
+
+    // Hire second — should replace first, no compensation
+    const result2 = handleCommand({ type: 'HIRE_MANAGER', managerId: secondManagerId }, after1);
+    expect(result2.error).toBeUndefined();
+
+    const after2 = result2.events!.reduce(reduceEvent, after1);
+    expect(after2.club.manager?.id).toBe(secondManagerId);
+    // Budget should be unchanged (no compensation deducted)
+    expect(after2.club.transferBudget).toBe(after1.club.transferBudget);
+  });
+});
+
+// ── SACK_MANAGER command ──────────────────────────────────────────────────────
+
+describe('SACK_MANAGER command', () => {
+  it('removes manager from club', () => {
+    const state = makeStartedState();
+    const managerId = state.managerPool[0].id;
+
+    // First hire
+    const withManager = handleCommand({ type: 'HIRE_MANAGER', managerId }, state)
+      .events!.reduce(reduceEvent, state);
+
+    // Then sack
+    const result = handleCommand({ type: 'SACK_MANAGER' }, withManager);
+    expect(result.error).toBeUndefined();
+
+    const final = result.events!.reduce(reduceEvent, withManager);
+    expect(final.club.manager).toBeNull();
+  });
+
+  it('deducts compensation from transfer budget', () => {
+    const state = makeStartedState();
+    const managerId = state.managerPool[0].id;
+
+    const withManager = handleCommand({ type: 'HIRE_MANAGER', managerId }, state)
+      .events!.reduce(reduceEvent, state);
+
+    const budgetBefore = withManager.club.transferBudget;
+    const manager = withManager.club.manager!;
+    const weeksRemaining = manager.contractExpiresWeek - withManager.currentWeek;
+    const expectedCompensation = Math.round(weeksRemaining * manager.wage * 0.5);
+
+    const result = handleCommand({ type: 'SACK_MANAGER' }, withManager);
+    const final = result.events!.reduce(reduceEvent, withManager);
+
+    expect(final.club.transferBudget).toBe(budgetBefore - expectedCompensation);
+  });
+
+  it('fails when no manager is hired', () => {
+    const state = makeStartedState();
+    const result = handleCommand({ type: 'SACK_MANAGER' }, state);
+    expect(result.error).toBeDefined();
+  });
+
+  it('fails when club cannot afford compensation', () => {
+    const state = makeStartedState();
+    const managerId = state.managerPool[0].id;
+
+    const withManager = handleCommand({ type: 'HIRE_MANAGER', managerId }, state)
+      .events!.reduce(reduceEvent, state);
+
+    // Set transfer budget to 0
+    const brokeState: GameState = {
+      ...withManager,
+      club: { ...withManager.club, transferBudget: 0 },
+    };
+
+    const result = handleCommand({ type: 'SACK_MANAGER' }, brokeState);
+    expect(result.error?.code).toBe('INSUFFICIENT_BUDGET');
+  });
+});
+
+// ── Match sim — manager experience ───────────────────────────────────────────
+
+describe('Match sim — manager experience contribution', () => {
+  it('experienced manager increases teamStrength modifier vs no manager', () => {
+    const base = makeMinimalClub({ manager: null });
+    const experienced = makeMinimalClub({
+      manager: makeManager({ attributes: { tactical: 50, motivation: 50, experience: 100 } }),
+    });
+
+    const teamWithout = clubToTeam(base);
+    const teamWith = clubToTeam(experienced);
+
+    expect(teamWith.teamStrength).toBeGreaterThan(teamWithout.teamStrength);
+  });
+
+  it('zero-experience manager contributes no experience bonus', () => {
+    const base = makeMinimalClub({ manager: null });
+    const zeroExp = makeMinimalClub({
+      manager: makeManager({ attributes: { tactical: 50, motivation: 50, experience: 0 } }),
+    });
+
+    // tacticalAmplifier = 0.5 + 50/100 = 1.0 → no training focus (no focus set)
+    // experience = 0 → no experience bonus
+    // So teamStrength should be equal
+    const teamWithout = clubToTeam(base);
+    const teamWith = clubToTeam(zeroExp);
+
+    expect(teamWith.teamStrength).toBeCloseTo(teamWithout.teamStrength, 5);
+  });
+});
+
+// ── Match sim — manager tactical amplifies training focus ────────────────────
+
+describe('Match sim — tactical amplifies training focus', () => {
+  it('high tactical manager produces greater ATTACKING bonus than low tactical', () => {
+    const highTactical = makeMinimalClub({
+      trainingFocus: 'ATTACKING',
+      manager: makeManager({ attributes: { tactical: 100, motivation: 50, experience: 0 } }),
+    });
+    const lowTactical = makeMinimalClub({
+      trainingFocus: 'ATTACKING',
+      manager: makeManager({ attributes: { tactical: 0, motivation: 50, experience: 0 } }),
+    });
+
+    const teamHigh = clubToTeam(highTactical);
+    const teamLow = clubToTeam(lowTactical);
+
+    expect(teamHigh.attackStrength).toBeGreaterThan(teamLow.attackStrength);
+  });
+
+  it('tactical=50 produces same attack as no manager (neutral amplifier)', () => {
+    const noManager = makeMinimalClub({ trainingFocus: 'ATTACKING', manager: null });
+    const neutralManager = makeMinimalClub({
+      trainingFocus: 'ATTACKING',
+      manager: makeManager({ attributes: { tactical: 50, motivation: 50, experience: 0 } }),
+    });
+
+    const teamNoMgr = clubToTeam(noManager);
+    const teamNeutral = clubToTeam(neutralManager);
+
+    // Both should use amplifier=1.0 → identical attackStrength
+    expect(teamNeutral.attackStrength).toBeCloseTo(teamNoMgr.attackStrength, 5);
+  });
+
+  it('DEFENSIVE focus: high tactical raises defenceStrength', () => {
+    const highTactical = makeMinimalClub({
+      trainingFocus: 'DEFENSIVE',
+      manager: makeManager({ attributes: { tactical: 100, motivation: 50, experience: 0 } }),
+    });
+    const lowTactical = makeMinimalClub({
+      trainingFocus: 'DEFENSIVE',
+      manager: makeManager({ attributes: { tactical: 0, motivation: 50, experience: 0 } }),
+    });
+
+    const high = clubToTeam(highTactical);
+    const low = clubToTeam(lowTactical);
+
+    expect(high.defenceStrength).toBeGreaterThan(low.defenceStrength);
+  });
+});
+
+// ── Weekly morale nudge ───────────────────────────────────────────────────────
+
+describe('Manager motivation — weekly morale nudge', () => {
+  it('high motivation manager increases squad morale each week', () => {
+    const state = makeStartedState();
+    const managerId = state.managerPool.find(
+      m => m.attributes.motivation >= 75
+    )?.id;
+    if (!managerId) return; // skip if no such manager in pool
+
+    const withManager = handleCommand({ type: 'HIRE_MANAGER', managerId }, state)
+      .events!.reduce(reduceEvent, state);
+
+    const beforeMorale = withManager.club.squad.reduce((s, p) => s + p.morale, 0);
+
+    // Advance a week
+    const afterWeek = reduceEvent(withManager, {
+      type: 'WEEK_ADVANCED',
+      timestamp: Date.now(),
+      week: 1,
+      season: 1,
+    });
+
+    const afterMorale = afterWeek.club.squad.reduce((s, p) => s + p.morale, 0);
+    expect(afterMorale).toBeGreaterThanOrEqual(beforeMorale);
+  });
+
+  it('no manager → morale unchanged by week advance (no nudge)', () => {
+    const state = makeStartedState();
+    // Ensure no manager
+    expect(state.club.manager).toBeNull();
+
+    const moraleBefore = state.club.squad.reduce((s, p) => s + p.morale, 0);
+
+    const afterWeek = reduceEvent(state, {
+      type: 'WEEK_ADVANCED',
+      timestamp: Date.now(),
+      week: 1,
+      season: 1,
+    });
+
+    const moraleAfter = afterWeek.club.squad.reduce((s, p) => s + p.morale, 0);
+    // No manager = no morale nudge
+    expect(moraleAfter).toBe(moraleBefore);
+  });
+
+  it('motivation=50 manager produces zero morale delta', () => {
+    const state = makeStartedState();
+    // Find a manager with motivation exactly 50, or skip
+    const neutralMgr = state.managerPool.find(m => m.attributes.motivation === 50);
+    if (!neutralMgr) return;
+
+    const withManager = handleCommand({ type: 'HIRE_MANAGER', managerId: neutralMgr.id }, state)
+      .events!.reduce(reduceEvent, state);
+
+    const moraleBefore = withManager.club.squad.reduce((s, p) => s + p.morale, 0);
+    const afterWeek = reduceEvent(withManager, {
+      type: 'WEEK_ADVANCED', timestamp: Date.now(), week: 1, season: 1,
+    });
+    const moraleAfter = afterWeek.club.squad.reduce((s, p) => s + p.morale, 0);
+    expect(moraleAfter).toBe(moraleBefore);
+  });
+
+  it('morale is clamped to [0, 100]', () => {
+    // Manager with motivation=0 — squad morale should not go below 0
+    const state = makeStartedState();
+    const lowMoraleMgr = state.managerPool.find(m => m.attributes.motivation <= 25);
+    if (!lowMoraleMgr) return;
+
+    // Set all squad morale to 0
+    const zeroMoraleState: GameState = {
+      ...state,
+      club: {
+        ...state.club,
+        squad: state.club.squad.map(p => ({ ...p, morale: 0 })),
+        manager: { ...lowMoraleMgr, contractExpiresWeek: 52 },
+      },
+    };
+
+    const afterWeek = reduceEvent(zeroMoraleState, {
+      type: 'WEEK_ADVANCED', timestamp: Date.now(), week: 1, season: 1,
+    });
+
+    for (const p of afterWeek.club.squad) {
+      expect(p.morale).toBeGreaterThanOrEqual(0);
+      expect(p.morale).toBeLessThanOrEqual(100);
+    }
+  });
+});

--- a/packages/domain/src/__tests__/match.test.ts
+++ b/packages/domain/src/__tests__/match.test.ts
@@ -148,6 +148,7 @@ describe('clubToTeam', () => {
       trainingFocus: null,
       preferredFormation: null,
       squadCapacity: 24,
+      manager: null,
     };
 
     const team = clubToTeam(club);
@@ -179,6 +180,7 @@ describe('clubToTeam', () => {
       trainingFocus: null,
       preferredFormation: null,
       squadCapacity: 24,
+      manager: null,
     };
 
     const team = clubToTeam(club);
@@ -203,6 +205,7 @@ describe('clubToTeam', () => {
       trainingFocus: null,
       preferredFormation: null,
       squadCapacity: 24,
+      manager: null,
     };
 
     const winningClub: Club = { ...baseClub, form: ['W', 'W', 'W', 'W', 'W'] };

--- a/packages/domain/src/__tests__/reducer-match.test.ts
+++ b/packages/domain/src/__tests__/reducer-match.test.ts
@@ -43,6 +43,7 @@ function makeState(entries: LeagueTableEntry[], playerClubId: string = 'club-1')
       trainingFocus: null,
       preferredFormation: null,
       squadCapacity: 24,
+      manager: null,
     },
     league: {
       entries,
@@ -62,6 +63,7 @@ function makeState(entries: LeagueTableEntry[], playerClubId: string = 'club-1')
     resolvedEventHistory: [],
     season: 1,
     freeAgentPool: [],
+    managerPool: [],
   };
 }
 

--- a/packages/domain/src/__tests__/type-utils.test.ts
+++ b/packages/domain/src/__tests__/type-utils.test.ts
@@ -98,6 +98,7 @@ describe('calculateClubStrength', () => {
       trainingFocus: null,
       preferredFormation: null,
       squadCapacity: 24,
+      manager: null,
     };
     // No squad → calculateSquadStrength crashes on division by zero? Let me check...
     // Actually: totalRating / squad.length = 0/0 = NaN → Math.floor(NaN * 100) = NaN
@@ -124,6 +125,7 @@ describe('calculateClubStrength', () => {
       trainingFocus: null,
       preferredFormation: null,
       squadCapacity: 24,
+      manager: null,
     };
     const strength = calculateClubStrength(club);
     // squadStrength = floor(70 * 100) = 7000
@@ -147,6 +149,7 @@ describe('calculateClubStrength', () => {
       trainingFocus: null,
       preferredFormation: null,
       squadCapacity: 24,
+      manager: null,
     };
     const strength = calculateClubStrength(club);
     // squadStrength = 7000, staffBonus = 0, facilityBonus = 3 * 50 = 150, reputationBonus = 0

--- a/packages/domain/src/commands/handlers.ts
+++ b/packages/domain/src/commands/handlers.ts
@@ -42,6 +42,10 @@ export function handleCommand(command: GameCommand, state: GameState): CommandRe
       return handleSignFreeAgent(command, state);
     case 'RELEASE_PLAYER':
       return handleReleasePlayer(command, state);
+    case 'HIRE_MANAGER':
+      return handleHireManager(command, state);
+    case 'SACK_MANAGER':
+      return handleSackManager(command, state);
     default:
       return {
         error: {
@@ -591,6 +595,96 @@ function handleReleasePlayer(command: any, state: GameState): CommandResult {
       clubId: state.club.id,
       releaseFee,
     }
+  ];
+
+  return { events };
+}
+
+function handleHireManager(command: any, state: GameState): CommandResult {
+  // Find manager in pool
+  const manager = state.managerPool.find(m => m.id === command.managerId);
+  if (!manager) {
+    return {
+      error: {
+        code: 'PLAYER_NOT_FOUND',
+        message: `Manager '${command.managerId}' not found in pool`,
+      },
+    };
+  }
+
+  // Check whether we can afford the weekly wage
+  const currentTotalWages =
+    state.club.squad.reduce((sum, p) => sum + p.wage, 0) +
+    state.club.staff.reduce((sum, s) => sum + s.salary, 0) +
+    (state.club.manager ? state.club.manager.wage : 0);
+
+  if (manager.wage > state.club.wageBudget - currentTotalWages) {
+    return {
+      error: {
+        code: 'INSUFFICIENT_BUDGET',
+        message: `Manager wage exceeds remaining weekly wage budget`,
+      },
+    };
+  }
+
+  // Sack existing manager first (no compensation in pre-season — mutual consent)
+  const events: GameEvent[] = [];
+  if (state.club.manager) {
+    events.push({
+      type: 'MANAGER_SACKED',
+      timestamp: Date.now(),
+      clubId: state.club.id,
+      managerId: state.club.manager.id,
+      compensationPaid: 0,
+    });
+  }
+
+  const contractExpiresWeek = state.currentWeek + manager.contractLengthWeeks;
+
+  events.push({
+    type: 'MANAGER_HIRED',
+    timestamp: Date.now(),
+    clubId: state.club.id,
+    manager,
+    contractExpiresWeek,
+  });
+
+  return { events };
+}
+
+function handleSackManager(_command: any, state: GameState): CommandResult {
+  if (!state.club.manager) {
+    return {
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: `No manager to sack`,
+      },
+    };
+  }
+
+  const manager = state.club.manager;
+  // Compensation: half of remaining contracted wages
+  const weeksRemaining = Math.max(0, manager.contractExpiresWeek - state.currentWeek);
+  const compensationPaid = Math.round(weeksRemaining * manager.wage * 0.5);
+
+  // Check club can afford compensation
+  if (compensationPaid > state.club.transferBudget) {
+    return {
+      error: {
+        code: 'INSUFFICIENT_BUDGET',
+        message: `Cannot afford sacking compensation of ${compensationPaid} pence`,
+      },
+    };
+  }
+
+  const events: GameEvent[] = [
+    {
+      type: 'MANAGER_SACKED',
+      timestamp: Date.now(),
+      clubId: state.club.id,
+      managerId: manager.id,
+      compensationPaid,
+    },
   ];
 
   return { events };

--- a/packages/domain/src/commands/types.ts
+++ b/packages/domain/src/commands/types.ts
@@ -21,7 +21,9 @@ export type GameCommand =
   | SetTrainingFocusCommand
   | SetFormationCommand
   | SignFreeAgentCommand
-  | ReleasePlayerCommand;
+  | ReleasePlayerCommand
+  | HireManagerCommand
+  | SackManagerCommand;
 
 export interface MakeTransferCommand {
   type: 'MAKE_TRANSFER';
@@ -91,6 +93,15 @@ export interface SignFreeAgentCommand {
 export interface ReleasePlayerCommand {
   type: 'RELEASE_PLAYER';
   playerId: string;
+}
+
+export interface HireManagerCommand {
+  type: 'HIRE_MANAGER';
+  managerId: string;
+}
+
+export interface SackManagerCommand {
+  type: 'SACK_MANAGER';
 }
 
 export interface CommandResult {

--- a/packages/domain/src/data/manager-generator.ts
+++ b/packages/domain/src/data/manager-generator.ts
@@ -1,0 +1,127 @@
+/**
+ * Manager Pool Generator
+ *
+ * Generates a pool of 8 available managers from a seed.
+ * Deterministic — same seed always produces the same pool.
+ *
+ * Three tiers:
+ *   Elite (2)   — high experience, high wages, well-rounded
+ *   Mid (3)     — specialist strength (high tactical or high motivation), moderate wages
+ *   Budget (3)  — low stats, low wages — stepping-stone option
+ *
+ * All names are fictional lower-league gaffer archetypes.
+ */
+
+import { Manager, ManagerAttributes } from '../types/staff';
+import { createRng, Rng } from '../simulation/rng';
+
+// ─── Manager name pool ─────────────────────────────────────────────────────────
+
+const MANAGER_NAMES: string[] = [
+  'Terry Boulton',
+  'Graham Nix',
+  'Phil Stanwick',
+  'Dave Corrigan',
+  'Steve Outhwaite',
+  'Mick Farron',
+  'Paul Hendry',
+  'Kevin Saddler',
+  'Ray Trotter',
+  'Brian Colwell',
+  'Neil Asprey',
+  'Andy Marshfield',
+  'Chris Dunwell',
+  'Martin Chalk',
+  'Gary Pennick',
+  'Bob Ashbridge',
+];
+
+// ─── Tier definitions ─────────────────────────────────────────────────────────
+
+interface ManagerTier {
+  count: number;
+  /** Attribute range [min, max] for each stat */
+  tacticalRange: [number, number];
+  motivationRange: [number, number];
+  experienceRange: [number, number];
+  /** Weekly wage range in pence */
+  wageRange: [number, number];
+  contractLengthWeeks: number;
+}
+
+const TIERS: ManagerTier[] = [
+  // Elite — two managers. High across the board, expensive.
+  {
+    count: 2,
+    tacticalRange: [70, 90],
+    motivationRange: [65, 85],
+    experienceRange: [75, 95],
+    wageRange: [400_000, 700_000],   // £4,000–£7,000/wk
+    contractLengthWeeks: 104,        // 2 seasons
+  },
+  // Mid-tier — three managers. One stat dominates. Affordable.
+  {
+    count: 3,
+    tacticalRange: [45, 75],
+    motivationRange: [45, 75],
+    experienceRange: [45, 75],
+    wageRange: [150_000, 350_000],   // £1,500–£3,500/wk
+    contractLengthWeeks: 52,         // 1 season
+  },
+  // Budget — three managers. Low stats, very cheap.
+  {
+    count: 3,
+    tacticalRange: [20, 50],
+    motivationRange: [20, 50],
+    experienceRange: [15, 45],
+    wageRange: [50_000, 130_000],    // £500–£1,300/wk
+    contractLengthWeeks: 52,
+  },
+];
+
+// ─── Generator ────────────────────────────────────────────────────────────────
+
+function randInt(rng: Rng, min: number, max: number): number {
+  return Math.round(min + rng.next() * (max - min));
+}
+
+/**
+ * Generate the pool of 8 available managers, deterministic from seed.
+ * Managers are sorted worst-to-best (budget first, elite last) so the UI
+ * can present them in a sensible order.
+ */
+export function generateManagerPool(seed: string): Manager[] {
+  const rng = createRng(`managers-${seed}`);
+  const namePool = [...MANAGER_NAMES];
+  const managers: Manager[] = [];
+  let idCounter = 1;
+
+  for (const tier of TIERS) {
+    for (let i = 0; i < tier.count; i++) {
+      // Pick a unique name
+      const nameIdx = randInt(rng, 0, namePool.length - 1);
+      const name = namePool.splice(nameIdx, 1)[0];
+
+      const attributes: ManagerAttributes = {
+        tactical:    randInt(rng, tier.tacticalRange[0],    tier.tacticalRange[1]),
+        motivation:  randInt(rng, tier.motivationRange[0],  tier.motivationRange[1]),
+        experience:  randInt(rng, tier.experienceRange[0],  tier.experienceRange[1]),
+      };
+
+      const wage = randInt(rng, tier.wageRange[0], tier.wageRange[1]);
+      // Round wage to nearest £100 (10_000 pence)
+      const roundedWage = Math.round(wage / 10_000) * 10_000;
+
+      managers.push({
+        id: `mgr-${idCounter++}`,
+        name,
+        attributes,
+        wage: roundedWage,
+        contractLengthWeeks: tier.contractLengthWeeks,
+        contractExpiresWeek: 0, // set on hire
+      });
+    }
+  }
+
+  return managers;
+}

--- a/packages/domain/src/events/types.ts
+++ b/packages/domain/src/events/types.ts
@@ -6,7 +6,7 @@
  */
 
 import { Player } from '../types/player';
-import { Staff } from '../types/staff';
+import { Staff, Manager } from '../types/staff';
 import { PendingClubEvent } from '../types/game-state-updated';
 import { TrainingFocus } from '../types/facility';
 import { Formation } from '../types/formation';
@@ -30,7 +30,9 @@ export type GameEvent =
   | FormationSetEvent
   | FreeAgentSignedEvent
   | PlayerReleasedEvent
-  | NpcPlayerSignedEvent;
+  | NpcPlayerSignedEvent
+  | ManagerHiredEvent
+  | ManagerSackedEvent;
 
 export interface TransferCompletedEvent {
   type: 'TRANSFER_COMPLETED';
@@ -203,4 +205,22 @@ export interface NpcPlayerSignedEvent {
   npcClubId: string;
   npcClubName: string;
   player: Player;
+}
+
+export interface ManagerHiredEvent {
+  type: 'MANAGER_HIRED';
+  timestamp: number;
+  clubId: string;
+  manager: Manager;
+  /** Week the contract expires */
+  contractExpiresWeek: number;
+}
+
+export interface ManagerSackedEvent {
+  type: 'MANAGER_SACKED';
+  timestamp: number;
+  clubId: string;
+  managerId: string;
+  /** Compensation paid in pence */
+  compensationPaid: number;
 }

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -36,6 +36,7 @@ export * from './data/league-two-teams';
 export * from './data/club-events';
 export * from './data/squad-generator';
 export * from './data/free-agent-generator';
+export * from './data/manager-generator';
 
 // Core state types
 export * from './types/game-state-updated';

--- a/packages/domain/src/reducers/index.ts
+++ b/packages/domain/src/reducers/index.ts
@@ -4,7 +4,7 @@
  * Pure functions that apply events to state.
  */
 
-import { GameEvent, GameStartedEvent, MatchSimulatedEvent, TransferCompletedEvent, StaffHiredEvent, MathAttemptRecordedEvent, ClubEventOccurredEvent, ClubEventResolvedEvent, SeasonStartedEvent, TrainingFocusSetEvent, FormationSetEvent, FreeAgentSignedEvent, PlayerReleasedEvent, NpcPlayerSignedEvent } from '../events/types';
+import { GameEvent, GameStartedEvent, MatchSimulatedEvent, TransferCompletedEvent, StaffHiredEvent, MathAttemptRecordedEvent, ClubEventOccurredEvent, ClubEventResolvedEvent, SeasonStartedEvent, TrainingFocusSetEvent, FormationSetEvent, FreeAgentSignedEvent, PlayerReleasedEvent, NpcPlayerSignedEvent, ManagerHiredEvent, ManagerSackedEvent } from '../events/types';
 import { GameState } from '../types/game-state-updated';
 import { Club } from '../types/club';
 import { LeagueTable, LeagueTableEntry, sortLeagueTable } from '../types/league';
@@ -13,6 +13,7 @@ import { LEAGUE_TWO_TEAMS } from '../data/league-two-teams';
 import { getDefaultFacilities, getUpgradeCost } from '../types/facility';
 import { generateStartingSquad } from '../data/squad-generator';
 import { generateFreeAgentPool } from '../data/free-agent-generator';
+import { generateManagerPool } from '../data/manager-generator';
 
 /**
  * Reduce an event into state
@@ -57,6 +58,10 @@ export function reduceEvent(state: GameState, event: GameEvent): GameState {
       return handlePlayerReleased(state, event);
     case 'NPC_PLAYER_SIGNED':
       return handleNpcPlayerSigned(state, event);
+    case 'MANAGER_HIRED':
+      return handleManagerHired(state, event);
+    case 'MANAGER_SACKED':
+      return handleManagerSacked(state, event);
     default:
       return state;
   }
@@ -94,6 +99,7 @@ export function buildState(events: GameEvent[]): GameState {
     resolvedEventHistory: [],
     season: 1,
     freeAgentPool: [],
+    managerPool: [],
   };
 
   return events.reduce(reduceEvent, initialState);
@@ -149,6 +155,9 @@ function handleGameStarted(state: GameState, event: GameStartedEvent): GameState
   // Generate the free agent pool for the season
   const freeAgentPool = generateFreeAgentPool(event.seed);
 
+  // Generate the manager pool for the season
+  const managerPool = generateManagerPool(event.seed);
+
   return {
     ...state,
     phase: 'PRE_SEASON',
@@ -161,12 +170,14 @@ function handleGameStarted(state: GameState, event: GameStartedEvent): GameState
       facilities: getDefaultFacilities(),
       squad: inheritedSquad,
       squadCapacity: 24,
+      manager: null,
     },
     league: {
       ...state.league,
       entries: sortedEntries
     },
     freeAgentPool,
+    managerPool,
   };
 }
 
@@ -388,12 +399,27 @@ function handleWeekAdvanced(state: GameState, event: any): GameState {
     phase = 'LATE_SEASON';
   }
 
+  // Manager motivation nudges squad morale each week.
+  // motivation=50 → 0/wk  |  motivation=100 → +2/wk  |  motivation=0 → −2/wk
+  // Rounds to integer: steps of 1 at 25/75, steps of 2 at 0/100.
+  let squad = state.club.squad;
+  if (state.club.manager && state.club.squad.length > 0) {
+    const moraleDelta = Math.round((state.club.manager.attributes.motivation - 50) / 25);
+    if (moraleDelta !== 0) {
+      squad = squad.map(p => ({
+        ...p,
+        morale: Math.max(0, Math.min(100, p.morale + moraleDelta)),
+      }));
+    }
+  }
+
   return {
     ...state,
     currentWeek: week,
     phase,
     club: {
       ...state.club,
+      squad,
       transferBudget: state.club.transferBudget + weeklyRevenue,
     }
   };
@@ -518,6 +544,30 @@ function handleNpcPlayerSigned(state: GameState, event: NpcPlayerSignedEvent): G
   };
 }
 
+function handleManagerHired(state: GameState, event: ManagerHiredEvent): GameState {
+  return {
+    ...state,
+    // Remove from pool once hired
+    managerPool: state.managerPool.filter(m => m.id !== event.manager.id),
+    club: {
+      ...state.club,
+      manager: { ...event.manager, contractExpiresWeek: event.contractExpiresWeek },
+    },
+  };
+}
+
+function handleManagerSacked(state: GameState, event: ManagerSackedEvent): GameState {
+  return {
+    ...state,
+    club: {
+      ...state.club,
+      manager: null,
+      // Compensation comes out of transfer budget
+      transferBudget: state.club.transferBudget - event.compensationPaid,
+    },
+  };
+}
+
 // Utility functions
 
 function createEmptyClub(): Club {
@@ -540,6 +590,7 @@ function createEmptyClub(): Club {
     trainingFocus: null,
     preferredFormation: null,
     squadCapacity: 24,
+    manager: null,
   };
 }
 

--- a/packages/domain/src/simulation/match.ts
+++ b/packages/domain/src/simulation/match.ts
@@ -165,23 +165,32 @@ export function clubToTeam(club: Club): Team {
   const { attack, defence } = calculatePositionalStrengths(club.squad);
   const { modifier, fanZoneBonus } = calculateTeamModifier(club);
 
-  // Apply training focus multipliers after base calculation
+  // Apply training focus multipliers after base calculation.
+  //
+  // Manager tactical attribute amplifies how well the focus translates to results:
+  //   tactical=0   → amplifier 0.5  (focus half as effective — poor communication)
+  //   tactical=50  → amplifier 1.0  (neutral, baseline)
+  //   tactical=100 → amplifier 1.5  (50% more effective — elite implementer)
+  //   no manager   → amplifier 1.0  (no penalty, no bonus)
   let attackStrength = attack;
   let defenceStrength = defence;
   let teamModifier = modifier;
+  const tacticalAmplifier = club.manager
+    ? 0.5 + club.manager.attributes.tactical / 100
+    : 1.0;
 
   switch (club.trainingFocus) {
     case 'ATTACKING':
-      attackStrength *= 1.05;
+      attackStrength *= 1 + 0.05 * tacticalAmplifier;
       break;
     case 'DEFENSIVE':
-      defenceStrength *= 1.05;
+      defenceStrength *= 1 + 0.05 * tacticalAmplifier;
       break;
     case 'FITNESS':
-      teamModifier += 0.03;
+      teamModifier += 0.03 * tacticalAmplifier;
       break;
     case 'SET_PIECES':
-      attackStrength *= 1.03;
+      attackStrength *= 1 + 0.03 * tacticalAmplifier;
       break;
     case 'YOUTH_INTEGRATION':
       // No match effect — developmental benefit accrues over the season
@@ -279,12 +288,15 @@ function calculatePositionalStrengths(squad: Player[]): {
  *   Squad avg teamwork  (0–100)   → +0.00 to +0.08
  *   TRAINING_GROUND level (0–5)   → +0.00 to +0.50  ← primary performance lever
  *   Staff avg quality   (0–100)   → +0.00 to +0.12
+ *   Manager experience  (0–100)   → +0.00 to +0.06
  *   Reputation          (0–100)   → +0.00 to +0.08
  *   Form last 5 (W/D/L)           → W=+0.02, D=0, L=−0.02 each
  *   Squad avg morale    (0–100)   → −0.05 to +0.05 (centred at 50)
  *   FAN_ZONE level (0–5)          → +0.00 to +0.05 (home only, returned separately)
  *
- * Theoretical max before clamping: 1.0+0.08+0.50+0.12+0.08+0.10+0.05+0.05 = 1.98 → clamped to 1.30
+ * Note: Manager tactical attribute amplifies training focus in clubToTeam (not here).
+ *
+ * Theoretical max before clamping: 1.0+0.08+0.50+0.12+0.06+0.08+0.10+0.05+0.05 = 2.04 → clamped to 1.30
  * Facilities NOT in the modifier: STADIUM, COMMERCIAL, F&B (revenue), MEDICAL_CENTER (injury),
  *   YOUTH_ACADEMY (development), GROUNDS_SECURITY (attendance/reputation).
  */
@@ -312,6 +324,13 @@ function calculateTeamModifier(club: Club): {
     const avgQuality =
       club.staff.reduce((sum, s) => sum + s.quality, 0) / club.staff.length;
     modifier += (avgQuality / 100) * 0.12;
+  }
+
+  // Manager experience (0–100) → +0.00 to +0.06
+  // A seasoned manager gets more from the same resources.
+  // (Tactical impact is handled in clubToTeam via training focus amplification.)
+  if (club.manager) {
+    modifier += (club.manager.attributes.experience / 100) * 0.06;
   }
 
   // Reputation (0–100) → +0.00 to +0.08

--- a/packages/domain/src/types/club.ts
+++ b/packages/domain/src/types/club.ts
@@ -4,7 +4,7 @@
 
 import { Player } from './player';
 import { Facility, TrainingFocus } from './facility';
-import { Staff } from './staff';
+import { Staff, Manager } from './staff';
 import { Formation } from './formation';
 
 /**
@@ -46,6 +46,9 @@ export interface Club {
 
   /** Total squad slots available (capped at 24) */
   squadCapacity: number;
+
+  /** Currently hired manager (null = no manager appointed) */
+  manager: Manager | null;
 }
 
 /**

--- a/packages/domain/src/types/game-state-updated.ts
+++ b/packages/domain/src/types/game-state-updated.ts
@@ -10,6 +10,7 @@ import { Club } from './club';
 import { LeagueTable } from './league';
 import { CurriculumConfig } from '../curriculum/curriculum-config';
 import { Player } from './player';
+import { Manager } from './staff';
 
 /**
  * A choice available within a club event
@@ -98,6 +99,9 @@ export interface GameState {
 
   /** Pool of available free agents */
   freeAgentPool: Player[];
+
+  /** Available managers to hire (generated at game start, removed on hire) */
+  managerPool: Manager[];
 }
 
 /**

--- a/packages/domain/src/types/staff.ts
+++ b/packages/domain/src/types/staff.ts
@@ -2,13 +2,51 @@
  * Staff-related types
  */
 
-export type StaffRole = 
+export type StaffRole =
   | 'MANAGER'
   | 'ATTACKING_COACH'
   | 'DEFENSIVE_COACH'
   | 'FITNESS_COACH'
   | 'YOUTH_COACH'
   | 'PHYSIO';
+
+/**
+ * Manager attributes — three independent ratings (0-100).
+ *
+ * tactical:    How well the manager translates the owner's training focus
+ *              into match performance. High tactical managers amplify the
+ *              training focus bonus; poor ones dampen it.
+ *
+ * motivation:  Weekly morale nudge applied to all players.
+ *              motivation=50 → neutral (±0/wk)
+ *              motivation=100 → +2 morale/wk across the squad
+ *              motivation=0   → −2 morale/wk across the squad
+ *
+ * experience:  Base team modifier contribution — seasoned managers just
+ *              get more out of the same resources.
+ *              experience=100 → +0.06 modifier (same ceiling as staff quality).
+ */
+export interface ManagerAttributes {
+  tactical: number;
+  motivation: number;
+  experience: number;
+}
+
+/**
+ * Manager — hired by the owner to run the playing side.
+ * Distinct from Staff (coaches): one manager per club, unlimited staff.
+ */
+export interface Manager {
+  id: string;
+  name: string;
+  attributes: ManagerAttributes;
+  /** Weekly wage in pence */
+  wage: number;
+  /** Contract duration in weeks (for display) */
+  contractLengthWeeks: number;
+  /** Absolute week the contract expires (set on hire) */
+  contractExpiresWeek: number;
+}
 
 export interface Staff {
   id: string;

--- a/packages/frontend/src/components/pre-season/ManagerPicker.tsx
+++ b/packages/frontend/src/components/pre-season/ManagerPicker.tsx
@@ -1,0 +1,150 @@
+import { Manager, formatMoney } from '@calculating-glory/domain';
+
+interface ManagerPickerProps {
+  managers: Manager[];
+  selected: Manager | null;
+  onSelect: (manager: Manager) => void;
+  wageBudgetRemaining: number;
+}
+
+/**
+ * Stat bar — 0-100 value rendered as a narrow filled bar.
+ */
+function StatBar({ value, label }: { value: number; label: string }) {
+  const pct = Math.round(value);
+  const colour =
+    pct >= 70 ? 'bg-pitch-green' :
+    pct >= 45 ? 'bg-warn-amber' :
+    'bg-alert-red';
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-xs text-txt-muted w-20 shrink-0">{label}</span>
+      <div className="flex-1 h-1.5 bg-bg-raised rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all ${colour}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-xs font-mono text-txt-muted w-6 text-right">{pct}</span>
+    </div>
+  );
+}
+
+function ManagerCard({
+  manager,
+  selected,
+  affordable,
+  onSelect,
+}: {
+  manager: Manager;
+  selected: boolean;
+  affordable: boolean;
+  onSelect: () => void;
+}) {
+  const avgRating = Math.round(
+    (manager.attributes.tactical +
+      manager.attributes.motivation +
+      manager.attributes.experience) /
+      3
+  );
+
+  const tier =
+    avgRating >= 70 ? { label: 'Elite', colour: 'text-data-blue' } :
+    avgRating >= 50 ? { label: 'Experienced', colour: 'text-warn-amber' } :
+    { label: 'Journeyman', colour: 'text-txt-muted' };
+
+  return (
+    <button
+      onClick={affordable ? onSelect : undefined}
+      disabled={!affordable}
+      className={[
+        'w-full text-left p-4 rounded-card border transition-all',
+        selected
+          ? 'border-data-blue bg-data-blue/10'
+          : affordable
+            ? 'border-white/10 bg-bg-surface hover:border-white/20 hover:bg-bg-raised'
+            : 'border-white/5 bg-bg-surface opacity-50 cursor-not-allowed',
+      ].join(' ')}
+    >
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold text-txt-primary">{manager.name}</span>
+            <span className={`text-xs ${tier.colour}`}>{tier.label}</span>
+          </div>
+          <div className="text-xs text-txt-muted mt-0.5">
+            {formatMoney(manager.wage)}/wk
+            <span className="mx-1.5 text-white/20">·</span>
+            {manager.contractLengthWeeks / 52} season contract
+            {!affordable && (
+              <span className="ml-2 text-alert-red">over budget</span>
+            )}
+          </div>
+        </div>
+        {selected && (
+          <div className="w-5 h-5 rounded-full bg-data-blue flex items-center justify-center shrink-0 mt-0.5">
+            <svg className="w-3 h-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+              <path
+                fillRule="evenodd"
+                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <StatBar value={manager.attributes.tactical} label="Tactical" />
+        <StatBar value={manager.attributes.motivation} label="Motivation" />
+        <StatBar value={manager.attributes.experience} label="Experience" />
+      </div>
+    </button>
+  );
+}
+
+export function ManagerPicker({
+  managers,
+  selected,
+  onSelect,
+  wageBudgetRemaining,
+}: ManagerPickerProps) {
+  // Sort: elite first (highest avg), then mid, then budget
+  const sorted = [...managers].sort((a, b) => {
+    const avgA = (a.attributes.tactical + a.attributes.motivation + a.attributes.experience) / 3;
+    const avgB = (b.attributes.tactical + b.attributes.motivation + b.attributes.experience) / 3;
+    return avgB - avgA;
+  });
+
+  return (
+    <div className="space-y-3">
+      <div className="bg-bg-surface rounded-card p-4 border border-white/5 text-sm text-txt-muted space-y-1">
+        <p>
+          <span className="text-txt-primary font-medium">Tactical</span> — determines how
+          effectively your training focus translates on match day.
+        </p>
+        <p>
+          <span className="text-txt-primary font-medium">Motivation</span> — affects squad morale
+          week-on-week. A poor motivator will quietly erode performance.
+        </p>
+        <p>
+          <span className="text-txt-primary font-medium">Experience</span> — base performance boost.
+          Seasoned managers get more out of the same squad.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        {sorted.map(manager => (
+          <ManagerCard
+            key={manager.id}
+            manager={manager}
+            selected={selected?.id === manager.id}
+            affordable={manager.wage <= wageBudgetRemaining}
+            onSelect={() => onSelect(manager)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/pre-season/PreSeasonScreen.tsx
+++ b/packages/frontend/src/components/pre-season/PreSeasonScreen.tsx
@@ -1,24 +1,39 @@
 import { useState } from 'react';
-import { GameState, GameCommand, Formation, formatMoney } from '@calculating-glory/domain';
+import { GameState, GameCommand, Formation, Manager, formatMoney } from '@calculating-glory/domain';
 import { FormationPicker } from './FormationPicker';
 import { InheritedSquad } from './InheritedSquad';
+import { ManagerPicker } from './ManagerPicker';
 
 interface PreSeasonScreenProps {
   state: GameState;
   dispatch: (command: GameCommand) => { error?: string };
 }
 
-type Step = 'formation' | 'squad';
+type Step = 'formation' | 'manager' | 'squad';
+
+const STEP_LABELS: Record<Step, string> = {
+  formation: 'Formation',
+  manager: 'Appoint Manager',
+  squad: 'Your Squad',
+};
+
+const STEPS: Step[] = ['formation', 'manager', 'squad'];
 
 export function PreSeasonScreen({ state, dispatch }: PreSeasonScreenProps) {
   const [step, setStep] = useState<Step>('formation');
   const [pendingFormation, setPendingFormation] = useState<Formation | null>(
     state.club.preferredFormation
   );
+  const [pendingManager, setPendingManager] = useState<Manager | null>(
+    state.club.manager
+  );
   const [error, setError] = useState<string | null>(null);
 
   const { club } = state;
-  const totalWages = club.squad.reduce((s, p) => s + p.wage, 0);
+  const totalWages = club.squad.reduce((s, p) => s + p.wage, 0)
+    + club.staff.reduce((s, st) => s + st.salary, 0)
+    + (club.manager ? club.manager.wage : 0);
+  const wageBudgetRemaining = club.wageBudget - totalWages;
 
   function confirmFormation() {
     if (!pendingFormation) return;
@@ -26,14 +41,33 @@ export function PreSeasonScreen({ state, dispatch }: PreSeasonScreenProps) {
     if (result.error) {
       setError(result.error);
     } else {
+      setError(null);
+      setStep('manager');
+    }
+  }
+
+  function confirmManager() {
+    if (!pendingManager) return;
+    const result = dispatch({ type: 'HIRE_MANAGER', managerId: pendingManager.id });
+    if (result.error) {
+      setError(result.error);
+    } else {
+      setError(null);
       setStep('squad');
     }
+  }
+
+  function skipManager() {
+    setError(null);
+    setStep('squad');
   }
 
   function beginSeason() {
     const result = dispatch({ type: 'START_SEASON', season: 1 });
     if (result.error) setError(result.error);
   }
+
+  const stepIndex = STEPS.indexOf(step);
 
   return (
     <div className="min-h-screen bg-bg-deep flex flex-col">
@@ -58,15 +92,15 @@ export function PreSeasonScreen({ state, dispatch }: PreSeasonScreenProps) {
       {/* Step indicator */}
       <div className="bg-bg-surface border-b border-white/5 px-4 py-2">
         <div className="max-w-2xl mx-auto flex gap-1">
-          {(['formation', 'squad'] as Step[]).map((s, i) => (
+          {STEPS.map((s, i) => (
             <button
               key={s}
-              onClick={() => step === 'squad' && s === 'formation' ? setStep(s) : undefined}
+              onClick={() => i < stepIndex ? setStep(s) : undefined}
               className={[
                 'flex items-center gap-2 px-3 py-1.5 rounded-tag text-xs font-medium transition-colors',
                 step === s
                   ? 'bg-data-blue/20 text-data-blue'
-                  : i < (['formation', 'squad'] as Step[]).indexOf(step)
+                  : i < stepIndex
                     ? 'text-txt-muted hover:text-txt-primary cursor-pointer'
                     : 'text-txt-muted/40 cursor-default',
               ].join(' ')}
@@ -74,7 +108,7 @@ export function PreSeasonScreen({ state, dispatch }: PreSeasonScreenProps) {
               <span className="w-4 h-4 rounded-full border flex items-center justify-center text-xs2 border-current">
                 {i + 1}
               </span>
-              {s === 'formation' ? 'Formation' : 'Your Squad'}
+              {STEP_LABELS[s]}
             </button>
           ))}
         </div>
@@ -84,9 +118,9 @@ export function PreSeasonScreen({ state, dispatch }: PreSeasonScreenProps) {
       <div className="flex-1 overflow-y-auto">
         <div className="max-w-2xl mx-auto px-4 py-6 space-y-6">
 
+          {/* ── Formation ── */}
           {step === 'formation' && (
             <>
-              {/* Narrative */}
               <div className="bg-bg-surface rounded-card p-5 border border-white/5">
                 <div className="flex items-start gap-3">
                   <div className="text-2xl mt-0.5">🏟️</div>
@@ -131,8 +165,81 @@ export function PreSeasonScreen({ state, dispatch }: PreSeasonScreenProps) {
             </>
           )}
 
+          {/* ── Manager ── */}
+          {step === 'manager' && (
+            <>
+              <div className="bg-bg-surface rounded-card p-5 border border-white/5">
+                <div className="flex items-start gap-3">
+                  <div className="text-2xl mt-0.5">🤝</div>
+                  <div>
+                    <h2 className="text-base font-bold text-txt-primary mb-2">
+                      Appoint a Manager
+                    </h2>
+                    <p className="text-sm text-txt-muted leading-relaxed">
+                      You're the owner — you set the strategy, budget and formation. The manager
+                      turns your instructions into results on the pitch. A good tactical manager
+                      makes your training focus count; a strong motivator keeps morale up through
+                      a long season.
+                    </p>
+                    <p className="text-sm text-txt-muted leading-relaxed mt-2">
+                      Wage budget remaining:{' '}
+                      <span className={wageBudgetRemaining > 0 ? 'text-txt-primary font-medium' : 'text-alert-red font-medium'}>
+                        {formatMoney(wageBudgetRemaining)}/wk
+                      </span>
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <ManagerPicker
+                managers={state.managerPool}
+                selected={pendingManager}
+                onSelect={setPendingManager}
+                wageBudgetRemaining={wageBudgetRemaining}
+              />
+
+              {error && (
+                <p className="text-sm text-alert-red bg-alert-red/10 rounded-card px-4 py-2">{error}</p>
+              )}
+
+              <div className="flex gap-3">
+                <button
+                  onClick={skipManager}
+                  className="flex-1 py-3 rounded-card font-semibold text-sm bg-bg-raised text-txt-muted hover:text-txt-primary transition-all"
+                >
+                  Skip for now
+                </button>
+                <button
+                  onClick={confirmManager}
+                  disabled={!pendingManager}
+                  className={[
+                    'flex-1 py-3 rounded-card font-semibold text-sm transition-all',
+                    pendingManager
+                      ? 'bg-data-blue text-white hover:bg-data-blue/90'
+                      : 'bg-bg-raised text-txt-muted/40 cursor-not-allowed',
+                  ].join(' ')}
+                >
+                  {pendingManager ? `Appoint ${pendingManager.name.split(' ')[1]} →` : 'Select a manager'}
+                </button>
+              </div>
+            </>
+          )}
+
+          {/* ── Squad ── */}
           {step === 'squad' && (
             <>
+              {club.manager && (
+                <div className="bg-bg-surface rounded-card px-4 py-3 border border-white/5 flex items-center gap-3">
+                  <div className="text-lg">🤝</div>
+                  <div className="text-sm text-txt-muted">
+                    Manager:{' '}
+                    <span className="text-txt-primary font-medium">{club.manager.name}</span>
+                    <span className="mx-1.5 text-white/20">·</span>
+                    {formatMoney(club.manager.wage)}/wk
+                  </div>
+                </div>
+              )}
+
               <InheritedSquad
                 squad={club.squad}
                 formation={club.preferredFormation}


### PR DESCRIPTION
## Summary

- Adds a `Manager` type with `tactical`, `motivation`, and `experience` attributes; `managerPool: Manager[]` to `GameState`; `manager: Manager | null` to `Club`
- Implements `HIRE_MANAGER` and `SACK_MANAGER` commands with full budget validation and sacking compensation (50% of remaining contract wages)
- Manager attributes feed into match sim: `experience` adds a base team modifier, `tactical` amplifies training-focus bonuses, `motivation` nudges player morale ±1 each week
- Deterministic `generateManagerPool` (8 managers, 3 tiers) seeded from game seed
- Pre-season flow extended from 2 → 3 steps: Formation → **Appoint Manager** → Your Squad, with `ManagerPicker` component (stat bars, tier labels, affordability gating)

## Test plan

- [ ] All 305 domain tests pass (`npm test` in `packages/domain`)
- [ ] Pre-season: select formation → confirm → manager step renders 8 cards with stat bars
- [ ] Select a manager, confirm → squad step shows manager banner, header wage updates
- [ ] Skip manager → squad step reached without error
- [ ] `SACK_MANAGER` deducts correct compensation from transfer budget
- [ ] TypeScript clean (`npx tsc --noEmit` in `packages/frontend`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)