### PR TITLE
feat: Phase 5.7 — season end screen

### DIFF
--- a/packages/domain/src/__tests__/season-flow.test.ts
+++ b/packages/domain/src/__tests__/season-flow.test.ts
@@ -207,3 +207,84 @@ describe('Season Flow: week 46 produces SeasonEndedEvent', () => {
     expect(state.phase).toBe('SEASON_END');
   }, 30000);
 });
+
+describe('Season Flow: BEGIN_NEXT_SEASON command', () => {
+  // Helper: build a state that is in SEASON_END phase
+  function makeSeasonEndState() {
+    const gameStarted = makeGameStarted();
+    const seasonEndedEvent: GameEvent = {
+      type: 'SEASON_ENDED',
+      timestamp: Date.now(),
+      season: 1,
+      finalPosition: 12,
+      promoted: false,
+      relegated: false,
+    };
+    // Manually apply via reducer to land in SEASON_END
+    let state = buildState([gameStarted]);
+    // Inject a WEEK_ADVANCED for week 46 to ensure correct phase (or just directly set via events)
+    state = reduceEvent(state, { type: 'SEASON_STARTED', timestamp: Date.now(), season: 1 });
+    state = reduceEvent(state, seasonEndedEvent);
+    return state;
+  }
+
+  it('emits PRE_SEASON_STARTED with season incremented by 1', () => {
+    const state = makeSeasonEndState();
+    expect(state.phase).toBe('SEASON_END');
+    expect(state.season).toBe(1);
+
+    const result = handleCommand({ type: 'BEGIN_NEXT_SEASON' }, state);
+    expect(result.error).toBeUndefined();
+    expect(result.events).toHaveLength(1);
+    expect(result.events![0].type).toBe('PRE_SEASON_STARTED');
+    const evt = result.events![0] as { type: 'PRE_SEASON_STARTED'; season: number };
+    expect(evt.season).toBe(2);
+  });
+
+  it('fails when phase is not SEASON_END', () => {
+    const gameStarted = makeGameStarted();
+    const state = buildState([gameStarted]);
+    expect(state.phase).toBe('PRE_SEASON');
+
+    const result = handleCommand({ type: 'BEGIN_NEXT_SEASON' }, state);
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe('INVALID_PHASE');
+  });
+
+  it('reducer transitions phase to PRE_SEASON and increments season', () => {
+    const state = makeSeasonEndState();
+    const result = handleCommand({ type: 'BEGIN_NEXT_SEASON' }, state);
+    const newState = reduceEvent(state, result.events![0]);
+
+    expect(newState.phase).toBe('PRE_SEASON');
+    expect(newState.season).toBe(2);
+  });
+
+  it('reducer resets currentWeek to 0', () => {
+    let state = makeSeasonEndState();
+    state = { ...state, currentWeek: 46 };
+    const result = handleCommand({ type: 'BEGIN_NEXT_SEASON' }, state);
+    const newState = reduceEvent(state, result.events![0]);
+
+    expect(newState.currentWeek).toBe(0);
+  });
+
+  it('reducer clears form, trainingFocus, and preferredFormation', () => {
+    let state = makeSeasonEndState();
+    state = {
+      ...state,
+      club: {
+        ...state.club,
+        form: ['W', 'L', 'D'],
+        trainingFocus: 'ATTACKING',
+        preferredFormation: '4-4-2',
+      },
+    };
+    const result = handleCommand({ type: 'BEGIN_NEXT_SEASON' }, state);
+    const newState = reduceEvent(state, result.events![0]);
+
+    expect(newState.club.form).toEqual([]);
+    expect(newState.club.trainingFocus).toBeNull();
+    expect(newState.club.preferredFormation).toBeNull();
+  });
+});

--- a/packages/domain/src/commands/handlers.ts
+++ b/packages/domain/src/commands/handlers.ts
@@ -48,6 +48,8 @@ export function handleCommand(command: GameCommand, state: GameState): CommandRe
       return handleSackManager(command, state);
     case 'SELL_PLAYER_TO_NPC':
       return handleSellPlayerToNpc(command, state);
+    case 'BEGIN_NEXT_SEASON':
+      return handleBeginNextSeason(command, state);
     default:
       return {
         error: {
@@ -744,6 +746,25 @@ function handleSellPlayerToNpc(command: any, state: GameState): CommandResult {
   ];
 
   return { events };
+}
+
+function handleBeginNextSeason(_command: any, state: GameState): CommandResult {
+  if (state.phase !== 'SEASON_END') {
+    return {
+      error: {
+        code: 'INVALID_PHASE',
+        message: `Cannot begin next season from phase '${state.phase}' — must be SEASON_END`,
+      },
+    };
+  }
+
+  return {
+    events: [{
+      type: 'PRE_SEASON_STARTED',
+      timestamp: Date.now(),
+      season: state.season + 1,
+    }],
+  };
 }
 
 function handleRecordMathAttempt(command: any, _state: GameState): CommandResult {

--- a/packages/domain/src/commands/types.ts
+++ b/packages/domain/src/commands/types.ts
@@ -24,7 +24,8 @@ export type GameCommand =
   | ReleasePlayerCommand
   | HireManagerCommand
   | SackManagerCommand
-  | SellPlayerToNpcCommand;
+  | SellPlayerToNpcCommand
+  | BeginNextSeasonCommand;
 
 export interface MakeTransferCommand {
   type: 'MAKE_TRANSFER';
@@ -110,6 +111,10 @@ export interface SellPlayerToNpcCommand {
   playerId: string;
   /** ID of the buying NPC club (from LEAGUE_TWO_TEAMS) */
   npcClubId: string;
+}
+
+export interface BeginNextSeasonCommand {
+  type: 'BEGIN_NEXT_SEASON';
 }
 
 export interface CommandResult {

--- a/packages/domain/src/events/types.ts
+++ b/packages/domain/src/events/types.ts
@@ -32,7 +32,8 @@ export type GameEvent =
   | PlayerReleasedEvent
   | NpcPlayerSignedEvent
   | ManagerHiredEvent
-  | ManagerSackedEvent;
+  | ManagerSackedEvent
+  | PreSeasonStartedEvent;
 
 export interface TransferCompletedEvent {
   type: 'TRANSFER_COMPLETED';
@@ -229,4 +230,11 @@ export interface ManagerSackedEvent {
   managerId: string;
   /** Compensation paid in pence */
   compensationPaid: number;
+}
+
+export interface PreSeasonStartedEvent {
+  type: 'PRE_SEASON_STARTED';
+  timestamp: number;
+  /** The new season number (previous season + 1) */
+  season: number;
 }

--- a/packages/domain/src/reducers/index.ts
+++ b/packages/domain/src/reducers/index.ts
@@ -4,7 +4,7 @@
  * Pure functions that apply events to state.
  */
 
-import { GameEvent, GameStartedEvent, MatchSimulatedEvent, TransferCompletedEvent, StaffHiredEvent, MathAttemptRecordedEvent, ClubEventOccurredEvent, ClubEventResolvedEvent, SeasonStartedEvent, TrainingFocusSetEvent, FormationSetEvent, FreeAgentSignedEvent, PlayerReleasedEvent, NpcPlayerSignedEvent, ManagerHiredEvent, ManagerSackedEvent } from '../events/types';
+import { GameEvent, GameStartedEvent, MatchSimulatedEvent, TransferCompletedEvent, StaffHiredEvent, MathAttemptRecordedEvent, ClubEventOccurredEvent, ClubEventResolvedEvent, SeasonStartedEvent, TrainingFocusSetEvent, FormationSetEvent, FreeAgentSignedEvent, PlayerReleasedEvent, NpcPlayerSignedEvent, ManagerHiredEvent, ManagerSackedEvent, PreSeasonStartedEvent } from '../events/types';
 import { GameState } from '../types/game-state-updated';
 import { Club } from '../types/club';
 import { LeagueTable, LeagueTableEntry, sortLeagueTable } from '../types/league';
@@ -62,6 +62,8 @@ export function reduceEvent(state: GameState, event: GameEvent): GameState {
       return handleManagerHired(state, event);
     case 'MANAGER_SACKED':
       return handleManagerSacked(state, event);
+    case 'PRE_SEASON_STARTED':
+      return handlePreSeasonStarted(state, event);
     default:
       return state;
   }
@@ -564,6 +566,22 @@ function handleManagerSacked(state: GameState, event: ManagerSackedEvent): GameS
       manager: null,
       // Compensation comes out of transfer budget
       transferBudget: state.club.transferBudget - event.compensationPaid,
+    },
+  };
+}
+
+function handlePreSeasonStarted(state: GameState, event: PreSeasonStartedEvent): GameState {
+  return {
+    ...state,
+    phase: 'PRE_SEASON',
+    season: event.season,
+    currentWeek: 0,
+    // Reset form so pre-season starts fresh
+    club: {
+      ...state.club,
+      form: [],
+      trainingFocus: null,
+      preferredFormation: null,
     },
   };
 }

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { CommandCentre } from './components/command-centre/CommandCentre';
 import { StadiumView } from './components/stadium-view/StadiumView';
 import { ViewToggle, ActiveView } from './components/shared/ViewToggle';
 import { PreSeasonScreen } from './components/pre-season/PreSeasonScreen';
+import { SeasonEndScreen } from './components/season-end/SeasonEndScreen';
 
 export default function App() {
   const { state, events, dispatch, isLoading } = useGameState();
@@ -12,6 +13,10 @@ export default function App() {
 
   if (state.phase === 'PRE_SEASON') {
     return <PreSeasonScreen state={state} dispatch={dispatch} />;
+  }
+
+  if (state.phase === 'SEASON_END') {
+    return <SeasonEndScreen state={state} dispatch={dispatch} />;
   }
 
   return (

--- a/packages/frontend/src/components/season-end/SeasonEndScreen.tsx
+++ b/packages/frontend/src/components/season-end/SeasonEndScreen.tsx
@@ -1,0 +1,198 @@
+import { GameState, GameCommand, formatMoney } from '@calculating-glory/domain';
+
+interface SeasonEndScreenProps {
+  state: GameState;
+  dispatch: (command: GameCommand) => { error?: string };
+}
+
+// ─── Outcome helpers ───────────────────────────────────────────────────────────
+
+function getOutcome(position: number, promoted: boolean, relegated: boolean) {
+  if (promoted) return { label: 'PROMOTED', colour: 'text-pitch-green', bg: 'bg-pitch-green/10 border-pitch-green/40', emoji: '🏆' };
+  if (relegated) return { label: 'RELEGATED', colour: 'text-alert-red', bg: 'bg-alert-red/10 border-alert-red/40', emoji: '📉' };
+  if (position <= 7) return { label: 'PLAYOFFS', colour: 'text-warn-amber', bg: 'bg-warn-amber/10 border-warn-amber/40', emoji: '⚔️' };
+  return { label: 'MID-TABLE', colour: 'text-data-blue', bg: 'bg-data-blue/10 border-data-blue/40', emoji: '🤝' };
+}
+
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] ?? s[v] ?? s[0]);
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function SeasonEndScreen({ state, dispatch }: SeasonEndScreenProps) {
+  const { club, league, season } = state;
+
+  // Find the SEASON_ENDED event for final position + promotion/relegation
+  const seasonEndedEvent = [...state.events]
+    .reverse()
+    .find(e => e.type === 'SEASON_ENDED');
+
+  const finalPosition = (seasonEndedEvent as any)?.finalPosition
+    ?? league.entries.find(e => e.clubId === club.id)?.position
+    ?? 0;
+  const promoted: boolean = (seasonEndedEvent as any)?.promoted ?? false;
+  const relegated: boolean = (seasonEndedEvent as any)?.relegated ?? false;
+
+  const outcome = getOutcome(finalPosition, promoted, relegated);
+
+  // Player's club league entry
+  const clubEntry = league.entries.find(e => e.clubId === club.id);
+
+  function handleBeginNextSeason() {
+    dispatch({ type: 'BEGIN_NEXT_SEASON' });
+  }
+
+  return (
+    <div className="min-h-screen bg-bg-deep text-txt-primary flex flex-col">
+
+      {/* ── Header ─────────────────────────────────────────────────────────── */}
+      <div className="px-4 pt-8 pb-4 text-center flex flex-col items-center gap-2">
+        <div className="text-xs font-bold text-txt-muted uppercase tracking-widest">
+          Season {season} Complete
+        </div>
+        <h1 className="text-2xl font-bold text-txt-primary">{club.name}</h1>
+        <div className={`text-4xl font-black mt-1 ${outcome.colour}`}>
+          {outcome.emoji} {outcome.label}
+        </div>
+        <div className="text-lg text-txt-muted">
+          Finished <span className="text-txt-primary font-semibold">{ordinal(finalPosition)}</span> in League Two
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-4 pb-24 flex flex-col gap-4 max-w-2xl mx-auto w-full">
+
+        {/* ── Season stats ───────────────────────────────────────────────── */}
+        {clubEntry && (
+          <div className="bg-bg-raised rounded-card border border-white/5 p-4">
+            <div className="text-xs font-bold text-txt-muted uppercase tracking-widest mb-3">Season Stats</div>
+            <div className="grid grid-cols-4 gap-3 text-center">
+              <div>
+                <div className="text-xl font-bold text-txt-primary">{clubEntry.played}</div>
+                <div className="text-[10px] text-txt-muted uppercase">Played</div>
+              </div>
+              <div>
+                <div className="text-xl font-bold text-pitch-green">{clubEntry.won}</div>
+                <div className="text-[10px] text-txt-muted uppercase">Won</div>
+              </div>
+              <div>
+                <div className="text-xl font-bold text-warn-amber">{clubEntry.drawn}</div>
+                <div className="text-[10px] text-txt-muted uppercase">Drawn</div>
+              </div>
+              <div>
+                <div className="text-xl font-bold text-alert-red">{clubEntry.lost}</div>
+                <div className="text-[10px] text-txt-muted uppercase">Lost</div>
+              </div>
+              <div>
+                <div className="text-xl font-bold text-txt-primary">{clubEntry.goalsFor}</div>
+                <div className="text-[10px] text-txt-muted uppercase">Goals For</div>
+              </div>
+              <div>
+                <div className="text-xl font-bold text-txt-primary">{clubEntry.goalsAgainst}</div>
+                <div className="text-[10px] text-txt-muted uppercase">Goals Against</div>
+              </div>
+              <div>
+                <div className={`text-xl font-bold ${clubEntry.goalDifference >= 0 ? 'text-pitch-green' : 'text-alert-red'}`}>
+                  {clubEntry.goalDifference >= 0 ? '+' : ''}{clubEntry.goalDifference}
+                </div>
+                <div className="text-[10px] text-txt-muted uppercase">GD</div>
+              </div>
+              <div>
+                <div className="text-xl font-bold text-data-blue">{clubEntry.points}</div>
+                <div className="text-[10px] text-txt-muted uppercase">Points</div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ── Club snapshot ──────────────────────────────────────────────── */}
+        <div className="bg-bg-raised rounded-card border border-white/5 p-4">
+          <div className="text-xs font-bold text-txt-muted uppercase tracking-widest mb-3">Club at Season End</div>
+          <div className="grid grid-cols-3 gap-3 text-center">
+            <div>
+              <div className="text-lg font-bold text-pitch-green">{formatMoney(club.transferBudget)}</div>
+              <div className="text-[10px] text-txt-muted uppercase">Transfer Budget</div>
+            </div>
+            <div>
+              <div className="text-lg font-bold text-data-blue">{club.squad.length}</div>
+              <div className="text-[10px] text-txt-muted uppercase">Squad Size</div>
+            </div>
+            <div>
+              <div className="text-lg font-bold text-txt-primary">{club.reputation}</div>
+              <div className="text-[10px] text-txt-muted uppercase">Reputation</div>
+            </div>
+          </div>
+        </div>
+
+        {/* ── Final league table ─────────────────────────────────────────── */}
+        <div className="bg-bg-raised rounded-card border border-white/5 overflow-hidden">
+          <div className="px-4 py-2.5 border-b border-white/5 text-xs font-bold text-txt-muted uppercase tracking-widest">
+            Final Table
+          </div>
+          <div className="divide-y divide-white/5">
+            {league.entries.map(entry => {
+              const isPlayer = entry.clubId === club.id;
+              const isPromo = entry.position <= league.automaticPromotion;
+              const isPlayoff = league.playoffPositions.includes(entry.position);
+              const isRele = league.relegation.includes(entry.position);
+
+              return (
+                <div
+                  key={entry.clubId}
+                  className={`flex items-center gap-3 px-3 py-1.5 text-xs ${
+                    isPlayer ? 'bg-data-blue/10' : ''
+                  }`}
+                >
+                  {/* Position */}
+                  <span className={`w-5 text-right font-bold shrink-0 ${
+                    isPromo ? 'text-pitch-green' :
+                    isPlayoff ? 'text-warn-amber' :
+                    isRele ? 'text-alert-red' :
+                    'text-txt-muted'
+                  }`}>
+                    {entry.position}
+                  </span>
+
+                  {/* Name */}
+                  <span className={`flex-1 truncate ${isPlayer ? 'font-bold text-data-blue' : 'text-txt-primary'}`}>
+                    {entry.clubName}
+                    {isPlayer && <span className="ml-1 text-[10px] text-data-blue/70">★</span>}
+                  </span>
+
+                  {/* Stats */}
+                  <span className="text-txt-muted w-5 text-right">{entry.played}</span>
+                  <span className="text-pitch-green w-5 text-right">{entry.won}</span>
+                  <span className="text-warn-amber w-5 text-right">{entry.drawn}</span>
+                  <span className="text-alert-red w-5 text-right">{entry.lost}</span>
+                  <span className={`w-7 text-right font-bold ${entry.goalDifference >= 0 ? 'text-txt-primary' : 'text-txt-muted'}`}>
+                    {entry.goalDifference >= 0 ? '+' : ''}{entry.goalDifference}
+                  </span>
+                  <span className="text-data-blue font-bold w-6 text-right">{entry.points}</span>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Table key */}
+          <div className="px-4 py-2 border-t border-white/5 flex gap-4 text-[10px] text-txt-muted">
+            <span><span className="text-pitch-green font-bold">■</span> Promotion</span>
+            <span><span className="text-warn-amber font-bold">■</span> Playoff</span>
+            <span><span className="text-alert-red font-bold">■</span> Relegation</span>
+          </div>
+        </div>
+      </div>
+
+      {/* ── CTA ────────────────────────────────────────────────────────────── */}
+      <div className="fixed bottom-0 left-0 right-0 p-4 bg-bg-deep border-t border-white/5">
+        <button
+          onClick={handleBeginNextSeason}
+          className="w-full max-w-2xl mx-auto block py-3 rounded-card bg-data-blue text-white font-bold text-sm hover:bg-data-blue/80 transition-colors"
+        >
+          Begin Pre-Season — Season {season + 1} →
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `SeasonEndScreen` shown when `state.phase === 'SEASON_END'` — outcome banner (promoted/relegated/playoffs/mid-table), season stats grid (P/W/D/L/GF/GA/GD/Pts), club snapshot (budget/squad/reputation), full final league table with colour-coded positions
- New `BEGIN_NEXT_SEASON` command → `PRE_SEASON_STARTED` event; reducer resets to pre-season, increments season, clears form/trainingFocus/preferredFormation
- Wired into `App.tsx` — phase gate before the main game loop

## Test plan

- [ ] 5 new `BEGIN_NEXT_SEASON` tests added to `season-flow.test.ts`
- [ ] 310/310 domain tests passing
- [ ] `tsc --noEmit` clean on frontend
- [ ] Simulate a full season to week 46 → verify season end screen renders
- [ ] Click "Begin Pre-Season" → verify transition back to pre-season screen with season 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)