### PR TITLE
feat: Phase 5.6 — sell squad players to NPC clubs (#31)

### DIFF
--- a/packages/domain/src/__tests__/sell-to-npc.test.ts
+++ b/packages/domain/src/__tests__/sell-to-npc.test.ts
@@ -1,0 +1,190 @@
+/**
+ * SELL_PLAYER_TO_NPC Tests
+ *
+ * Covers command validation, fee calculation, event shape, and reducer effects.
+ */
+
+import { handleCommand } from '../commands/handlers';
+import { buildState, reduceEvent } from '../reducers';
+import { GameState } from '../types/game-state-updated';
+import { GameStartedEvent, PlayerSoldEvent } from '../events/types';
+import { Player } from '../types/player';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const gameStartedEvent: GameStartedEvent = {
+  type: 'GAME_STARTED',
+  timestamp: 1000,
+  clubId: 'player-club',
+  clubName: 'Test FC',
+  initialBudget: 500_000_000,
+  difficulty: 'MEDIUM',
+  seed: 'sell-test-seed',
+};
+
+/** A mid-range squad player with transferValue set */
+const squadPlayer: Player = {
+  id: 'player-1',
+  name: 'Dale Hutchins',
+  overallRating: 62,
+  position: 'MID',
+  wage: 100_000,
+  transferValue: 1_500_000,
+  age: 26,
+  morale: 70,
+  attributes: { attack: 55, defence: 50, teamwork: 60, charisma: 45, publicPotential: 65 },
+  truePotential: 68,
+  contractExpiresWeek: 46,
+  stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 62 },
+};
+
+/** A signed free agent — transferValue is 0, fee computed from OVR */
+const freeAgentPlayer: Player = {
+  id: 'player-2',
+  name: 'Connor Farrell',
+  overallRating: 70,
+  position: 'FWD',
+  wage: 150_000,
+  transferValue: 0,
+  age: 24,
+  morale: 75,
+  attributes: { attack: 72, defence: 30, teamwork: 65, charisma: 50, publicPotential: 78 },
+  truePotential: 75,
+  contractExpiresWeek: 50,
+  stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 70 },
+};
+
+function stateWithSquad(players: Player[]): GameState {
+  const base = buildState([gameStartedEvent]);
+  return { ...base, club: { ...base.club, squad: players } };
+}
+
+// ─── handleCommand: SELL_PLAYER_TO_NPC ────────────────────────────────────────
+
+describe('SELL_PLAYER_TO_NPC command', () => {
+  it('returns PLAYER_SOLD event on valid sale', () => {
+    const state = stateWithSquad([squadPlayer]);
+    const result = handleCommand(
+      { type: 'SELL_PLAYER_TO_NPC', playerId: 'player-1', npcClubId: 'swinton' },
+      state,
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.events).toHaveLength(1);
+    expect(result.events![0].type).toBe('PLAYER_SOLD');
+  });
+
+  it('event carries correct fee (transferValue when > 0)', () => {
+    const state = stateWithSquad([squadPlayer]);
+    const result = handleCommand(
+      { type: 'SELL_PLAYER_TO_NPC', playerId: 'player-1', npcClubId: 'swinton' },
+      state,
+    );
+    const evt = result.events![0] as PlayerSoldEvent;
+    expect(evt.fee).toBe(1_500_000);
+  });
+
+  it('event carries correct fee derived from OVR when transferValue is 0', () => {
+    const state = stateWithSquad([freeAgentPlayer]);
+    const result = handleCommand(
+      { type: 'SELL_PLAYER_TO_NPC', playerId: 'player-2', npcClubId: 'bradfield' },
+      state,
+    );
+    const evt = result.events![0] as PlayerSoldEvent;
+    // fee = OVR * OVR * 500 = 70 * 70 * 500 = 2_450_000
+    expect(evt.fee).toBe(2_450_000);
+  });
+
+  it('event carries playerName and npcClubName', () => {
+    const state = stateWithSquad([squadPlayer]);
+    const result = handleCommand(
+      { type: 'SELL_PLAYER_TO_NPC', playerId: 'player-1', npcClubId: 'swinton' },
+      state,
+    );
+    const evt = result.events![0] as PlayerSoldEvent;
+    expect(evt.playerName).toBe('Dale Hutchins');
+    expect(evt.npcClubName).toBe('Swinton Town');
+    expect(evt.npcClubId).toBe('swinton');
+  });
+
+  it('errors when player not in squad', () => {
+    const state = stateWithSquad([]);
+    const result = handleCommand(
+      { type: 'SELL_PLAYER_TO_NPC', playerId: 'nobody', npcClubId: 'swinton' },
+      state,
+    );
+    expect(result.error?.code).toBe('PLAYER_NOT_FOUND');
+  });
+
+  it('errors when NPC club does not exist', () => {
+    const state = stateWithSquad([squadPlayer]);
+    const result = handleCommand(
+      { type: 'SELL_PLAYER_TO_NPC', playerId: 'player-1', npcClubId: 'nonexistent-club' },
+      state,
+    );
+    expect(result.error?.code).toBe('VALIDATION_FAILED');
+  });
+
+  it('errors when trying to sell to own club', () => {
+    const state = stateWithSquad([squadPlayer]);
+    const result = handleCommand(
+      { type: 'SELL_PLAYER_TO_NPC', playerId: 'player-1', npcClubId: 'player-club' },
+      state,
+    );
+    expect(result.error?.code).toBe('VALIDATION_FAILED');
+  });
+});
+
+// ─── Reducer: PLAYER_SOLD ─────────────────────────────────────────────────────
+
+describe('PLAYER_SOLD reducer', () => {
+  it('removes sold player from squad', () => {
+    const state = stateWithSquad([squadPlayer, freeAgentPlayer]);
+    const evt: PlayerSoldEvent = {
+      type: 'PLAYER_SOLD',
+      timestamp: Date.now(),
+      playerId: 'player-1',
+      clubId: 'player-club',
+      fee: 1_500_000,
+      playerName: 'Dale Hutchins',
+      npcClubId: 'swinton',
+      npcClubName: 'Swinton Town',
+    };
+    const next = reduceEvent(state, evt);
+    expect(next.club.squad).toHaveLength(1);
+    expect(next.club.squad[0].id).toBe('player-2');
+  });
+
+  it('credits transfer fee to transfer budget', () => {
+    const state = stateWithSquad([squadPlayer]);
+    const budgetBefore = state.club.transferBudget;
+    const evt: PlayerSoldEvent = {
+      type: 'PLAYER_SOLD',
+      timestamp: Date.now(),
+      playerId: 'player-1',
+      clubId: 'player-club',
+      fee: 1_500_000,
+    };
+    const next = reduceEvent(state, evt);
+    expect(next.club.transferBudget).toBe(budgetBefore + 1_500_000);
+  });
+});
+
+// ─── Round-trip: command → reduce ─────────────────────────────────────────────
+
+describe('SELL_PLAYER_TO_NPC round-trip', () => {
+  it('squad shrinks and budget grows after full command → reduce cycle', () => {
+    const state = stateWithSquad([squadPlayer]);
+    const budgetBefore = state.club.transferBudget;
+
+    const result = handleCommand(
+      { type: 'SELL_PLAYER_TO_NPC', playerId: 'player-1', npcClubId: 'crowley' },
+      state,
+    );
+
+    expect(result.error).toBeUndefined();
+    const finalState = result.events!.reduce(reduceEvent, state);
+
+    expect(finalState.club.squad).toHaveLength(0);
+    expect(finalState.club.transferBudget).toBe(budgetBefore + 1_500_000);
+  });
+});

--- a/packages/domain/src/commands/handlers.ts
+++ b/packages/domain/src/commands/handlers.ts
@@ -46,6 +46,8 @@ export function handleCommand(command: GameCommand, state: GameState): CommandRe
       return handleHireManager(command, state);
     case 'SACK_MANAGER':
       return handleSackManager(command, state);
+    case 'SELL_PLAYER_TO_NPC':
+      return handleSellPlayerToNpc(command, state);
     default:
       return {
         error: {
@@ -684,6 +686,60 @@ function handleSackManager(_command: any, state: GameState): CommandResult {
       clubId: state.club.id,
       managerId: manager.id,
       compensationPaid,
+    },
+  ];
+
+  return { events };
+}
+
+function handleSellPlayerToNpc(command: any, state: GameState): CommandResult {
+  // Validate player is in squad
+  const player = state.club.squad.find(p => p.id === command.playerId);
+  if (!player) {
+    return {
+      error: {
+        code: 'PLAYER_NOT_FOUND',
+        message: `Player '${command.playerId}' not found in squad`,
+      },
+    };
+  }
+
+  // Validate buying club exists
+  const buyingClub = LEAGUE_TWO_TEAMS.find(t => t.id === command.npcClubId);
+  if (!buyingClub) {
+    return {
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: `NPC club '${command.npcClubId}' not found`,
+      },
+    };
+  }
+
+  // Buying club cannot be the player's own club
+  if (command.npcClubId === state.club.id) {
+    return {
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: `Cannot sell a player to your own club`,
+      },
+    };
+  }
+
+  // Fee: use player's transferValue if set, otherwise derive from overallRating
+  const fee = player.transferValue > 0
+    ? player.transferValue
+    : Math.max(10_000, player.overallRating * player.overallRating * 500);
+
+  const events: GameEvent[] = [
+    {
+      type: 'PLAYER_SOLD',
+      timestamp: Date.now(),
+      playerId: player.id,
+      clubId: state.club.id,
+      fee,
+      playerName: player.name,
+      npcClubId: buyingClub.id,
+      npcClubName: buyingClub.name,
     },
   ];
 

--- a/packages/domain/src/commands/types.ts
+++ b/packages/domain/src/commands/types.ts
@@ -23,7 +23,8 @@ export type GameCommand =
   | SignFreeAgentCommand
   | ReleasePlayerCommand
   | HireManagerCommand
-  | SackManagerCommand;
+  | SackManagerCommand
+  | SellPlayerToNpcCommand;
 
 export interface MakeTransferCommand {
   type: 'MAKE_TRANSFER';
@@ -102,6 +103,13 @@ export interface HireManagerCommand {
 
 export interface SackManagerCommand {
   type: 'SACK_MANAGER';
+}
+
+export interface SellPlayerToNpcCommand {
+  type: 'SELL_PLAYER_TO_NPC';
+  playerId: string;
+  /** ID of the buying NPC club (from LEAGUE_TWO_TEAMS) */
+  npcClubId: string;
 }
 
 export interface CommandResult {

--- a/packages/domain/src/events/types.ts
+++ b/packages/domain/src/events/types.ts
@@ -115,6 +115,12 @@ export interface PlayerSoldEvent {
   playerId: string;
   clubId: string;
   fee: number; // in pence
+  /** Name of the sold player (for news ticker) */
+  playerName?: string;
+  /** Buying NPC club ID */
+  npcClubId?: string;
+  /** Buying NPC club name (for news ticker) */
+  npcClubName?: string;
 }
 
 export interface StaffFiredEvent {

--- a/packages/frontend/src/components/command-centre/NewsTicker.tsx
+++ b/packages/frontend/src/components/command-centre/NewsTicker.tsx
@@ -27,7 +27,12 @@ function buildHeadlines(
     } else if (e.type === 'TRANSFER_COMPLETED') {
       headlines.push(`Transfer: ${e.player.name} joins the squad`);
     } else if (e.type === 'PLAYER_SOLD') {
-      headlines.push(`Departure: Player sold for ${(e.fee / 100).toLocaleString('en-GB', { style: 'currency', currency: 'GBP', maximumFractionDigits: 0 })}`);
+      const fee = (e.fee / 100).toLocaleString('en-GB', { style: 'currency', currency: 'GBP', maximumFractionDigits: 0 });
+      if (e.playerName && e.npcClubName) {
+        headlines.push(`${e.playerName} joins ${e.npcClubName} for ${fee}`);
+      } else {
+        headlines.push(`Departure: Player sold for ${fee}`);
+      }
     } else if (e.type === 'FACILITY_UPGRADED') {
       headlines.push(`Facility upgraded: ${e.facilityType} → Level ${e.level}`);
     } else if (e.type === 'SEASON_ENDED') {

--- a/packages/frontend/src/components/transfer-market/TransferMarketSlideOver.tsx
+++ b/packages/frontend/src/components/transfer-market/TransferMarketSlideOver.tsx
@@ -6,6 +6,7 @@ import {
   Position,
   formatMoney,
   FORMATION_CONFIG,
+  LEAGUE_TWO_TEAMS,
 } from '@calculating-glory/domain';
 
 // ─── Types ─────────────────────────────────────────────────────────────────────
@@ -191,18 +192,31 @@ function FreeAgentCard({ player, canAfford, hasSquadRoom, onSign }: FreeAgentCar
 interface SquadPlayerCardProps {
   player: Player;
   currentWeek: number;
+  clubId: string;
   onRelease: () => void;
+  onSellToNpc: (npcClubId: string) => void;
 }
 
-function SquadPlayerCard({ player, currentWeek, onRelease }: SquadPlayerCardProps) {
-  const [confirming, setConfirming] = useState(false);
-  const [released, setReleased] = useState(false);
+type SquadAction = 'idle' | 'confirm-release' | 'pick-club' | 'confirm-sell';
+
+function SquadPlayerCard({ player, currentWeek, clubId, onRelease, onSellToNpc }: SquadPlayerCardProps) {
+  const [action, setAction] = useState<SquadAction>('idle');
+  const [selectedClubId, setSelectedClubId] = useState('');
+  const [done, setDone] = useState<'released' | 'sold' | null>(null);
 
   const isFreeAgent = player.contractExpiresWeek === 0;
   const isExpired = !isFreeAgent && currentWeek >= player.contractExpiresWeek;
   const releaseFee = (!isFreeAgent && !isExpired && player.contractExpiresWeek > currentWeek)
     ? Math.round((player.contractExpiresWeek - currentWeek) * player.wage * 0.5)
     : 0;
+
+  const sellFee = player.transferValue > 0
+    ? player.transferValue
+    : Math.max(10_000, player.overallRating * player.overallRating * 500);
+
+  // All 23 NPC clubs (excluding player's own club)
+  const npcClubs = LEAGUE_TWO_TEAMS.filter(t => t.id !== clubId);
+  const selectedClub = npcClubs.find(t => t.id === selectedClubId);
 
   function contractBadge() {
     if (isFreeAgent) {
@@ -215,15 +229,21 @@ function SquadPlayerCard({ player, currentWeek, onRelease }: SquadPlayerCardProp
     return <span className="text-[10px] text-txt-muted">Wk {player.contractExpiresWeek} ({weeksLeft}wk left)</span>;
   }
 
-  function releaseLabel() {
-    if (releaseFee > 0) return `Release (${formatMoney(releaseFee)} fee)`;
-    return 'Release (free)';
+  function handleConfirmRelease() {
+    onRelease();
+    setDone('released');
+    setAction('idle');
   }
 
-  function handleConfirm() {
-    onRelease();
-    setReleased(true);
-    setConfirming(false);
+  function handleConfirmSell() {
+    onSellToNpc(selectedClubId);
+    setDone('sold');
+    setAction('idle');
+  }
+
+  function cancel() {
+    setAction('idle');
+    setSelectedClubId('');
   }
 
   return (
@@ -257,34 +277,57 @@ function SquadPlayerCard({ player, currentWeek, onRelease }: SquadPlayerCardProp
         <AttrBar label="POT" value={player.attributes.publicPotential} colour="bg-purple-400" />
       </div>
 
-      {/* Release action */}
-      {released ? (
+      {/* Actions */}
+      {done === 'released' ? (
         <div className="text-xs text-warn-amber font-semibold">Released</div>
-      ) : confirming ? (
+      ) : done === 'sold' ? (
+        <div className="text-xs text-pitch-green font-semibold">Sold for {formatMoney(sellFee)}</div>
+      ) : action === 'confirm-release' ? (
         <div className="flex items-center gap-2 flex-wrap text-xs">
           <span className="text-txt-muted">
-            Release {player.name}{releaseFee > 0 ? ` (${formatMoney(releaseFee)} compensation)` : ' for free'}?
+            Release {player.name}{releaseFee > 0 ? ` (${formatMoney(releaseFee)} fee)` : ' for free'}?
           </span>
-          <button
-            onClick={handleConfirm}
-            className="px-2 py-0.5 bg-alert-red/20 text-alert-red border border-alert-red/40 rounded hover:bg-alert-red/30 transition-colors"
+          <button onClick={handleConfirmRelease} className="px-2 py-0.5 bg-alert-red/20 text-alert-red border border-alert-red/40 rounded hover:bg-alert-red/30 transition-colors">Yes</button>
+          <button onClick={cancel} className="px-2 py-0.5 bg-white/5 text-txt-muted border border-white/10 rounded hover:bg-white/10 transition-colors">Cancel</button>
+        </div>
+      ) : action === 'pick-club' ? (
+        <div className="flex flex-col gap-1.5 text-xs">
+          <span className="text-txt-muted">Sell to club for <span className="text-pitch-green font-semibold">{formatMoney(sellFee)}</span>:</span>
+          <select
+            value={selectedClubId}
+            onChange={e => { setSelectedClubId(e.target.value); setAction('confirm-sell'); }}
+            className="bg-bg-raised text-txt-primary text-xs border border-white/10 rounded px-2 py-1 focus:outline-none"
           >
-            Yes
-          </button>
-          <button
-            onClick={() => setConfirming(false)}
-            className="px-2 py-0.5 bg-white/5 text-txt-muted border border-white/10 rounded hover:bg-white/10 transition-colors"
-          >
-            Cancel
-          </button>
+            <option value="">— pick a club —</option>
+            {npcClubs.map(t => (
+              <option key={t.id} value={t.id}>{t.name}</option>
+            ))}
+          </select>
+          <button onClick={cancel} className="text-txt-muted hover:text-txt-primary transition-colors text-left">Cancel</button>
+        </div>
+      ) : action === 'confirm-sell' ? (
+        <div className="flex items-center gap-2 flex-wrap text-xs">
+          <span className="text-txt-muted">
+            Sell {player.name} to {selectedClub?.name} for <span className="text-pitch-green font-semibold">{formatMoney(sellFee)}</span>?
+          </span>
+          <button onClick={handleConfirmSell} className="px-2 py-0.5 bg-pitch-green/20 text-pitch-green border border-pitch-green/40 rounded hover:bg-pitch-green/30 transition-colors">Confirm</button>
+          <button onClick={() => setAction('pick-club')} className="px-2 py-0.5 bg-white/5 text-txt-muted border border-white/10 rounded hover:bg-white/10 transition-colors">Back</button>
         </div>
       ) : (
-        <button
-          onClick={() => setConfirming(true)}
-          className="w-full text-xs py-1.5 rounded bg-alert-red/10 text-alert-red border border-alert-red/30 hover:bg-alert-red/20 transition-colors"
-        >
-          {releaseLabel()}
-        </button>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setAction('pick-club')}
+            className="flex-1 text-xs py-1.5 rounded bg-pitch-green/10 text-pitch-green border border-pitch-green/30 hover:bg-pitch-green/20 transition-colors"
+          >
+            Sell ({formatMoney(sellFee)})
+          </button>
+          <button
+            onClick={() => setAction('confirm-release')}
+            className="flex-1 text-xs py-1.5 rounded bg-alert-red/10 text-alert-red border border-alert-red/30 hover:bg-alert-red/20 transition-colors"
+          >
+            {releaseFee > 0 ? `Release (${formatMoney(releaseFee)} fee)` : 'Release (free)'}
+          </button>
+        </div>
       )}
     </div>
   );
@@ -330,6 +373,11 @@ export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMa
 
   function handleRelease(playerId: string) {
     const result = dispatch({ type: 'RELEASE_PLAYER', playerId });
+    if (result.error) onError(result.error);
+  }
+
+  function handleSellToNpc(playerId: string, npcClubId: string) {
+    const result = dispatch({ type: 'SELL_PLAYER_TO_NPC', playerId, npcClubId });
     if (result.error) onError(result.error);
   }
 
@@ -433,7 +481,9 @@ export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMa
                 key={player.id}
                 player={player}
                 currentWeek={state.currentWeek}
+                clubId={state.club.id}
                 onRelease={() => handleRelease(player.id)}
+                onSellToNpc={npcClubId => handleSellToNpc(player.id, npcClubId)}
               />
             ))
           )


### PR DESCRIPTION
## Summary

- Players can now sell any squad member to one of the 23 NPC clubs for a transfer fee
- Fee logic: uses `player.transferValue` if set (inherited squad players); falls back to `OVR² × 500` pence for signed free agents whose transferValue is 0
- Transfer fee is credited immediately to the transfer budget
- Sale appears in the news ticker as "{name} joins {club} for £X"

## Domain changes

| File | Change |
|------|--------|
| `commands/types.ts` | `SellPlayerToNpcCommand { type, playerId, npcClubId }` |
| `events/types.ts` | `PlayerSoldEvent` + `playerName?`, `npcClubId?`, `npcClubName?` |
| `commands/handlers.ts` | `handleSellPlayerToNpc` — validates player in squad, NPC club exists, not own club; emits `PLAYER_SOLD` |
| `reducers/index.ts` | No change — `handlePlayerSold` already removes player and credits fee |
| `__tests__/sell-to-npc.test.ts` | 10 new tests covering validation, fee calc, reducer, round-trip |

## Frontend changes

| File | Change |
|------|--------|
| `TransferMarketSlideOver.tsx` | `SquadPlayerCard` now shows **Sell** + **Release** buttons; sell flow: pick NPC club → confirm → Sold! |
| `NewsTicker.tsx` | `PLAYER_SOLD` headline now reads "{name} joins {club} for £X" |

## Test plan

- [x] 315/315 domain tests green
- [x] TypeScript clean (domain + frontend)
- [ ] Manual: go to Transfer Market → My Squad → sell a player → confirm budget increases
- [ ] Manual: news ticker shows "{name} joins {club} for £X" after sale
- [ ] Manual: sold player no longer appears in My Squad tab

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)