### PR TITLE
feat: morale system — result deltas, contract anxiety, threshold events, unsettled debuff

### DIFF
--- a/packages/domain/src/commands/handlers.ts
+++ b/packages/domain/src/commands/handlers.ts
@@ -11,7 +11,7 @@ import { validateTransfer, validateFacilityUpgrade, validateStaffHire } from '..
 import { simulateMatch, clubToTeam, generateAITeam, Team } from '../simulation/match';
 import { generateSeasonFixtures, getWeekFixtures, matchSeed } from '../simulation/season';
 import { createRng } from '../simulation/rng';
-import { generateWeekEvents, generatePoachAttempts } from '../simulation/events';
+import { generateWeekEvents, generatePoachAttempts, generateMoraleThresholdEvents } from '../simulation/events';
 import { LEAGUE_TWO_TEAMS } from '../data/league-two-teams';
 import { Player } from '../types/player';
 
@@ -293,6 +293,24 @@ function handleSimulateWeek(command: any, state: GameState): CommandResult {
       clubId: state.club.id,
       pendingEvent
     });
+  }
+
+  // Generate morale threshold events (0 or 1 per week — only if no other events fired)
+  // Only fires when the inbox would otherwise be clear to avoid stacking.
+  const hasNewEvents = clubEvents.length > 0 || poachEvents.length > 0;
+  if (!hasNewEvents) {
+    const moraleEvents = generateMoraleThresholdEvents(state, week, season);
+    for (const pendingEvent of moraleEvents) {
+      events.push({
+        type: 'CLUB_EVENT_OCCURRED',
+        timestamp: now,
+        eventId: pendingEvent.id,
+        templateId: pendingEvent.templateId,
+        week,
+        clubId: state.club.id,
+        pendingEvent
+      });
+    }
   }
 
   // Advance the week after all matches and events

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -38,6 +38,9 @@ export * from './data/squad-generator';
 export * from './data/free-agent-generator';
 export * from './data/manager-generator';
 
+// Morale system
+export { isUnsettled, avgSquadMorale, UNSETTLED_THRESHOLD } from './simulation/morale';
+
 // Core state types
 export * from './types/game-state-updated';
 export * from './types/club';

--- a/packages/domain/src/reducers/index.ts
+++ b/packages/domain/src/reducers/index.ts
@@ -14,6 +14,13 @@ import { getDefaultFacilities, getUpgradeCost } from '../types/facility';
 import { generateStartingSquad } from '../data/squad-generator';
 import { generateFreeAgentPool } from '../data/free-agent-generator';
 import { generateManagerPool } from '../data/manager-generator';
+import {
+  applyResultMoraleDelta,
+  applyContractAnxiety,
+  applyContagion,
+  applyManagerChangeMorale,
+  avgSquadMorale,
+} from '../simulation/morale';
 
 /**
  * Reduce an event into state
@@ -102,6 +109,8 @@ export function buildState(events: GameEvent[]): GameState {
     season: 1,
     freeAgentPool: [],
     managerPool: [],
+    lowMoraleWeeks: 0,
+    moraleEventCooldowns: {},
   };
 
   return events.reduce(reduceEvent, initialState);
@@ -243,16 +252,30 @@ function handleMatchSimulated(state: GameState, event: MatchSimulatedEvent): Gam
 
   // Update player's club form if they played
   let clubForm = state.club.form;
+  let clubResult: 'W' | 'D' | 'L' | null = null;
   if (state.club.id === homeTeamId) {
+    clubResult = homeResult;
     clubForm = [...clubForm, homeResult].slice(-5);
   } else if (state.club.id === awayTeamId) {
+    clubResult = awayResult;
     clubForm = [...clubForm, awayResult].slice(-5);
+  }
+
+  // Layer 1: result morale delta — applied when the player's club played this fixture
+  let squad = state.club.squad;
+  if (clubResult && squad.length > 0) {
+    const playerEntry   = sorted.find(e => e.clubId === state.club.id);
+    const opponentId    = state.club.id === homeTeamId ? awayTeamId : homeTeamId;
+    const opponentEntry = sorted.find(e => e.clubId === opponentId);
+    const playerPos     = playerEntry?.position   ?? 12;
+    const opponentPos   = opponentEntry?.position ?? 12;
+    squad = applyResultMoraleDelta(squad, clubResult, playerPos, opponentPos, clubForm);
   }
 
   return {
     ...state,
     league: { ...state.league, entries: sorted },
-    club: { ...state.club, form: clubForm }
+    club: { ...state.club, form: clubForm, squad }
   };
 }
 
@@ -405,7 +428,7 @@ function handleWeekAdvanced(state: GameState, event: any): GameState {
   // motivation=50 → 0/wk  |  motivation=100 → +2/wk  |  motivation=0 → −2/wk
   // Rounds to integer: steps of 1 at 25/75, steps of 2 at 0/100.
   let squad = state.club.squad;
-  if (state.club.manager && state.club.squad.length > 0) {
+  if (state.club.manager && squad.length > 0) {
     const moraleDelta = Math.round((state.club.manager.attributes.motivation - 50) / 25);
     if (moraleDelta !== 0) {
       squad = squad.map(p => ({
@@ -415,10 +438,25 @@ function handleWeekAdvanced(state: GameState, event: any): GameState {
     }
   }
 
+  // Layer 2: contract anxiety drain (individual, bypasses manager nudge)
+  if (squad.length > 0) {
+    squad = applyContractAnxiety(squad, week);
+  }
+
+  // Layer 4: contagion — morale-0 players drain their position group
+  if (squad.length > 0) {
+    squad = applyContagion(squad);
+  }
+
+  // Track consecutive low-morale weeks (< 40 avg) for "Losing Faith" threshold
+  const avg = avgSquadMorale(squad);
+  const lowMoraleWeeks = avg < 40 ? (state.lowMoraleWeeks ?? 0) + 1 : 0;
+
   return {
     ...state,
     currentWeek: week,
     phase,
+    lowMoraleWeeks,
     club: {
       ...state.club,
       squad,
@@ -434,9 +472,22 @@ function handleSeasonEnded(state: GameState, _event: any): GameState {
   };
 }
 
+const MORALE_THRESHOLD_TEMPLATE_IDS = new Set([
+  'morale-unrest',
+  'morale-losing-faith',
+  'morale-unsettled-player',
+]);
+
 function handleClubEventOccurred(state: GameState, event: ClubEventOccurredEvent): GameState {
+  // Set a 6-week cooldown for morale threshold events when they fire
+  const templateId = event.pendingEvent.templateId;
+  const moraleEventCooldowns = MORALE_THRESHOLD_TEMPLATE_IDS.has(templateId)
+    ? { ...state.moraleEventCooldowns, [templateId]: event.week + 6 }
+    : state.moraleEventCooldowns;
+
   return {
     ...state,
+    moraleEventCooldowns,
     pendingEvents: [...state.pendingEvents, event.pendingEvent]
   };
 }
@@ -467,13 +518,33 @@ function handleClubEventResolved(state: GameState, event: ClubEventResolvedEvent
     squad = squad.filter(p => p.id !== event.playerRemovedId);
   }
 
-  // Poaching: apply morale delta to target player (clamped 0-100)
+  // Poaching: apply morale delta to specific target player (clamped 0-100)
   if (event.moraleTargetId && event.moraleEffect !== undefined) {
     squad = squad.map(p =>
       p.id === event.moraleTargetId
         ? { ...p, morale: Math.max(0, Math.min(100, p.morale + event.moraleEffect!)) }
         : p
     );
+  }
+
+  // Morale threshold events: apply moraleEffect squad-wide (no target = all players)
+  // Also handles the unsettled-player event's targeted talk/pay-rise (metadata.poachTargetPlayerId)
+  if (!event.moraleTargetId && event.moraleEffect !== undefined) {
+    const targetPlayerId = pendingEvent.metadata?.poachTargetPlayerId;
+    if (targetPlayerId) {
+      // Unsettled player event — apply only to that player
+      squad = squad.map(p =>
+        p.id === targetPlayerId
+          ? { ...p, morale: Math.max(0, Math.min(100, p.morale + event.moraleEffect!)) }
+          : p
+      );
+    } else {
+      // Squad-wide morale events (unrest, losing faith)
+      squad = squad.map(p => ({
+        ...p,
+        morale: Math.max(0, Math.min(100, p.morale + event.moraleEffect!)),
+      }));
+    }
   }
 
   return {
@@ -547,12 +618,17 @@ function handleNpcPlayerSigned(state: GameState, event: NpcPlayerSignedEvent): G
 }
 
 function handleManagerHired(state: GameState, event: ManagerHiredEvent): GameState {
+  // Manager change morale: gravitational pull toward 55 (independent of new manager's attributes)
+  const squad = state.club.squad.length > 0
+    ? applyManagerChangeMorale(state.club.squad)
+    : state.club.squad;
+
   return {
     ...state,
-    // Remove from pool once hired
     managerPool: state.managerPool.filter(m => m.id !== event.manager.id),
     club: {
       ...state.club,
+      squad,
       manager: { ...event.manager, contractExpiresWeek: event.contractExpiresWeek },
     },
   };

--- a/packages/domain/src/simulation/events.ts
+++ b/packages/domain/src/simulation/events.ts
@@ -15,6 +15,7 @@ import { GameState, PendingClubEvent } from '../types/game-state-updated';
 import { CLUB_EVENT_TEMPLATES, ClubEventTemplate } from '../data/club-events';
 import { createRng } from './rng';
 import { LEAGUE_TWO_TEAMS } from '../data/league-two-teams';
+import { avgSquadMorale, isUnsettled } from './morale';
 
 /**
  * Check whether a template's prerequisite has been met in the resolved history.
@@ -260,11 +261,15 @@ export function generatePoachAttempts(
   );
   if (poachPending) return [];
 
-  // Pick a random target, weighted by overallRating
-  const totalWeight = targets.reduce((sum, p) => sum + p.overallRating, 0);
+  // Pick a random target, weighted by overallRating × unsettled multiplier.
+  // Unsettled players (morale < 20) are 3× more likely to be approached.
+  const UNSETTLED_POACH_MULT = 3;
+  const weightOf = (p: typeof targets[0]) =>
+    p.overallRating * (isUnsettled(p) ? UNSETTLED_POACH_MULT : 1);
+  const totalWeight = targets.reduce((sum, p) => sum + weightOf(p), 0);
   let pick = rng.next() * totalWeight;
   const target = targets.find(p => {
-    pick -= p.overallRating;
+    pick -= weightOf(p);
     return pick <= 0;
   }) ?? targets[targets.length - 1];
 
@@ -336,4 +341,158 @@ export function generatePoachAttempts(
   };
 
   return [poachEvent];
+}
+
+// ── Morale threshold events ────────────────────────────────────────────────────
+
+const MORALE_TEMPLATE_IDS = {
+  UNREST:         'morale-unrest',
+  LOSING_FAITH:   'morale-losing-faith',
+  UNSETTLED:      'morale-unsettled-player',
+} as const;
+
+/**
+ * Generate 0–1 morale-based threshold events for the current week.
+ * Uses `state.moraleEventCooldowns` for precise week-based cooldowns.
+ *
+ * Priority order (only one fires per week):
+ *   1. Individual unsettled player (morale < 20) — minor
+ *   2. Squad avg morale < 30 — "Dressing Room Unrest"  — major
+ *   3. Squad avg morale < 40 for 3+ consecutive weeks  — "Losing Faith" — major
+ */
+export function generateMoraleThresholdEvents(
+  state: GameState,
+  week: number,
+  season: number
+): PendingClubEvent[] {
+  if (state.phase === 'PRE_SEASON' || state.phase === 'SEASON_END') return [];
+  if (state.club.squad.length === 0) return [];
+
+  const cooldowns = state.moraleEventCooldowns ?? {};
+
+  function onCooldown(templateId: string): boolean {
+    if (state.pendingEvents.some(e => e.templateId === templateId && !e.resolved)) return true;
+    const expires = cooldowns[templateId] ?? 0;
+    return week < expires;
+  }
+
+  const avg = avgSquadMorale(state.club.squad);
+
+  // ── 1. Individual unsettled player ────────────────────────────────────────
+  if (!onCooldown(MORALE_TEMPLATE_IDS.UNSETTLED)) {
+    const unsettledPlayers = state.club.squad.filter(p => isUnsettled(p));
+    if (unsettledPlayers.length > 0) {
+      // Pick the most unsettled player
+      const target = unsettledPlayers.reduce((a, b) => a.morale < b.morale ? a : b);
+      const event: PendingClubEvent = {
+        id: `evt-S${season}-W${week}-morale-unsettled`,
+        templateId: MORALE_TEMPLATE_IDS.UNSETTLED,
+        week,
+        title: `${target.name} is unsettled`,
+        description: `${target.name}'s morale has dropped to ${target.morale} — they're visibly disengaged in training. You need to act before it infects the rest of the dressing room.`,
+        severity: 'minor',
+        choices: [
+          {
+            id: 'team-talk',
+            label: 'Pull them aside for a talk',
+            description: `Spend time with ${target.name} one-on-one. Morale boost of +15, but it takes up coaching time.`,
+            moraleEffect: 15,
+          },
+          {
+            id: 'pay-rise',
+            label: 'Offer a pay rise',
+            description: `Bump ${target.name}'s weekly wage. Costs more but secures their commitment.`,
+            moraleEffect: 20,
+            budgetEffect: -Math.round(target.wage * 0.15 * 10), // 10 weeks' uplift upfront
+          },
+          {
+            id: 'list',
+            label: 'Put them on the transfer list',
+            description: `Signal to the market that ${target.name} is available. Morale stays low but a sale may be coming.`,
+            moraleEffect: -5,
+          },
+        ],
+        resolved: false,
+        metadata: { poachTargetPlayerId: target.id },
+      };
+      return [event];
+    }
+  }
+
+  // ── 2. Dressing room unrest (avg < 30) ────────────────────────────────────
+  if (!onCooldown(MORALE_TEMPLATE_IDS.UNREST) && avg < 30) {
+    const event: PendingClubEvent = {
+      id: `evt-S${season}-W${week}-morale-unrest`,
+      templateId: MORALE_TEMPLATE_IDS.UNREST,
+      week,
+      title: 'Dressing room unrest',
+      description: `Squad morale has collapsed to ${Math.round(avg)}. Players are openly questioning the direction of the club. You need to act immediately.`,
+      severity: 'major',
+      choices: [
+        {
+          id: 'emergency-talk',
+          label: 'Emergency team meeting',
+          description: 'Address the squad directly. Costs £3,000 in bonuses and extra sessions, but lifts morale by +15 across the board.',
+          budgetEffect: -300000,
+          moraleEffect: 15,
+        },
+        {
+          id: 'reshuffle-training',
+          label: 'Reshuffle training schedule',
+          description: 'Change the training focus and inject some variety. Morale nudged up by +8, no cost.',
+          moraleEffect: 8,
+        },
+        {
+          id: 'do-nothing',
+          label: 'Hold firm — results will turn it around',
+          description: "Say nothing publicly. The squad interprets silence as indifference.",
+          reputationEffect: -5,
+        },
+      ],
+      resolved: false,
+    };
+    return [event];
+  }
+
+  // ── 3. Losing faith (avg < 40 for 3+ consecutive weeks) ──────────────────
+  if (
+    !onCooldown(MORALE_TEMPLATE_IDS.LOSING_FAITH) &&
+    avg < 40 &&
+    (state.lowMoraleWeeks ?? 0) >= 3
+  ) {
+    const event: PendingClubEvent = {
+      id: `evt-S${season}-W${week}-morale-losing-faith`,
+      templateId: MORALE_TEMPLATE_IDS.LOSING_FAITH,
+      week,
+      title: 'Players are losing faith in the manager',
+      description: `Squad morale has been below 40 for ${state.lowMoraleWeeks} consecutive weeks. Senior players have been seen talking to their agents. The board is watching.`,
+      severity: 'major',
+      choices: [
+        {
+          id: 'vote-confidence',
+          label: 'Issue a public vote of confidence',
+          description: 'The board publicly backs the manager. Morale edges up +10, but if results don\'t improve the next board review will be brutal.',
+          moraleEffect: 10,
+          reputationEffect: 3,
+        },
+        {
+          id: 'change-emphasis',
+          label: 'Change the team\'s training emphasis',
+          description: 'Visibly change approach — different formations, fresh drills. Morale +6 across the squad.',
+          moraleEffect: 6,
+        },
+        {
+          id: 'sack-hint',
+          label: 'Hint that changes may be coming',
+          description: 'Signal the manager is under pressure. Players respond positively to accountability (+8 morale) but the manager\'s authority is damaged.',
+          moraleEffect: 8,
+          reputationEffect: -3,
+        },
+      ],
+      resolved: false,
+    };
+    return [event];
+  }
+
+  return [];
 }

--- a/packages/domain/src/simulation/match.ts
+++ b/packages/domain/src/simulation/match.ts
@@ -12,6 +12,7 @@
 import { createRng, Rng } from './rng';
 import { Club } from '../types/club';
 import { Player } from '../types/player';
+import { isUnsettled } from './morale';
 
 /** Base expected goals for an average-vs-average matchup (League Two realistic) */
 const BASE_EXPECTED_GOALS = 1.2;
@@ -236,9 +237,13 @@ function calculatePositionalStrengths(squad: Player[]): {
   let defenceWeightedSum = 0;
   let defenceWeightTotal = 0;
 
+  // Unsettled players (morale < 20) contribute 85% of their normal attributes
+  const UNSETTLED_DEBUFF = 0.85;
+
   for (const player of squad) {
-    const atk = player.attributes.attack;
-    const def = player.attributes.defence;
+    const debuff = isUnsettled(player) ? UNSETTLED_DEBUFF : 1.0;
+    const atk = player.attributes.attack  * debuff;
+    const def = player.attributes.defence * debuff;
 
     switch (player.position) {
       case 'FWD':

--- a/packages/domain/src/simulation/morale.ts
+++ b/packages/domain/src/simulation/morale.ts
@@ -1,0 +1,159 @@
+/**
+ * Morale system — pure helpers for computing morale deltas.
+ *
+ * All functions are stateless, deterministic, and side-effect free.
+ * They are called from:
+ *   - reducers/index.ts  (handleMatchSimulated, handleWeekAdvanced, handleManagerHired)
+ *   - simulation/match.ts (unsettled debuff)
+ *   - simulation/events.ts (threshold event generation, poach weighting)
+ */
+
+import { Player } from '../types/player';
+
+// ── Charisma factor ─────────────────────────────────────────────────────────────
+
+/**
+ * Scale factor for morale swings based on player charisma.
+ * Models emotional stability: high charisma resists change in both directions.
+ *
+ *   charisma=100 → 0.5× swing  (very stable)
+ *   charisma=50  → 1.0× swing  (normal)
+ *   charisma=0   → 1.5× swing  (very volatile)
+ */
+export function charismaFactor(charisma: number): number {
+  return 1 + (50 - charisma) / 100;
+}
+
+// ── Squad average ──────────────────────────────────────────────────────────────
+
+export function avgSquadMorale(squad: Player[]): number {
+  if (squad.length === 0) return 50;
+  return squad.reduce((sum, p) => sum + p.morale, 0) / squad.length;
+}
+
+// ── Layer 1: Result delta ──────────────────────────────────────────────────────
+
+const RESULT_BASE: Record<'W' | 'D' | 'L', number> = { W: 3, D: 1, L: -4 };
+
+/**
+ * Apply per-player morale delta after the player's club match result.
+ *
+ * Factors:
+ *   - base delta:    W +3 / D +1 / L −4
+ *   - context ×1.5: upset win (beat a team 5+ positions higher) or
+ *                   shock loss (lost to a team 5+ positions lower)
+ *   - streak bonus:  +2 if last 3 results all W / −3 if last 5 all L
+ *   - per-player:    scaled by charismaFactor (volatile players swing harder)
+ *
+ * @param squad         Current squad
+ * @param result        W/D/L for the player's club in this match
+ * @param playerPos     Player's club league position (1–24)
+ * @param opponentPos   Opponent's league position (1–24)
+ * @param currentForm   Club form AFTER this result has been appended (last 5)
+ */
+export function applyResultMoraleDelta(
+  squad: Player[],
+  result: 'W' | 'D' | 'L',
+  playerPos: number,
+  opponentPos: number,
+  currentForm: ('W' | 'D' | 'L')[]
+): Player[] {
+  const base = RESULT_BASE[result];
+
+  // Context: upset win (beat stronger opponent) or shock loss (lost to weaker)
+  const posGap = opponentPos - playerPos; // positive = opponent is lower ranked
+  const isUpset =
+    (result === 'W' && posGap >= 5) ||
+    (result === 'L' && posGap <= -5);
+  const contextMult = isUpset ? 1.5 : 1.0;
+
+  // Form streak modifier (uniform across squad, shaped by charisma per player)
+  const last5 = currentForm.slice(-5);
+  const last3 = currentForm.slice(-3);
+  const streakBonus =
+    last3.length === 3 && last3.every(r => r === 'W') ? 2 :
+    last5.length === 5 && last5.every(r => r === 'L') ? -3 :
+    0;
+
+  return squad.map(p => {
+    const cf = charismaFactor(p.attributes.charisma);
+    const delta = Math.round((base * contextMult + streakBonus) * cf);
+    return { ...p, morale: Math.max(0, Math.min(100, p.morale + delta)) };
+  });
+}
+
+// ── Layer 2: Contract anxiety ──────────────────────────────────────────────────
+
+/**
+ * Weekly morale drain for players with expiring contracts.
+ * Applied silently in WEEK_ADVANCED — independent of manager nudge.
+ *
+ *   < 4 weeks left: −2/wk
+ *   < 8 weeks left: −1/wk
+ */
+export function applyContractAnxiety(
+  squad: Player[],
+  currentWeek: number
+): Player[] {
+  return squad.map(p => {
+    const weeksLeft = p.contractExpiresWeek - currentWeek;
+    const drain = weeksLeft < 4 ? -2 : weeksLeft < 8 ? -1 : 0;
+    if (drain === 0) return p;
+    return { ...p, morale: Math.max(0, Math.min(100, p.morale + drain)) };
+  });
+}
+
+// ── Layer 4: Contagion ─────────────────────────────────────────────────────────
+
+/**
+ * Players at morale 0 drain teammates in the same position group by −1/wk.
+ * At most one contagion source per position group; the source itself is unaffected.
+ */
+export function applyContagion(squad: Player[]): Player[] {
+  // Find positions that have at least one player at morale 0
+  const contagionPositions = new Set<string>(
+    squad.filter(p => p.morale === 0).map(p => p.position)
+  );
+  if (contagionPositions.size === 0) return squad;
+
+  return squad.map(p => {
+    if (!contagionPositions.has(p.position)) return p;
+    if (p.morale === 0) return p; // source is not drained further
+    return { ...p, morale: Math.max(0, p.morale - 1) };
+  });
+}
+
+// ── Manager change: gravitational pull ────────────────────────────────────────
+
+/**
+ * One-time morale effect fired on MANAGER_HIRED.
+ * Pulls each player's morale toward 55 (slight optimism — new chapter),
+ * scaled by charisma. This is independent of the incoming manager's attributes.
+ *
+ *   High morale squad → pulled down (uncertainty)
+ *   Low morale squad  → pulled up   (hope of turnaround)
+ *   ~55 morale squad  → no effect
+ *
+ *   Pull strength: 20% of the gap toward 55 per appointment.
+ */
+const MANAGER_CHANGE_TARGET = 55;
+const MANAGER_CHANGE_PULL   = 0.20;
+
+export function applyManagerChangeMorale(squad: Player[]): Player[] {
+  return squad.map(p => {
+    const cf = charismaFactor(p.attributes.charisma);
+    const delta = Math.round(
+      (MANAGER_CHANGE_TARGET - p.morale) * MANAGER_CHANGE_PULL * cf
+    );
+    return { ...p, morale: Math.max(0, Math.min(100, p.morale + delta)) };
+  });
+}
+
+// ── Unsettled flag (derived — no storage needed) ───────────────────────────────
+
+/** Players below this threshold are "unsettled" — debuffed in match sim and poach-priority. */
+export const UNSETTLED_THRESHOLD = 20;
+
+export function isUnsettled(player: Player): boolean {
+  return player.morale < UNSETTLED_THRESHOLD;
+}

--- a/packages/domain/src/types/game-state-updated.ts
+++ b/packages/domain/src/types/game-state-updated.ts
@@ -102,6 +102,20 @@ export interface GameState {
 
   /** Available managers to hire (generated at game start, removed on hire) */
   managerPool: Manager[];
+
+  /**
+   * Consecutive weeks the squad average morale has been below 40.
+   * Resets to 0 when avg morale rises back above 40.
+   * Used to trigger the "Players Losing Faith" event at 3+ weeks.
+   */
+  lowMoraleWeeks: number;
+
+  /**
+   * Cooldown tracker for threshold morale events.
+   * Maps event templateId → week the cooldown expires.
+   * Prevents the same event firing more than once per 6 weeks.
+   */
+  moraleEventCooldowns: Record<string, number>;
 }
 
 /**

--- a/packages/frontend/src/components/command-centre/SquadAuditTable.tsx
+++ b/packages/frontend/src/components/command-centre/SquadAuditTable.tsx
@@ -1,4 +1,4 @@
-import { GameState, formatMoney, Player, getScoutedPotential, scoutNoiseRange, getScoutLevel } from '@calculating-glory/domain';
+import { GameState, formatMoney, Player, getScoutedPotential, scoutNoiseRange, getScoutLevel, isUnsettled } from '@calculating-glory/domain';
 
 interface SquadAuditTableProps {
   state: GameState;
@@ -13,12 +13,24 @@ const POS_COLORS: Record<string, string> = {
   FWD: 'text-alert-red',
 };
 
-function MoraleBar({ morale }: { morale: number }) {
+function MoraleBar({ player }: { player: Player }) {
+  const { morale } = player;
   const color =
     morale >= 70 ? 'bg-pitch-green' : morale >= 40 ? 'bg-warn-amber' : 'bg-alert-red';
+  const unsettled = isUnsettled(player);
   return (
-    <div className="w-10 h-1.5 bg-bg-raised rounded-full overflow-hidden">
-      <div className={`h-full ${color} rounded-full`} style={{ width: `${morale}%` }} />
+    <div className="flex items-center gap-1">
+      <div className="w-10 h-1.5 bg-bg-raised rounded-full overflow-hidden">
+        <div className={`h-full ${color} rounded-full`} style={{ width: `${morale}%` }} />
+      </div>
+      {unsettled && (
+        <span
+          className="text-[9px] text-alert-red font-bold leading-none"
+          title="Unsettled — performance debuffed"
+        >
+          !
+        </span>
+      )}
     </div>
   );
 }
@@ -57,7 +69,7 @@ function PlayerRow({ player, scoutLevel }: { player: Player; scoutLevel: number 
       </td>
       <td className="text-right pr-3 py-1">{formatMoney(player.wage)}<span className="text-xs2 text-txt-muted">/wk</span></td>
       <td className="py-1">
-        <MoraleBar morale={player.morale} />
+        <MoraleBar player={player} />
       </td>
     </tr>
   );


### PR DESCRIPTION
## Summary

- New `simulation/morale.ts`: pure stateless helpers for all morale maths
- **Layer 1** — per-player result delta after each match (W+3/D+1/L−4, ×1.5 for upset wins/shock losses, ±streak bonus, charisma-shaped)
- **Layer 2** — contract anxiety drain in `handleWeekAdvanced` (−1/wk <8 weeks left, −2/wk <4 weeks)
- **Layer 3** — `generateMoraleThresholdEvents`: "Unsettled player" (morale <20), "Dressing Room Unrest" (avg <30), "Players Losing Faith" (avg <40 × 3 weeks); 6-week cooldowns via `moraleEventCooldowns`; only fires when inbox is otherwise clear
- **Layer 4** — contagion: morale-0 players drain their position group −1/wk
- **Manager change** — `handleManagerHired` applies a gravitational pull toward 55 (uncertainty for high morale squads, hope for low); charisma-shaped; independent of the incoming manager's attributes
- **Match sim** — unsettled players (morale <20) contribute 85% of attributes to positional strength
- **Poach weighting** — unsettled players weighted 3× more likely to be targeted by NPCs
- **`GameState`** — two new fields: `lowMoraleWeeks` and `moraleEventCooldowns`
- **SquadAuditTable** — red `!` badge next to morale bar for unsettled players

## Test plan

- [ ] Win 3 in a row — verify squad morale rises, volatile (low-charisma) players rise more
- [ ] Lose 5 in a row — verify morale falls; streak penalty visible; unsettled badge appears on low-morale players
- [ ] Hire a new manager with high squad morale — verify slight morale dip; hire with low squad morale — verify uptick
- [ ] Let a player's contract run down to <8 weeks — verify morale drain in squad table
- [ ] Force avg morale below 30 — verify "Dressing Room Unrest" event fires with correct choices
- [ ] Force avg morale below 40 for 3+ weeks — verify "Losing Faith" event fires
- [ ] TypeScript clean: `npx tsc --noEmit` in `packages/frontend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)