### PR TITLE
feat: Scout Network facility — truePotential visibility by level

### DIFF
--- a/packages/domain/src/types/facility.ts
+++ b/packages/domain/src/types/facility.ts
@@ -2,6 +2,8 @@
  * Facility-related types
  */
 
+import { Player } from './player';
+
 // ── Training Focus ────────────────────────────────────────────────────────────
 
 export type TrainingFocus =
@@ -63,7 +65,8 @@ export type FacilityType =
   | 'CLUB_COMMERCIAL'
   | 'FOOD_AND_BEVERAGE'
   | 'FAN_ZONE'
-  | 'GROUNDS_SECURITY';
+  | 'GROUNDS_SECURITY'
+  | 'SCOUT_NETWORK';
 
 export interface Facility {
   type: FacilityType;
@@ -80,7 +83,7 @@ export interface Facility {
 
 export interface FacilityBenefit {
   /** What this facility improves */
-  type: 'performance' | 'injury_reduction' | 'youth_quality' | 'revenue' | 'board_confidence' | 'reputation' | 'attendance';
+  type: 'performance' | 'injury_reduction' | 'youth_quality' | 'revenue' | 'board_confidence' | 'reputation' | 'attendance' | 'scouting';
 
   /** Percentage improvement per level */
   improvement: number;
@@ -181,6 +184,15 @@ export const FACILITY_CONFIG: Record<FacilityType, {
     startingLevel: 0,
     upgradeCosts: [15_000_00, 50_000_00, 120_000_00, 300_000_00, 700_000_00],
   },
+  SCOUT_NETWORK: {
+    label: 'Scout Network',
+    icon: '🔭',
+    description: 'Reduces noise on player potential readings. At level 5 you see true potential exactly.',
+    benefitType: 'scouting',
+    improvementPerLevel: 3,
+    startingLevel: 0,
+    upgradeCosts: [15_000_00, 45_000_00, 120_000_00, 300_000_00, 600_000_00],
+  },
 };
 
 /**
@@ -244,4 +256,64 @@ export function calculateFacilityROI(
     benefit: equivalentValue,
     breakEven: 1 // Immediate for performance
   };
+}
+
+// ── Scout Network — potential visibility ──────────────────────────────────────
+
+/**
+ * Maximum noise applied to potential at scout level 0 (±15 points).
+ * Scales linearly to 0 at level 5.
+ */
+const SCOUT_MAX_NOISE = 15;
+
+/**
+ * Deterministic noise offset for a player given the current scout level.
+ *
+ * Uses a simple hash of the player's ID so the same player always shows the
+ * same (wrong) value at a given scout level — upgrading the scout network
+ * sharpens the reading rather than re-rolling it.
+ *
+ * Returns an integer in [-noiseRange, +noiseRange].
+ */
+function scoutNoise(playerId: string, noiseRange: number): number {
+  if (noiseRange === 0) return 0;
+  // Simple deterministic hash: sum char codes mod (2*noiseRange+1), shift to centre
+  let hash = 0;
+  for (let i = 0; i < playerId.length; i++) {
+    hash = (hash * 31 + playerId.charCodeAt(i)) >>> 0;
+  }
+  const span = noiseRange * 2 + 1; // e.g. 31 values for noiseRange=15
+  return (hash % span) - noiseRange;
+}
+
+/**
+ * Returns the displayed potential for a player given the current scout network level (0–5).
+ *
+ * - Level 0: truePotential ± up to 15 (deterministic per player)
+ * - Level 5: truePotential exactly
+ *
+ * Always clamped to [1, 100].
+ */
+export function getScoutedPotential(player: Player, scoutLevel: number): number {
+  const level = Math.max(0, Math.min(5, scoutLevel));
+  const noiseRange = Math.round(SCOUT_MAX_NOISE * (1 - level / 5));
+  const noise = scoutNoise(player.id, noiseRange);
+  return Math.max(1, Math.min(100, player.truePotential + noise));
+}
+
+/**
+ * Returns the noise range (±N) for a given scout level.
+ * Used by the UI to decide how to label the potential display.
+ */
+export function scoutNoiseRange(scoutLevel: number): number {
+  const level = Math.max(0, Math.min(5, scoutLevel));
+  return Math.round(SCOUT_MAX_NOISE * (1 - level / 5));
+}
+
+/**
+ * Returns the scout network level from a club's facilities array.
+ * 0 if the facility is not present or not yet built.
+ */
+export function getScoutLevel(facilities: Facility[]): number {
+  return facilities.find(f => f.type === 'SCOUT_NETWORK')?.level ?? 0;
 }

--- a/packages/frontend/src/components/command-centre/SquadAuditTable.tsx
+++ b/packages/frontend/src/components/command-centre/SquadAuditTable.tsx
@@ -1,5 +1,4 @@
-import { GameState, formatMoney } from '@calculating-glory/domain';
-import { Player } from '@calculating-glory/domain';
+import { GameState, formatMoney, Player, getScoutedPotential, scoutNoiseRange, getScoutLevel } from '@calculating-glory/domain';
 
 interface SquadAuditTableProps {
   state: GameState;
@@ -24,7 +23,7 @@ function MoraleBar({ morale }: { morale: number }) {
   );
 }
 
-function PlayerRow({ player }: { player: Player }) {
+function PlayerRow({ player, scoutLevel }: { player: Player; scoutLevel: number }) {
   const statCol =
     player.position === 'FWD' || player.position === 'MID'
       ? player.stats.goals
@@ -32,11 +31,19 @@ function PlayerRow({ player }: { player: Player }) {
   const statLabel =
     player.position === 'FWD' || player.position === 'MID' ? 'G' : 'CS';
 
+  const noise = scoutNoiseRange(scoutLevel);
+  const scoutedPot = getScoutedPotential(player, scoutLevel);
+  const potPrefix = noise >= 9 ? '~' : noise >= 3 ? '≈' : '';
+  const potClass = noise === 0 ? 'text-purple-400' : noise <= 6 ? 'text-purple-400/60' : 'text-purple-400/35';
+
   return (
     <tr className="border-b border-bg-raised/50 hover:bg-bg-raised/30 transition-colors text-txt-muted">
       <td className="py-1 pr-2 truncate max-w-[130px] text-txt-primary">{player.name}</td>
       <td className={`pr-2 py-1 font-bold ${POS_COLORS[player.position]}`}>{player.position}</td>
       <td className="text-right pr-2 py-1 text-txt-primary font-semibold">{player.overallRating}</td>
+      <td className={`text-right pr-2 py-1 font-semibold ${potClass}`} title={`Scout accuracy: ±${noise}`}>
+        {potPrefix}{scoutedPot}
+      </td>
       <td className="text-right pr-2 py-1">{player.age}</td>
       <td className="text-right pr-2 py-1">{player.stats.appearances}</td>
       <td className="text-right pr-2 py-1">
@@ -58,6 +65,7 @@ function PlayerRow({ player }: { player: Player }) {
 
 export function SquadAuditTable({ state }: SquadAuditTableProps) {
   const { club } = state;
+  const scoutLevel = getScoutLevel(club.facilities);
 
   const sorted = [...club.squad].sort((a, b) => {
     const pa = POSITION_ORDER.indexOf(a.position);
@@ -93,6 +101,7 @@ export function SquadAuditTable({ state }: SquadAuditTableProps) {
               <th className="pb-1 pr-2">Name</th>
               <th className="pb-1 pr-2">Pos</th>
               <th className="text-right pb-1 pr-2 w-8">OVR</th>
+              <th className="text-right pb-1 pr-2 w-8 text-purple-400/60">POT</th>
               <th className="text-right pb-1 pr-2 w-8">Age</th>
               <th className="text-right pb-1 pr-2 w-8">App</th>
               <th className="text-right pb-1 pr-2 w-10">G/CS</th>
@@ -103,7 +112,7 @@ export function SquadAuditTable({ state }: SquadAuditTableProps) {
           </thead>
           <tbody>
             {sorted.map(player => (
-              <PlayerRow key={player.id} player={player} />
+              <PlayerRow key={player.id} player={player} scoutLevel={scoutLevel} />
             ))}
           </tbody>
         </table>

--- a/packages/frontend/src/components/isometric/stadium-layout.ts
+++ b/packages/frontend/src/components/isometric/stadium-layout.ts
@@ -9,7 +9,8 @@
  *   ─────────────────────────────────────────────────────
  *   Training (1,1)      The Pitch (7,2)      Club Office (15,1)
  *   Medical  (1,5)                           Commercial  (15,5)
- *   Youth    (1,9)                           Food & Bev  (15,9)
+ *   Scout    (1,7)                           Food & Bev  (15,9)
+ *   Youth    (1,9)
  *                   Fan Zone (6,11)  Security (11,11)
  *
  * Every facility is represented by exactly one CoreUnitDef.  The STADIUM
@@ -128,6 +129,19 @@ export const STADIUM_LAYOUT: CoreUnitDef[] = [
       base:      '#ECEFF1',
       swPattern: 'url(#pat-concrete)',
       label:     '#263238',
+    },
+  },
+  {
+    id:           'scout',
+    facilityType: 'SCOUT_NETWORK',
+    label:        'Scout Network',
+    icon:         '🔭',
+    gc: 1, gr: 7, cols: 2, rows: 2,
+    blockHeights: [0, 16, 24, 34, 44, 56],
+    colors: {
+      ground: '#0A1A2A',
+      base:   '#1565C0',
+      label:  '#FFFFFF',
     },
   },
   {

--- a/packages/frontend/src/components/transfer-market/TransferMarketSlideOver.tsx
+++ b/packages/frontend/src/components/transfer-market/TransferMarketSlideOver.tsx
@@ -7,6 +7,9 @@ import {
   formatMoney,
   FORMATION_CONFIG,
   LEAGUE_TWO_TEAMS,
+  getScoutedPotential,
+  scoutNoiseRange,
+  getScoutLevel,
 } from '@calculating-glory/domain';
 
 // ─── Types ─────────────────────────────────────────────────────────────────────
@@ -100,16 +103,42 @@ function AttrBar({ label, value, colour }: AttrBarProps) {
   );
 }
 
+// ─── Scouted Potential Bar ──────────────────────────────────────────────────────
+
+function PotBar({ player, scoutLevel }: { player: Player; scoutLevel: number }) {
+  const noise = scoutNoiseRange(scoutLevel);
+  const value = getScoutedPotential(player, scoutLevel);
+
+  // Label prefix signals confidence: ~ = rough, ≈ = close, no prefix = exact
+  const prefix = noise >= 9 ? '~' : noise >= 3 ? '≈' : '';
+  const label  = `${prefix}POT`;
+  const colour = noise === 0 ? 'text-purple-400' : noise <= 6 ? 'text-purple-400/70' : 'text-purple-400/40';
+
+  return (
+    <div className="flex items-center gap-1">
+      <span className={`text-[10px] w-7 shrink-0 ${colour}`}>{label}</span>
+      <div className="h-1.5 bg-white/5 rounded-full overflow-hidden" style={{ width: 80 }}>
+        <div
+          className={`h-full rounded-full bg-purple-400 ${noise > 0 ? 'opacity-50' : 'opacity-100'}`}
+          style={{ width: `${value}%` }}
+        />
+      </div>
+      <span className={`text-[10px] w-5 text-right ${colour}`}>{value}</span>
+    </div>
+  );
+}
+
 // ─── Free Agent Card ───────────────────────────────────────────────────────────
 
 interface FreeAgentCardProps {
   player: Player;
   canAfford: boolean;
   hasSquadRoom: boolean;
+  scoutLevel: number;
   onSign: (wage: number) => void;
 }
 
-function FreeAgentCard({ player, canAfford, hasSquadRoom, onSign }: FreeAgentCardProps) {
+function FreeAgentCard({ player, canAfford, hasSquadRoom, scoutLevel, onSign }: FreeAgentCardProps) {
   const [confirming, setConfirming] = useState(false);
   const [signed, setSigned] = useState(false);
 
@@ -146,7 +175,7 @@ function FreeAgentCard({ player, canAfford, hasSquadRoom, onSign }: FreeAgentCar
         <AttrBar label="DEF" value={player.attributes.defence}  colour="bg-data-blue" />
         <AttrBar label="TMW" value={player.attributes.teamwork} colour="bg-pitch-green" />
         <AttrBar label="CHA" value={player.attributes.charisma} colour="bg-warn-amber" />
-        <AttrBar label="POT" value={player.attributes.publicPotential} colour="bg-purple-400" />
+        <PotBar player={player} scoutLevel={scoutLevel} />
       </div>
 
       {/* Action row */}
@@ -193,13 +222,14 @@ interface SquadPlayerCardProps {
   player: Player;
   currentWeek: number;
   clubId: string;
+  scoutLevel: number;
   onRelease: () => void;
   onSellToNpc: (npcClubId: string) => void;
 }
 
 type SquadAction = 'idle' | 'confirm-release' | 'pick-club' | 'confirm-sell';
 
-function SquadPlayerCard({ player, currentWeek, clubId, onRelease, onSellToNpc }: SquadPlayerCardProps) {
+function SquadPlayerCard({ player, currentWeek, clubId, scoutLevel, onRelease, onSellToNpc }: SquadPlayerCardProps) {
   const [action, setAction] = useState<SquadAction>('idle');
   const [selectedClubId, setSelectedClubId] = useState('');
   const [done, setDone] = useState<'released' | 'sold' | null>(null);
@@ -274,7 +304,7 @@ function SquadPlayerCard({ player, currentWeek, clubId, onRelease, onSellToNpc }
         <AttrBar label="DEF" value={player.attributes.defence}  colour="bg-data-blue" />
         <AttrBar label="TMW" value={player.attributes.teamwork} colour="bg-pitch-green" />
         <AttrBar label="CHA" value={player.attributes.charisma} colour="bg-warn-amber" />
-        <AttrBar label="POT" value={player.attributes.publicPotential} colour="bg-purple-400" />
+        <PotBar player={player} scoutLevel={scoutLevel} />
       </div>
 
       {/* Actions */}
@@ -344,6 +374,7 @@ export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMa
   const remainingWageBudget = state.club.wageBudget - currentTotalWages;
   const squadCount = state.club.squad.length;
   const squadCapacity = state.club.squadCapacity;
+  const scoutLevel = getScoutLevel(state.club.facilities);
 
   // ── Filter + sort free agents ──────────────────────────────────────────────
 
@@ -468,6 +499,7 @@ export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMa
                 player={player}
                 canAfford={player.wage <= remainingWageBudget}
                 hasSquadRoom={squadCount < squadCapacity}
+                scoutLevel={scoutLevel}
                 onSign={wage => handleSign(player.id, wage)}
               />
             ))
@@ -482,6 +514,7 @@ export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMa
                 player={player}
                 currentWeek={state.currentWeek}
                 clubId={state.club.id}
+                scoutLevel={scoutLevel}
                 onRelease={() => handleRelease(player.id)}
                 onSellToNpc={npcClubId => handleSellToNpc(player.id, npcClubId)}
               />


### PR DESCRIPTION
## Summary

- Adds `SCOUT_NETWORK` as a new upgradeable facility (🔭, £15k–£600k to level 5)
- `getScoutedPotential(player, scoutLevel)` returns `truePotential ± deterministic noise` seeded from `player.id` — upgrading the scout sharpens the same player's reading rather than re-rolling it
- Noise range: ±15 at level 0 → ±0 at level 5 (exact true potential)
- `~POT` / `≈POT` / `POT` prefix in TransferMarketSlideOver and SquadAuditTable signals confidence level visually
- Scout Network unit placed at grid `(1,7)` in the isometric stadium renderer — between Medical Centre and Youth Academy

## Test plan

- [ ] Upgrade Scout Network in Stadium View; verify POT readings sharpen across the squad table and transfer market
- [ ] At level 0, confirm `~POT` prefix and faded bar appear on all player cards
- [ ] At level 5, confirm exact `POT` with no prefix and full bar opacity
- [ ] Verify scout unit renders correctly in isometric view at all levels 0–5
- [ ] TypeScript clean: `npx tsc --noEmit` in `packages/frontend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)