### PR TITLE
feat: targeted scouting — scout for contracted players & negotiate transfers

### DIFF
--- a/packages/domain/src/__tests__/reducer-match.test.ts
+++ b/packages/domain/src/__tests__/reducer-match.test.ts
@@ -64,6 +64,9 @@ function makeState(entries: LeagueTableEntry[], playerClubId: string = 'club-1')
     season: 1,
     freeAgentPool: [],
     managerPool: [],
+    lowMoraleWeeks: 0,
+    moraleEventCooldowns: {},
+    scoutMission: null,
   };
 }
 

--- a/packages/domain/src/__tests__/scout-mission.test.ts
+++ b/packages/domain/src/__tests__/scout-mission.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Scout Mission Tests
+ *
+ * Tests for:
+ *   - START_SCOUT_MISSION: validates no duplicate missions, budget deducted
+ *   - SCOUT_TARGET_FOUND: emitted on week tick when SEARCHING, mission → TARGET_FOUND
+ *   - PLACE_SCOUT_BID: pass → BID_PENDING with offeredWage; fail → BID_REJECTED
+ *   - SCOUT_TRANSFER_COMPLETED: fires on window-open week, player in squad, budget deducted
+ *   - CANCEL_SCOUT_MISSION: clears scoutMission
+ *   - Transfer window: isTransferWindowOpen correctness
+ *   - generateScoutTarget: determinism + position filter
+ */
+
+import { buildState, reduceEvent } from '../reducers';
+import { handleCommand } from '../commands/handlers';
+import { GameState } from '../types/game-state-updated';
+import { GameStartedEvent } from '../events/types';
+import { isTransferWindowOpen } from '../types/facility';
+import { generateScoutTarget, getScoutFee } from '../data/scout-target-generator';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeState(overrides: Partial<GameState> = {}): GameState {
+  const base = buildState([
+    {
+      type: 'GAME_STARTED',
+      timestamp: Date.now(),
+      clubId: 'test-club',
+      clubName: 'Test FC',
+      initialBudget: 100_000_000, // £100k
+      difficulty: 'MEDIUM',
+      seed: 'test-seed',
+    } as GameStartedEvent,
+  ]);
+  return { ...base, ...overrides };
+}
+
+function inSeason(state: GameState, week = 5): GameState {
+  return { ...state, phase: 'MID_SEASON', currentWeek: week };
+}
+
+// ── Transfer window ───────────────────────────────────────────────────────────
+
+describe('isTransferWindowOpen', () => {
+  it('is always open in PRE_SEASON', () => {
+    expect(isTransferWindowOpen(0, 'PRE_SEASON')).toBe(true);
+  });
+
+  it('is open for summer window weeks 1–4', () => {
+    for (let w = 1; w <= 4; w++) {
+      expect(isTransferWindowOpen(w, 'EARLY_SEASON')).toBe(true);
+    }
+  });
+
+  it('is closed in weeks 5–20', () => {
+    for (let w = 5; w <= 20; w++) {
+      expect(isTransferWindowOpen(w, 'EARLY_SEASON')).toBe(false);
+    }
+  });
+
+  it('is open for January window weeks 21–24', () => {
+    for (let w = 21; w <= 24; w++) {
+      expect(isTransferWindowOpen(w, 'MID_SEASON')).toBe(true);
+    }
+  });
+
+  it('is closed from week 25 onwards', () => {
+    for (let w = 25; w <= 46; w++) {
+      expect(isTransferWindowOpen(w, 'LATE_SEASON')).toBe(false);
+    }
+  });
+});
+
+// ── Scout fee ─────────────────────────────────────────────────────────────────
+
+describe('getScoutFee', () => {
+  it('returns 50,000p at level 0', () => expect(getScoutFee(0)).toBe(50_000));
+  it('returns 750,000p at level 5', () => expect(getScoutFee(5)).toBe(750_000));
+  it('clamps below 0 to level 0', () => expect(getScoutFee(-1)).toBe(50_000));
+  it('clamps above 5 to level 5', () => expect(getScoutFee(9)).toBe(750_000));
+});
+
+// ── Target generator ──────────────────────────────────────────────────────────
+
+describe('generateScoutTarget', () => {
+  it('generates a player at the requested position', () => {
+    const { player } = generateScoutTarget('FWD', null, 3, 'seed', 1, 10, 'my-club');
+    expect(player.position).toBe('FWD');
+  });
+
+  it('is deterministic for same inputs', () => {
+    const a = generateScoutTarget('MID', 'attack', 2, 'seed', 1, 8, 'my-club');
+    const b = generateScoutTarget('MID', 'attack', 2, 'seed', 1, 8, 'my-club');
+    expect(a.player.id).toBe(b.player.id);
+    expect(a.askingPrice).toBe(b.askingPrice);
+    expect(a.npcClubId).toBe(b.npcClubId);
+  });
+
+  it('produces different targets for different weeks', () => {
+    const a = generateScoutTarget('DEF', null, 2, 'seed', 1, 8, 'my-club');
+    const b = generateScoutTarget('DEF', null, 2, 'seed', 1, 9, 'my-club');
+    // Different week → different RNG seed → different name/club at minimum
+    expect(a.player.id).not.toBe(b.player.id);
+  });
+
+  it('does not return the player club as npc club', () => {
+    // Run many times with different weeks — the player club should never appear
+    for (let w = 1; w <= 20; w++) {
+      const { npcClubId } = generateScoutTarget('GK', null, 0, 'seed', 1, w, 'swinton');
+      expect(npcClubId).not.toBe('swinton');
+    }
+  });
+
+  it('sets askingPrice > 0', () => {
+    const { askingPrice } = generateScoutTarget('FWD', null, 0, 'seed', 1, 5, 'my-club');
+    expect(askingPrice).toBeGreaterThan(0);
+  });
+});
+
+// ── START_SCOUT_MISSION ───────────────────────────────────────────────────────
+
+describe('START_SCOUT_MISSION command', () => {
+  it('emits SCOUT_MISSION_STARTED and deducts scout fee from budget', () => {
+    const state = makeState();
+    const budgetBefore = state.club.transferBudget;
+    const result = handleCommand({ type: 'START_SCOUT_MISSION', position: 'FWD', attributePriority: null, budgetCeiling: 5_000_000 }, state);
+    expect(result.error).toBeUndefined();
+    const event = result.events![0];
+    expect(event.type).toBe('SCOUT_MISSION_STARTED');
+
+    const newState = reduceEvent(state, event);
+    expect(newState.scoutMission).not.toBeNull();
+    expect(newState.scoutMission!.status).toBe('SEARCHING');
+    expect(newState.club.transferBudget).toBe(budgetBefore - (event as any).scoutFee);
+  });
+
+  it('rejects when a mission is already active', () => {
+    const state = makeState();
+    const { events } = handleCommand({ type: 'START_SCOUT_MISSION', position: 'MID', attributePriority: null, budgetCeiling: 5_000_000 }, state);
+    const stateWithMission = reduceEvent(state, events![0]);
+    const result = handleCommand({ type: 'START_SCOUT_MISSION', position: 'DEF', attributePriority: null, budgetCeiling: 5_000_000 }, stateWithMission);
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe('VALIDATION_FAILED');
+  });
+
+  it('rejects when transfer budget is too low for the scout fee', () => {
+    const broke = makeState();
+    const state = { ...broke, club: { ...broke.club, transferBudget: 0 } };
+    const result = handleCommand({ type: 'START_SCOUT_MISSION', position: 'GK', attributePriority: null, budgetCeiling: 100_000 }, state);
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe('INSUFFICIENT_BUDGET');
+  });
+});
+
+// ── Week tick: SEARCHING → TARGET_FOUND ──────────────────────────────────────
+
+describe('SIMULATE_WEEK with SEARCHING mission', () => {
+  it('emits SCOUT_TARGET_FOUND alongside match events', () => {
+    const base = makeState();
+    const { events: startEvents } = handleCommand(
+      { type: 'START_SCOUT_MISSION', position: 'FWD', attributePriority: null, budgetCeiling: 10_000_000 },
+      base,
+    );
+    const stateWithMission = reduceEvent(base, startEvents![0]);
+    const midSeason = inSeason(stateWithMission, 10);
+
+    const result = handleCommand({ type: 'SIMULATE_WEEK', week: 11, season: 1, seed: 'test' }, midSeason);
+    expect(result.error).toBeUndefined();
+
+    const foundEvent = result.events!.find(e => e.type === 'SCOUT_TARGET_FOUND');
+    expect(foundEvent).toBeDefined();
+    expect((foundEvent as any).target.position).toBe('FWD');
+
+    // Week still advances
+    const weekAdvanced = result.events!.find(e => e.type === 'WEEK_ADVANCED');
+    expect(weekAdvanced).toBeDefined();
+  });
+
+  it('transitions state to TARGET_FOUND after reducer applies the events', () => {
+    const base = makeState();
+    const { events: startEvents } = handleCommand(
+      { type: 'START_SCOUT_MISSION', position: 'DEF', attributePriority: 'defence', budgetCeiling: 10_000_000 },
+      base,
+    );
+    let state = reduceEvent(base, startEvents![0]);
+    state = inSeason(state, 10);
+
+    const { events: weekEvents } = handleCommand({ type: 'SIMULATE_WEEK', week: 11, season: 1, seed: 'test' }, state);
+    for (const ev of weekEvents!) state = reduceEvent(state, ev);
+
+    expect(state.scoutMission!.status).toBe('TARGET_FOUND');
+    expect(state.scoutMission!.target).toBeDefined();
+    expect(state.scoutMission!.askingPrice).toBeGreaterThan(0);
+  });
+});
+
+// ── PLACE_SCOUT_BID ───────────────────────────────────────────────────────────
+
+describe('PLACE_SCOUT_BID command', () => {
+  function stateWithTarget(): GameState {
+    let state = makeState();
+    // Must have an active mission before TARGET_FOUND can be applied
+    state = reduceEvent(state, {
+      type: 'SCOUT_MISSION_STARTED', timestamp: Date.now(), clubId: 'test-club',
+      position: 'FWD', attributePriority: null, budgetCeiling: 10_000_000,
+      scoutFee: 50_000, weekStarted: 5,
+    });
+    return reduceEvent(state, {
+      type:              'SCOUT_TARGET_FOUND',
+      timestamp:         Date.now(),
+      clubId:            'test-club',
+      target: {
+        id: 'scout-target-S1-W11-FWD', name: 'Test Target', overallRating: 65,
+        position: 'FWD', wage: 150_000, transferValue: 3_000_000, age: 24,
+        morale: 70, attributes: { attack: 70, defence: 25, teamwork: 60, charisma: 55, publicPotential: 70 },
+        truePotential: 72, contractExpiresWeek: 0,
+        stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 65 },
+      },
+      targetNpcClubId:   'bradfield',
+      targetNpcClubName: 'Bradfield City',
+      askingPrice:       3_000_000,
+    });
+  }
+
+  it('transitions to BID_PENDING on negotiation success', () => {
+    const state = stateWithTarget();
+    const result = handleCommand({ type: 'PLACE_SCOUT_BID', negotiationPassed: true, offeredWage: 200_000 }, state);
+    expect(result.error).toBeUndefined();
+    const newState = reduceEvent(state, result.events![0]);
+    expect(newState.scoutMission!.status).toBe('BID_PENDING');
+    expect(newState.scoutMission!.offeredWage).toBe(200_000);
+  });
+
+  it('transitions to BID_REJECTED on negotiation failure', () => {
+    const state = stateWithTarget();
+    const result = handleCommand({ type: 'PLACE_SCOUT_BID', negotiationPassed: false, offeredWage: 200_000 }, state);
+    const newState = reduceEvent(state, result.events![0]);
+    expect(newState.scoutMission!.status).toBe('BID_REJECTED');
+  });
+
+  it('allows re-bid directly from BID_REJECTED → BID_PENDING', () => {
+    let state = stateWithTarget();
+    const fail = handleCommand({ type: 'PLACE_SCOUT_BID', negotiationPassed: false, offeredWage: 200_000 }, state);
+    state = reduceEvent(state, fail.events![0]);
+    expect(state.scoutMission!.status).toBe('BID_REJECTED');
+
+    // Can bid again without needing to re-find the target
+    const pass = handleCommand({ type: 'PLACE_SCOUT_BID', negotiationPassed: true, offeredWage: 200_000 }, state);
+    expect(pass.error).toBeUndefined();
+    const newState = reduceEvent(state, pass.events![0]);
+    expect(newState.scoutMission!.status).toBe('BID_PENDING');
+  });
+});
+
+// ── SCOUT_TRANSFER_COMPLETED on window open ───────────────────────────────────
+
+describe('SIMULATE_WEEK at transfer window open with BID_PENDING', () => {
+  it('emits SCOUT_TRANSFER_COMPLETED at week 21, adds player to squad, deducts fee', () => {
+    let state = makeState();
+
+    // Set up a BID_PENDING mission manually via events
+    state = reduceEvent(state, {
+      type: 'SCOUT_MISSION_STARTED', timestamp: Date.now(), clubId: 'test-club',
+      position: 'MID', attributePriority: null, budgetCeiling: 10_000_000,
+      scoutFee: 50_000, weekStarted: 10,
+    });
+    state = reduceEvent(state, {
+      type: 'SCOUT_TARGET_FOUND', timestamp: Date.now(), clubId: 'test-club',
+      target: {
+        id: 'scout-target-S1-W11-MID', name: 'Target Dude', overallRating: 60,
+        position: 'MID', wage: 150_000, transferValue: 2_500_000, age: 26,
+        morale: 70, attributes: { attack: 55, defence: 50, teamwork: 70, charisma: 55, publicPotential: 65 },
+        truePotential: 67, contractExpiresWeek: 0,
+        stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 60 },
+      },
+      targetNpcClubId: 'bradfield', targetNpcClubName: 'Bradfield City', askingPrice: 2_500_000,
+    });
+    state = reduceEvent(state, {
+      type: 'SCOUT_BID_PLACED', timestamp: Date.now(), clubId: 'test-club',
+      negotiationPassed: true, offeredWage: 200_000,
+    });
+
+    expect(state.scoutMission!.status).toBe('BID_PENDING');
+
+    // Set phase so window is open at week 21
+    state = { ...state, phase: 'MID_SEASON', currentWeek: 20 };
+
+    const budgetBefore = state.club.transferBudget;
+    const squadBefore  = state.club.squad.length;
+
+    const result = handleCommand({ type: 'SIMULATE_WEEK', week: 21, season: 1, seed: 'test' }, state);
+    expect(result.error).toBeUndefined();
+
+    const completedEvent = result.events!.find(e => e.type === 'SCOUT_TRANSFER_COMPLETED');
+    expect(completedEvent).toBeDefined();
+    expect((completedEvent as any).player.name).toBe('Target Dude');
+
+    // Apply all events
+    for (const ev of result.events!) state = reduceEvent(state, ev);
+
+    expect(state.scoutMission).toBeNull();
+    expect(state.club.squad.length).toBe(squadBefore + 1);
+    expect(state.club.transferBudget).toBeLessThan(budgetBefore);
+    // Week also advanced
+    expect(state.currentWeek).toBe(21);
+  });
+});
+
+// ── CANCEL_SCOUT_MISSION ──────────────────────────────────────────────────────
+
+describe('CANCEL_SCOUT_MISSION command', () => {
+  it('clears the active mission', () => {
+    const base = makeState();
+    const { events } = handleCommand({ type: 'START_SCOUT_MISSION', position: 'GK', attributePriority: null, budgetCeiling: 2_000_000 }, base);
+    let state = reduceEvent(base, events![0]);
+    expect(state.scoutMission).not.toBeNull();
+
+    const cancel = handleCommand({ type: 'CANCEL_SCOUT_MISSION' }, state);
+    expect(cancel.error).toBeUndefined();
+    state = reduceEvent(state, cancel.events![0]);
+    expect(state.scoutMission).toBeNull();
+  });
+
+  it('rejects when no mission is active', () => {
+    const state = makeState();
+    const result = handleCommand({ type: 'CANCEL_SCOUT_MISSION' }, state);
+    expect(result.error).toBeDefined();
+  });
+});

--- a/packages/domain/src/commands/handlers.ts
+++ b/packages/domain/src/commands/handlers.ts
@@ -14,6 +14,9 @@ import { createRng } from '../simulation/rng';
 import { generateWeekEvents, generatePoachAttempts, generateMoraleThresholdEvents } from '../simulation/events';
 import { LEAGUE_TWO_TEAMS } from '../data/league-two-teams';
 import { Player } from '../types/player';
+import { getScoutLevel, isTransferWindowOpen } from '../types/facility';
+import { generateScoutTarget, getScoutFee } from '../data/scout-target-generator';
+import { ScoutTargetFoundEvent, ScoutTransferCompletedEvent } from '../events/types';
 
 /**
  * Handle a game command
@@ -50,6 +53,12 @@ export function handleCommand(command: GameCommand, state: GameState): CommandRe
       return handleSellPlayerToNpc(command, state);
     case 'BEGIN_NEXT_SEASON':
       return handleBeginNextSeason(command, state);
+    case 'START_SCOUT_MISSION':
+      return handleStartScoutMission(command, state);
+    case 'PLACE_SCOUT_BID':
+      return handlePlaceScoutBid(command, state);
+    case 'CANCEL_SCOUT_MISSION':
+      return handleCancelScoutMission(command, state);
     default:
       return {
         error: {
@@ -311,6 +320,57 @@ function handleSimulateWeek(command: any, state: GameState): CommandResult {
         pendingEvent
       });
     }
+  }
+
+  // ── Scout mission resolution ─────────────────────────────────────────────────
+
+  // Complete a pending bid when the transfer window opens this week
+  if (isTransferWindowOpen(week, state.phase) && state.scoutMission?.status === 'BID_PENDING') {
+    const mission = state.scoutMission;
+    const contractExpiresWeek = week + 46;
+    const updatedPlayer: Player = {
+      ...mission.target!,
+      wage:                mission.offeredWage!,
+      contractExpiresWeek,
+    };
+    const completionEvent: ScoutTransferCompletedEvent = {
+      type:              'SCOUT_TRANSFER_COMPLETED',
+      timestamp:         now,
+      clubId:            state.club.id,
+      player:            updatedPlayer,
+      fee:               mission.askingPrice!,
+      targetNpcClubId:   mission.targetNpcClubId!,
+      targetNpcClubName: mission.targetNpcClubName!,
+    };
+    events.push(completionEvent);
+  }
+
+  // Resolve a SEARCHING mission into TARGET_FOUND (fires once per week tick)
+  if (state.scoutMission?.status === 'SEARCHING') {
+    const mission    = state.scoutMission;
+    const scoutLevel = getScoutLevel(state.club.facilities);
+    const gameStartEvent = state.events.find(e => e.type === 'GAME_STARTED') as
+      { type: 'GAME_STARTED'; seed: string } | undefined;
+    const seedStr = gameStartEvent?.seed ?? 'default-seed';
+    const { player, npcClubId, npcClubName, askingPrice } = generateScoutTarget(
+      mission.position,
+      mission.attributePriority,
+      scoutLevel,
+      seedStr,
+      season,
+      week,
+      state.club.id,
+    );
+    const foundEvent: ScoutTargetFoundEvent = {
+      type:              'SCOUT_TARGET_FOUND',
+      timestamp:         now,
+      clubId:            state.club.id,
+      target:            player,
+      targetNpcClubId:   npcClubId,
+      targetNpcClubName: npcClubName,
+      askingPrice,
+    };
+    events.push(foundEvent);
   }
 
   // Advance the week after all matches and events
@@ -781,6 +841,117 @@ function handleBeginNextSeason(_command: any, state: GameState): CommandResult {
       type: 'PRE_SEASON_STARTED',
       timestamp: Date.now(),
       season: state.season + 1,
+    }],
+  };
+}
+
+function handleStartScoutMission(command: any, state: GameState): CommandResult {
+  // Only one mission at a time
+  if (state.scoutMission !== null) {
+    return {
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: 'A scout mission is already active — cancel it before starting a new one',
+      },
+    };
+  }
+
+  // Need squad room for the eventual signing
+  if (state.club.squad.length >= state.club.squadCapacity) {
+    return {
+      error: {
+        code: 'SQUAD_LIMIT_EXCEEDED',
+        message: 'Squad is at capacity — release a player before scouting',
+      },
+    };
+  }
+
+  const scoutLevel = getScoutLevel(state.club.facilities);
+  const scoutFee   = getScoutFee(scoutLevel);
+
+  if (scoutFee > state.club.transferBudget) {
+    return {
+      error: {
+        code: 'INSUFFICIENT_BUDGET',
+        message: `Scout fee of ${scoutFee} pence exceeds available transfer budget`,
+      },
+    };
+  }
+
+  return {
+    events: [{
+      type:             'SCOUT_MISSION_STARTED',
+      timestamp:        Date.now(),
+      clubId:           state.club.id,
+      position:         command.position,
+      attributePriority: command.attributePriority,
+      budgetCeiling:    command.budgetCeiling,
+      scoutFee,
+      weekStarted:      state.currentWeek,
+    }],
+  };
+}
+
+function handlePlaceScoutBid(command: any, state: GameState): CommandResult {
+  const bidAllowed = state.scoutMission?.status === 'TARGET_FOUND' ||
+                     state.scoutMission?.status === 'BID_REJECTED';
+  if (!bidAllowed || !state.scoutMission) {
+    return {
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: 'No target available to bid on',
+      },
+    };
+  }
+
+  const mission = state.scoutMission;
+
+  // Check we can afford the asking price + offered wage
+  if (mission.askingPrice! > state.club.transferBudget) {
+    return {
+      error: {
+        code: 'INSUFFICIENT_BUDGET',
+        message: 'Transfer budget is insufficient to cover the asking price',
+      },
+    };
+  }
+
+  const currentTotalWages = state.club.squad.reduce((sum, p) => sum + p.wage, 0);
+  if (command.offeredWage > state.club.wageBudget - currentTotalWages) {
+    return {
+      error: {
+        code: 'INSUFFICIENT_BUDGET',
+        message: 'Offered wage exceeds remaining weekly wage budget',
+      },
+    };
+  }
+
+  return {
+    events: [{
+      type:              'SCOUT_BID_PLACED',
+      timestamp:         Date.now(),
+      clubId:            state.club.id,
+      negotiationPassed: command.negotiationPassed,
+      offeredWage:       command.offeredWage,
+    }],
+  };
+}
+
+function handleCancelScoutMission(_command: any, state: GameState): CommandResult {
+  if (!state.scoutMission) {
+    return {
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: 'No active scout mission to cancel',
+      },
+    };
+  }
+
+  return {
+    events: [{
+      type:      'SCOUT_MISSION_CANCELLED',
+      timestamp: Date.now(),
+      clubId:    state.club.id,
     }],
   };
 }

--- a/packages/domain/src/commands/types.ts
+++ b/packages/domain/src/commands/types.ts
@@ -9,6 +9,7 @@ import { GameEvent } from '../events/types';
 import { CommandError } from '../types/game-state-updated';
 import { TrainingFocus } from '../types/facility';
 import { Formation } from '../types/formation';
+import { Position } from '../types/player';
 
 export type GameCommand =
   | MakeTransferCommand
@@ -25,7 +26,10 @@ export type GameCommand =
   | HireManagerCommand
   | SackManagerCommand
   | SellPlayerToNpcCommand
-  | BeginNextSeasonCommand;
+  | BeginNextSeasonCommand
+  | StartScoutMissionCommand
+  | PlaceScoutBidCommand
+  | CancelScoutMissionCommand;
 
 export interface MakeTransferCommand {
   type: 'MAKE_TRANSFER';
@@ -115,6 +119,26 @@ export interface SellPlayerToNpcCommand {
 
 export interface BeginNextSeasonCommand {
   type: 'BEGIN_NEXT_SEASON';
+}
+
+export interface StartScoutMissionCommand {
+  type: 'START_SCOUT_MISSION';
+  position: Position;
+  attributePriority: 'attack' | 'defence' | 'teamwork' | null;
+  /** Maximum transfer fee willing to pay, in pence */
+  budgetCeiling: number;
+}
+
+export interface PlaceScoutBidCommand {
+  type: 'PLACE_SCOUT_BID';
+  /** Whether the math challenge was passed in the frontend */
+  negotiationPassed: boolean;
+  /** Weekly wage offered to the player, in pence */
+  offeredWage: number;
+}
+
+export interface CancelScoutMissionCommand {
+  type: 'CANCEL_SCOUT_MISSION';
 }
 
 export interface CommandResult {

--- a/packages/domain/src/data/scout-target-generator.ts
+++ b/packages/domain/src/data/scout-target-generator.ts
@@ -1,0 +1,226 @@
+/**
+ * Scout Target Generator
+ *
+ * Generates a contracted player at an NPC club, seeded from the mission
+ * context so the same mission always finds the same player.
+ *
+ * Quality scales with scout level — a better network finds better players.
+ * Scout level also gates access to the getScoutedPotential noise system
+ * (already in facility.ts).
+ */
+
+import { Player, Position, PlayerAttributes } from '../types/player';
+import { createRng } from '../simulation/rng';
+import { LEAGUE_TWO_TEAMS } from './league-two-teams';
+
+// ── Names for contracted players ──────────────────────────────────────────────
+
+const TARGET_NAMES: string[] = [
+  'Danny Forsyth',
+  'Leon Cartwright',
+  'Tom Maguire',
+  'Ryan Estrada',
+  'Pedro Alves',
+  'Florian Krause',
+  'Lukas Petrak',
+  'Andre Beaumont',
+  'Joe Whitmore',
+  'Calvin Ashby',
+  'Noel Stroud',
+  'Remi Dubois',
+  'Ariel Goldstein',
+  'Omar Nassar',
+  'Ivan Marchetti',
+  'Phil Garvey',
+  'Cian Doherty',
+  'Kwabena Asare',
+  'Thibault Renaud',
+  'Sander Bakker',
+  'Carlos Benitez',
+  'Yannick Bosman',
+  'Marcus Ferreira',
+  'Georgi Petrov',
+  'Alistair Quinn',
+  'Dmitri Nikitin',
+  'Seun Olatunji',
+  'Xavier Moreau',
+  'Emre Yilmaz',
+  'Benedikt Wolf',
+];
+
+// ── Quality bands by scout level ──────────────────────────────────────────────
+// Better scout levels find higher-quality players.
+// OVR = avg(attack, defence, teamwork), so we target those attribute ranges.
+
+interface QualityBand {
+  attrMin: number;
+  attrMax: number;
+  wageMin: number;   // pence/week
+  wageMax: number;
+}
+
+const QUALITY_BAND: QualityBand[] = [
+  { attrMin: 38, attrMax: 52, wageMin: 50_000,  wageMax: 120_000  }, // level 0
+  { attrMin: 42, attrMax: 56, wageMin: 60_000,  wageMax: 150_000  }, // level 1
+  { attrMin: 47, attrMax: 62, wageMin: 75_000,  wageMax: 190_000  }, // level 2
+  { attrMin: 52, attrMax: 67, wageMin: 100_000, wageMax: 230_000  }, // level 3
+  { attrMin: 58, attrMax: 72, wageMin: 130_000, wageMax: 280_000  }, // level 4
+  { attrMin: 63, attrMax: 78, wageMin: 160_000, wageMax: 340_000  }, // level 5
+];
+
+// ── Scout fee by level ─────────────────────────────────────────────────────────
+
+const SCOUT_FEES_PENCE: number[] = [
+  50_000,   // level 0 — £500
+  100_000,  // level 1 — £1,000
+  200_000,  // level 2 — £2,000
+  350_000,  // level 3 — £3,500
+  500_000,  // level 4 — £5,000
+  750_000,  // level 5 — £7,500
+];
+
+export function getScoutFee(scoutLevel: number): number {
+  return SCOUT_FEES_PENCE[Math.max(0, Math.min(5, scoutLevel))];
+}
+
+// ── Attribute generator ───────────────────────────────────────────────────────
+
+function generateTargetAttributes(
+  position: Position,
+  attributePriority: 'attack' | 'defence' | 'teamwork' | null,
+  band: QualityBand,
+  rng: ReturnType<typeof createRng>,
+): PlayerAttributes {
+  const { attrMin, attrMax } = band;
+
+  // Base attributes for position
+  let attack: number;
+  let defence: number;
+  let teamwork: number;
+
+  switch (position) {
+    case 'GK':
+      attack  = rng.nextInt(10, 25);
+      defence = rng.nextInt(attrMin + 5, attrMax + 5);
+      teamwork = rng.nextInt(attrMin - 10, attrMax - 5);
+      break;
+    case 'DEF':
+      attack  = rng.nextInt(attrMin - 15, attrMax - 10);
+      defence = rng.nextInt(attrMin + 5, attrMax + 5);
+      teamwork = rng.nextInt(attrMin - 5, attrMax);
+      break;
+    case 'MID':
+      attack  = rng.nextInt(attrMin - 5, attrMax);
+      defence = rng.nextInt(attrMin - 5, attrMax);
+      teamwork = rng.nextInt(attrMin, attrMax + 5);
+      break;
+    case 'FWD':
+      attack  = rng.nextInt(attrMin + 5, attrMax + 10);
+      defence = rng.nextInt(attrMin - 20, attrMax - 10);
+      teamwork = rng.nextInt(attrMin - 10, attrMax);
+      break;
+  }
+
+  // Attribute priority boosts the relevant stat by ~10%
+  if (attributePriority === 'attack')   attack   = Math.min(99, Math.round(attack   * 1.1));
+  if (attributePriority === 'defence')  defence  = Math.min(99, Math.round(defence  * 1.1));
+  if (attributePriority === 'teamwork') teamwork = Math.min(99, Math.round(teamwork * 1.1));
+
+  const charisma       = rng.nextInt(30, 70);
+  const publicPotential = rng.nextInt(attrMin - 10, attrMax);
+
+  return {
+    attack:          Math.max(1, attack),
+    defence:         Math.max(1, defence),
+    teamwork:        Math.max(1, teamwork),
+    charisma,
+    publicPotential: Math.max(1, Math.min(99, publicPotential)),
+  };
+}
+
+// ── Main export ───────────────────────────────────────────────────────────────
+
+export interface ScoutTargetResult {
+  player: Player;
+  npcClubId: string;
+  npcClubName: string;
+  askingPrice: number;
+}
+
+/**
+ * Deterministically generate the player a scout finds, given mission context.
+ *
+ * Seeded from baseSeed + season + week so the same state always produces the
+ * same target. Upgrading the Scout Network before the week ticks will change
+ * the quality band but same target identity within that band.
+ */
+export function generateScoutTarget(
+  position: Position,
+  attributePriority: 'attack' | 'defence' | 'teamwork' | null,
+  scoutLevel: number,
+  baseSeed: string,
+  season: number,
+  week: number,
+  playerClubId: string,
+): ScoutTargetResult {
+  const level = Math.max(0, Math.min(5, scoutLevel));
+  const band  = QUALITY_BAND[level];
+  const rng   = createRng(`scout-${baseSeed}-S${season}-W${week}`);
+
+  // Pick an NPC club (not the player's own club)
+  const eligibleClubs = LEAGUE_TWO_TEAMS.filter(t => t.id !== playerClubId);
+  const npcClub = eligibleClubs[rng.nextInt(0, eligibleClubs.length - 1)];
+
+  // Pick a name
+  const name = TARGET_NAMES[rng.nextInt(0, TARGET_NAMES.length - 1)];
+
+  // Age: typically 20–32 for contracted players
+  const age = rng.nextInt(20, 32);
+
+  // Attributes
+  const attributes = generateTargetAttributes(position, attributePriority, band, rng);
+
+  // Overall rating: average of primary attributes
+  const overallRating = Math.round(
+    (attributes.attack + attributes.defence + attributes.teamwork) / 3
+  );
+
+  // Wage: within the band
+  const wage = rng.nextInt(band.wageMin, band.wageMax);
+
+  // truePotential: public ± offset
+  const potentialOffset = rng.nextInt(0, 20);
+  const potentialDirection = rng.next() < 0.5 ? 1 : -1;
+  const truePotential = Math.max(1, Math.min(99,
+    attributes.publicPotential + potentialDirection * potentialOffset
+  ));
+
+  // Morale: contracted players are generally content
+  const morale = rng.nextInt(55, 80);
+
+  // Transfer value / asking price: same formula as SELL_PLAYER_TO_NPC
+  const askingPrice = Math.max(10_000_00, overallRating * overallRating * 800);
+
+  const player: Player = {
+    id: `scout-target-S${season}-W${week}-${position}`,
+    name,
+    overallRating,
+    position,
+    wage,
+    transferValue: askingPrice,
+    age,
+    morale,
+    attributes,
+    truePotential,
+    contractExpiresWeek: 0, // updated on SCOUT_TRANSFER_COMPLETED
+    stats: {
+      goals: 0,
+      assists: 0,
+      cleanSheets: 0,
+      appearances: 0,
+      averageRating: overallRating,
+    },
+  };
+
+  return { player, npcClubId: npcClub.id, npcClubName: npcClub.name, askingPrice };
+}

--- a/packages/domain/src/events/types.ts
+++ b/packages/domain/src/events/types.ts
@@ -5,7 +5,7 @@
  * They are immutable facts that build up the event stream.
  */
 
-import { Player } from '../types/player';
+import { Player, Position } from '../types/player';
 import { Staff, Manager } from '../types/staff';
 import { PendingClubEvent } from '../types/game-state-updated';
 import { TrainingFocus } from '../types/facility';
@@ -33,7 +33,12 @@ export type GameEvent =
   | NpcPlayerSignedEvent
   | ManagerHiredEvent
   | ManagerSackedEvent
-  | PreSeasonStartedEvent;
+  | PreSeasonStartedEvent
+  | ScoutMissionStartedEvent
+  | ScoutTargetFoundEvent
+  | ScoutBidPlacedEvent
+  | ScoutTransferCompletedEvent
+  | ScoutMissionCancelledEvent;
 
 export interface TransferCompletedEvent {
   type: 'TRANSFER_COMPLETED';
@@ -237,4 +242,57 @@ export interface PreSeasonStartedEvent {
   timestamp: number;
   /** The new season number (previous season + 1) */
   season: number;
+}
+
+// ── Scout Mission Events ───────────────────────────────────────────────────────
+
+export interface ScoutMissionStartedEvent {
+  type: 'SCOUT_MISSION_STARTED';
+  timestamp: number;
+  clubId: string;
+  position: Position;
+  attributePriority: 'attack' | 'defence' | 'teamwork' | null;
+  budgetCeiling: number;   // pence
+  scoutFee: number;        // pence deducted from transferBudget
+  weekStarted: number;
+}
+
+/** Emitted on the week tick after SCOUT_MISSION_STARTED — player identified at NPC club */
+export interface ScoutTargetFoundEvent {
+  type: 'SCOUT_TARGET_FOUND';
+  timestamp: number;
+  clubId: string;
+  target: Player;
+  targetNpcClubId: string;
+  targetNpcClubName: string;
+  /** Transfer fee the NPC club is asking, in pence */
+  askingPrice: number;
+}
+
+/** Emitted when the player attempts negotiation (math challenge result) */
+export interface ScoutBidPlacedEvent {
+  type: 'SCOUT_BID_PLACED';
+  timestamp: number;
+  clubId: string;
+  /** true = challenge passed, bid pending window; false = rejected, can retry */
+  negotiationPassed: boolean;
+  /** Wage offered to the player, stored until window opens */
+  offeredWage: number;
+}
+
+/** Emitted at the start of the first eligible transfer window week after a successful bid */
+export interface ScoutTransferCompletedEvent {
+  type: 'SCOUT_TRANSFER_COMPLETED';
+  timestamp: number;
+  clubId: string;
+  player: Player;          // full player object with agreed wage + contract
+  fee: number;             // pence deducted from transferBudget
+  targetNpcClubId: string;
+  targetNpcClubName: string;
+}
+
+export interface ScoutMissionCancelledEvent {
+  type: 'SCOUT_MISSION_CANCELLED';
+  timestamp: number;
+  clubId: string;
 }

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -37,6 +37,7 @@ export * from './data/club-events';
 export * from './data/squad-generator';
 export * from './data/free-agent-generator';
 export * from './data/manager-generator';
+export * from './data/scout-target-generator';
 
 // Morale system
 export { isUnsettled, avgSquadMorale, UNSETTLED_THRESHOLD } from './simulation/morale';

--- a/packages/domain/src/reducers/index.ts
+++ b/packages/domain/src/reducers/index.ts
@@ -4,7 +4,7 @@
  * Pure functions that apply events to state.
  */
 
-import { GameEvent, GameStartedEvent, MatchSimulatedEvent, TransferCompletedEvent, StaffHiredEvent, MathAttemptRecordedEvent, ClubEventOccurredEvent, ClubEventResolvedEvent, SeasonStartedEvent, TrainingFocusSetEvent, FormationSetEvent, FreeAgentSignedEvent, PlayerReleasedEvent, NpcPlayerSignedEvent, ManagerHiredEvent, ManagerSackedEvent, PreSeasonStartedEvent } from '../events/types';
+import { GameEvent, GameStartedEvent, MatchSimulatedEvent, TransferCompletedEvent, StaffHiredEvent, MathAttemptRecordedEvent, ClubEventOccurredEvent, ClubEventResolvedEvent, SeasonStartedEvent, TrainingFocusSetEvent, FormationSetEvent, FreeAgentSignedEvent, PlayerReleasedEvent, NpcPlayerSignedEvent, ManagerHiredEvent, ManagerSackedEvent, PreSeasonStartedEvent, ScoutMissionStartedEvent, ScoutTargetFoundEvent, ScoutBidPlacedEvent, ScoutTransferCompletedEvent } from '../events/types';
 import { GameState } from '../types/game-state-updated';
 import { Club } from '../types/club';
 import { LeagueTable, LeagueTableEntry, sortLeagueTable } from '../types/league';
@@ -71,6 +71,16 @@ export function reduceEvent(state: GameState, event: GameEvent): GameState {
       return handleManagerSacked(state, event);
     case 'PRE_SEASON_STARTED':
       return handlePreSeasonStarted(state, event);
+    case 'SCOUT_MISSION_STARTED':
+      return handleScoutMissionStarted(state, event);
+    case 'SCOUT_TARGET_FOUND':
+      return handleScoutTargetFound(state, event);
+    case 'SCOUT_BID_PLACED':
+      return handleScoutBidPlaced(state, event);
+    case 'SCOUT_TRANSFER_COMPLETED':
+      return handleScoutTransferCompleted(state, event);
+    case 'SCOUT_MISSION_CANCELLED':
+      return handleScoutMissionCancelled(state);
     default:
       return state;
   }
@@ -111,6 +121,7 @@ export function buildState(events: GameEvent[]): GameState {
     managerPool: [],
     lowMoraleWeeks: 0,
     moraleEventCooldowns: {},
+    scoutMission: null,
   };
 
   return events.reduce(reduceEvent, initialState);
@@ -659,6 +670,72 @@ function handlePreSeasonStarted(state: GameState, event: PreSeasonStartedEvent):
       trainingFocus: null,
       preferredFormation: null,
     },
+  };
+}
+
+// ── Scout Mission Reducers ────────────────────────────────────────────────────
+
+function handleScoutMissionStarted(state: GameState, event: ScoutMissionStartedEvent): GameState {
+  return {
+    ...state,
+    scoutMission: {
+      status:           'SEARCHING',
+      position:          event.position,
+      attributePriority: event.attributePriority,
+      budgetCeiling:     event.budgetCeiling,
+      scoutFee:          event.scoutFee,
+      weekStarted:       event.weekStarted,
+    },
+    club: {
+      ...state.club,
+      transferBudget: state.club.transferBudget - event.scoutFee,
+    },
+  };
+}
+
+function handleScoutTargetFound(state: GameState, event: ScoutTargetFoundEvent): GameState {
+  if (!state.scoutMission) return state;
+  return {
+    ...state,
+    scoutMission: {
+      ...state.scoutMission,
+      status:            'TARGET_FOUND',
+      target:             event.target,
+      targetNpcClubId:    event.targetNpcClubId,
+      targetNpcClubName:  event.targetNpcClubName,
+      askingPrice:        event.askingPrice,
+    },
+  };
+}
+
+function handleScoutBidPlaced(state: GameState, event: ScoutBidPlacedEvent): GameState {
+  if (!state.scoutMission) return state;
+  return {
+    ...state,
+    scoutMission: {
+      ...state.scoutMission,
+      status:      event.negotiationPassed ? 'BID_PENDING' : 'BID_REJECTED',
+      offeredWage: event.offeredWage,
+    },
+  };
+}
+
+function handleScoutTransferCompleted(state: GameState, event: ScoutTransferCompletedEvent): GameState {
+  return {
+    ...state,
+    scoutMission: null,
+    club: {
+      ...state.club,
+      squad: [...state.club.squad, event.player],
+      transferBudget: state.club.transferBudget - event.fee,
+    },
+  };
+}
+
+function handleScoutMissionCancelled(state: GameState): GameState {
+  return {
+    ...state,
+    scoutMission: null,
   };
 }
 

--- a/packages/domain/src/types/facility.ts
+++ b/packages/domain/src/types/facility.ts
@@ -317,3 +317,22 @@ export function scoutNoiseRange(scoutLevel: number): number {
 export function getScoutLevel(facilities: Facility[]): number {
   return facilities.find(f => f.type === 'SCOUT_NETWORK')?.level ?? 0;
 }
+
+/**
+ * Returns true when a transfer can legally complete.
+ * Pre-season is always open.
+ * In-season: summer window (weeks 1–4) and January window (weeks 21–24).
+ */
+export function isTransferWindowOpen(week: number, phase: string): boolean {
+  if (phase === 'PRE_SEASON') return true;
+  return (week >= 1 && week <= 4) || (week >= 21 && week <= 24);
+}
+
+/**
+ * Human-readable label for the next transfer window that will open,
+ * relative to the current in-season week.
+ */
+export function nextWindowLabel(week: number): string {
+  if (week < 21) return 'January window (week 21)';
+  return 'next summer window (start of next season)';
+}

--- a/packages/domain/src/types/game-state-updated.ts
+++ b/packages/domain/src/types/game-state-updated.ts
@@ -9,7 +9,7 @@ import { GameEvent } from '../events/types';
 import { Club } from './club';
 import { LeagueTable } from './league';
 import { CurriculumConfig } from '../curriculum/curriculum-config';
-import { Player } from './player';
+import { Player, Position } from './player';
 import { Manager } from './staff';
 
 /**
@@ -52,6 +52,34 @@ export interface PendingClubEvent {
     npcClubName?: string;
     offeredFee?: number;
   };
+}
+
+// ── Scout Mission ─────────────────────────────────────────────────────────────
+
+export type ScoutMissionStatus =
+  | 'SEARCHING'     // Scout is out looking — resolves to TARGET_FOUND on next week tick
+  | 'TARGET_FOUND'  // Player identified at NPC club — awaiting bid
+  | 'BID_PENDING'   // Math challenge passed, bid submitted — completes when window opens
+  | 'BID_REJECTED'; // Math challenge failed — can re-bid
+
+export interface ScoutMission {
+  status: ScoutMissionStatus;
+  position: Position;
+  attributePriority: 'attack' | 'defence' | 'teamwork' | null;
+  /** Maximum transfer fee willing to pay, in pence */
+  budgetCeiling: number;
+  /** Scout fee already paid upfront, in pence */
+  scoutFee: number;
+  /** Week the mission was started */
+  weekStarted: number;
+  /** Populated when status moves to TARGET_FOUND */
+  target?: Player;
+  targetNpcClubId?: string;
+  targetNpcClubName?: string;
+  /** Transfer fee the NPC club wants, in pence */
+  askingPrice?: number;
+  /** Wage offered by the player — stored when bid is placed, used on window open */
+  offeredWage?: number;
 }
 
 /**
@@ -116,6 +144,12 @@ export interface GameState {
    * Prevents the same event firing more than once per 6 weeks.
    */
   moraleEventCooldowns: Record<string, number>;
+
+  /**
+   * Active scout mission, if any.
+   * Only one mission can be active at a time.
+   */
+  scoutMission: ScoutMission | null;
 }
 
 /**

--- a/packages/frontend/src/components/stadium-view/ScoutNetworkSlideOver.tsx
+++ b/packages/frontend/src/components/stadium-view/ScoutNetworkSlideOver.tsx
@@ -1,0 +1,587 @@
+/**
+ * ScoutNetworkSlideOver
+ *
+ * Opened when the player clicks the Scout Network core unit.
+ *
+ * State machine reflected in the UI:
+ *   NO_MISSION   → pick position/priority, start mission
+ *   SEARCHING    → "Scout is out, results next week"
+ *   TARGET_FOUND → player card + wage offer + negotiate (math challenge)
+ *   BID_PENDING  → "Bid submitted, transfer completes when window opens"
+ *   BID_REJECTED → player card + "Negotiation failed — try again"
+ */
+
+import { useState } from 'react';
+import {
+  GameState,
+  GameCommand,
+  Position,
+  formatMoney,
+  getScoutedPotential,
+  scoutNoiseRange,
+  getScoutLevel,
+  nextWindowLabel,
+  getScoutFee,
+} from '@calculating-glory/domain';
+import { SlideOver } from '../shared/SlideOver';
+import { MathChallengeCard } from '../social-feed/MathChallengeCard';
+import { generateChallenge } from '../social-feed/generateChallenge';
+
+interface ScoutNetworkSlideOverProps {
+  isOpen:   boolean;
+  onClose:  () => void;
+  state:    GameState;
+  dispatch: (command: GameCommand) => { error?: string };
+}
+
+const POSITIONS: Position[]         = ['GK', 'DEF', 'MID', 'FWD'];
+const ATTR_OPTIONS                  = [null, 'attack', 'defence', 'teamwork'] as const;
+type  AttrPriority                  = typeof ATTR_OPTIONS[number];
+const ATTR_LABELS: Record<string, string> = {
+  attack: 'Attacking',
+  defence: 'Defensive',
+  teamwork: 'Teamwork',
+};
+
+export function ScoutNetworkSlideOver({
+  isOpen, onClose, state, dispatch,
+}: ScoutNetworkSlideOverProps) {
+  const { club, scoutMission } = state;
+  const scoutLevel = getScoutLevel(club.facilities);
+  const scoutFee   = getScoutFee(scoutLevel);
+  const noiseRange = scoutNoiseRange(scoutLevel);
+
+  // ── Form state (NO_MISSION view) ────────────────────────────────────────────
+  const [position,   setPosition]   = useState<Position>('MID');
+  const [attrPri,    setAttrPri]    = useState<AttrPriority>(null);
+  const [budgetCeil, setBudgetCeil] = useState(
+    Math.floor(club.transferBudget / 2 / 100) * 100  // half current budget, rounded
+  );
+
+  // ── Negotiate / math challenge state ────────────────────────────────────────
+  const [showChallenge, setShowChallenge]   = useState(false);
+  const [hintIndex,     setHintIndex]       = useState(0);
+  const [userAnswer,    setUserAnswer]      = useState('');
+  const [challengeIdx,  setChallengeIdx]    = useState(0);
+  const [offeredWage,   setOfferedWage]     = useState(
+    scoutMission?.target?.wage ?? 150_000
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const challenge = generateChallenge(state, challengeIdx, undefined, 'ratios');
+
+  function handleStartMission() {
+    if (budgetCeil <= 0) { setError('Set a budget ceiling above zero'); return; }
+    const result = dispatch({
+      type: 'START_SCOUT_MISSION',
+      position,
+      attributePriority: attrPri,
+      budgetCeiling: budgetCeil * 100, // UI is in pounds
+    });
+    if (result.error) setError(result.error);
+    else setError(null);
+  }
+
+  function handleCancel() {
+    const result = dispatch({ type: 'CANCEL_SCOUT_MISSION' });
+    if (result.error) setError(result.error);
+    else { setError(null); setShowChallenge(false); setUserAnswer(''); setHintIndex(0); }
+  }
+
+  function handleNegotiateClick() {
+    setOfferedWage(scoutMission?.target?.wage ?? 150_000);
+    setUserAnswer('');
+    setHintIndex(0);
+    setShowChallenge(true);
+  }
+
+  function handleSubmitAnswer() {
+    const parsed  = parseFloat(userAnswer);
+    const correct = !isNaN(parsed) && Math.abs(parsed - challenge.answer) < 0.05;
+
+    dispatch({
+      type:           'RECORD_MATH_ATTEMPT',
+      studentId:      club.id,
+      topic:          challenge.topic,
+      difficulty:     challenge.difficulty,
+      answer:         userAnswer,
+      expectedAnswer: String(challenge.answer),
+      startTime:      Date.now() - 5000,
+      endTime:        Date.now(),
+    });
+
+    const result = dispatch({
+      type:              'PLACE_SCOUT_BID',
+      negotiationPassed: correct,
+      offeredWage,
+    });
+
+    if (result.error) {
+      setError(result.error);
+    } else {
+      setError(null);
+      setShowChallenge(false);
+      setUserAnswer('');
+      setHintIndex(0);
+      if (!correct) setChallengeIdx(prev => prev + 1); // fresh challenge next time
+    }
+  }
+
+  // ── Shared header ────────────────────────────────────────────────────────────
+  function ScoutHeader() {
+    return (
+      <div className="px-4 py-3 bg-bg-raised border-b border-bg-raised/50 shrink-0 flex items-center justify-between">
+        <div>
+          <p className="text-xs2 text-txt-muted uppercase tracking-wide">Scout Level</p>
+          <p className="text-2xl font-black data-font text-pitch-green">{scoutLevel}</p>
+        </div>
+        <div className="text-right">
+          <p className="text-xs2 text-txt-muted uppercase tracking-wide">Potential reading</p>
+          <p className="text-sm font-semibold text-warn-amber">
+            {noiseRange === 0 ? 'Exact' : `±${noiseRange} noise`}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // VIEW: No active mission
+  // ────────────────────────────────────────────────────────────────────────────
+  if (!scoutMission) {
+    return (
+      <SlideOver isOpen={isOpen} onClose={onClose} title="🔭 Scout Network">
+        <div className="flex flex-col h-full">
+          <ScoutHeader />
+
+          <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-4">
+
+            {/* Scout fee callout */}
+            <div className="card bg-bg-raised border border-bg-raised/50">
+              <p className="text-xs2 text-txt-muted uppercase tracking-wide mb-1">Mission cost</p>
+              <p className="text-lg font-bold data-font text-data-blue">
+                {formatMoney(scoutFee)}
+              </p>
+              <p className="text-xs2 text-txt-muted mt-0.5">
+                Paid upfront. Scout finds a target next week.
+              </p>
+            </div>
+
+            {/* Position picker */}
+            <div>
+              <p className="text-xs text-txt-muted uppercase tracking-wide mb-2">Position needed</p>
+              <div className="grid grid-cols-4 gap-1.5">
+                {POSITIONS.map(pos => (
+                  <button
+                    key={pos}
+                    onClick={() => setPosition(pos)}
+                    className={[
+                      'py-2 rounded-card border text-sm font-bold transition-colors',
+                      position === pos
+                        ? 'bg-data-blue/20 border-data-blue text-data-blue'
+                        : 'bg-bg-raised border-bg-raised/50 text-txt-muted hover:border-data-blue/40',
+                    ].join(' ')}
+                  >
+                    {pos}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Attribute priority */}
+            <div>
+              <p className="text-xs text-txt-muted uppercase tracking-wide mb-2">
+                Attribute priority <span className="normal-case text-txt-muted/60">(optional)</span>
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {ATTR_OPTIONS.map(opt => (
+                  <button
+                    key={opt ?? 'none'}
+                    onClick={() => setAttrPri(opt)}
+                    className={[
+                      'px-3 py-1.5 rounded-tag border text-xs font-semibold transition-colors',
+                      attrPri === opt
+                        ? 'bg-pitch-green/20 border-pitch-green text-pitch-green'
+                        : 'bg-bg-raised border-bg-raised/50 text-txt-muted hover:border-pitch-green/40',
+                    ].join(' ')}
+                  >
+                    {opt === null ? 'Any' : ATTR_LABELS[opt]}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Budget ceiling */}
+            <div>
+              <p className="text-xs text-txt-muted uppercase tracking-wide mb-1">
+                Max transfer fee (£)
+              </p>
+              <input
+                type="number"
+                min={0}
+                step={1000}
+                value={Math.round(budgetCeil / 100)}
+                onChange={e => setBudgetCeil(Number(e.target.value) * 100)}
+                className="w-full bg-bg-raised border border-bg-raised/50 rounded-card px-3 py-2 text-sm text-txt-primary data-font focus:outline-none focus:border-data-blue/60"
+              />
+              <p className="text-xs2 text-txt-muted mt-1">
+                Available: {formatMoney(club.transferBudget)}
+              </p>
+            </div>
+
+            {error && (
+              <p className="text-xs text-warn-red bg-warn-red/10 border border-warn-red/30 rounded-card px-3 py-2">
+                {error}
+              </p>
+            )}
+
+            {/* CTA */}
+            <button
+              onClick={handleStartMission}
+              disabled={scoutFee > club.transferBudget}
+              className="btn-primary w-full disabled:opacity-40"
+            >
+              Start Scout Mission — {formatMoney(scoutFee)}
+            </button>
+
+            {scoutFee > club.transferBudget && (
+              <p className="text-xs2 text-txt-muted text-center -mt-2">
+                Insufficient budget for scout fee
+              </p>
+            )}
+          </div>
+        </div>
+      </SlideOver>
+    );
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // VIEW: SEARCHING
+  // ────────────────────────────────────────────────────────────────────────────
+  if (scoutMission.status === 'SEARCHING') {
+    return (
+      <SlideOver isOpen={isOpen} onClose={onClose} title="🔭 Scout Network">
+        <div className="flex flex-col h-full">
+          <ScoutHeader />
+          <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-4">
+
+            <div className="card bg-data-blue/5 border border-data-blue/30 flex flex-col gap-2">
+              <div className="flex items-center gap-2">
+                <span className="text-lg animate-pulse">🔍</span>
+                <p className="text-sm font-semibold text-data-blue">Scout is searching…</p>
+              </div>
+              <p className="text-xs2 text-txt-muted">
+                Looking for a{' '}
+                <span className="text-txt-primary font-semibold">
+                  {scoutMission.attributePriority
+                    ? `${ATTR_LABELS[scoutMission.attributePriority]} `
+                    : ''}
+                  {scoutMission.position}
+                </span>{' '}
+                with a max fee of{' '}
+                <span className="text-txt-primary font-semibold">
+                  {formatMoney(scoutMission.budgetCeiling)}
+                </span>.
+              </p>
+              <p className="text-xs2 text-txt-muted border-t border-data-blue/20 pt-2">
+                Results arrive next week.
+              </p>
+            </div>
+
+            {error && (
+              <p className="text-xs text-warn-red bg-warn-red/10 border border-warn-red/30 rounded-card px-3 py-2">
+                {error}
+              </p>
+            )}
+
+            <button
+              onClick={handleCancel}
+              className="btn-secondary w-full text-warn-red border-warn-red/40 hover:bg-warn-red/10"
+            >
+              Cancel Mission
+            </button>
+
+          </div>
+        </div>
+      </SlideOver>
+    );
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // VIEWS: TARGET_FOUND / BID_REJECTED
+  // ────────────────────────────────────────────────────────────────────────────
+  if (scoutMission.status === 'TARGET_FOUND' || scoutMission.status === 'BID_REJECTED') {
+    const target       = scoutMission.target!;
+    const scoutedPot   = getScoutedPotential(target, scoutLevel);
+    const potPrefix    = noiseRange >= 10 ? '~' : noiseRange >= 3 ? '≈' : '';
+    const askingPrice  = scoutMission.askingPrice!;
+    const canAfford    = askingPrice <= club.transferBudget;
+    const currentTotalWages = club.squad.reduce((s, p) => s + p.wage, 0);
+    const wageRoomLeft = club.wageBudget - currentTotalWages;
+    const wageOfferedPounds = Math.round(offeredWage / 100);
+
+    return (
+      <SlideOver isOpen={isOpen} onClose={onClose} title="🔭 Scout Network">
+        <div className="flex flex-col h-full">
+          <ScoutHeader />
+          <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-4">
+
+            {/* Status banner */}
+            {scoutMission.status === 'BID_REJECTED' && (
+              <div className="card bg-warn-red/10 border border-warn-red/30">
+                <p className="text-xs font-semibold text-warn-red">
+                  Negotiation failed — the player wasn't convinced. Try again.
+                </p>
+              </div>
+            )}
+
+            {/* Target player card */}
+            <div className="card bg-bg-raised border border-bg-raised/50">
+              <div className="flex items-start justify-between mb-3">
+                <div>
+                  <p className="text-sm font-bold text-txt-primary">{target.name}</p>
+                  <p className="text-xs2 text-txt-muted mt-0.5">
+                    Age {target.age} · {target.position} · {scoutMission.targetNpcClubName}
+                  </p>
+                </div>
+                <div className="text-right">
+                  <p className="text-xl font-black data-font text-data-blue">
+                    {target.overallRating}
+                  </p>
+                  <p className="text-xs2 text-txt-muted">OVR</p>
+                </div>
+              </div>
+
+              {/* Attributes */}
+              <div className="grid grid-cols-3 gap-2 text-center mb-3">
+                {[
+                  { label: 'ATK', val: target.attributes.attack },
+                  { label: 'DEF', val: target.attributes.defence },
+                  { label: 'TWK', val: target.attributes.teamwork },
+                ].map(({ label, val }) => (
+                  <div key={label} className="bg-bg-deep rounded-tag py-1.5">
+                    <p className="text-xs2 text-txt-muted">{label}</p>
+                    <p className="text-sm font-bold data-font text-txt-primary">{val}</p>
+                  </div>
+                ))}
+              </div>
+
+              {/* Potential */}
+              <div className="flex items-center justify-between border-t border-bg-raised/50 pt-2">
+                <p className="text-xs2 text-txt-muted">Scouted potential</p>
+                <p className="text-sm font-bold data-font text-warn-amber">
+                  {potPrefix}{scoutedPot}
+                  {noiseRange > 0 && (
+                    <span className="text-xs2 text-txt-muted font-normal ml-1">
+                      (±{noiseRange})
+                    </span>
+                  )}
+                </p>
+              </div>
+
+              {/* Asking price */}
+              <div className="flex items-center justify-between mt-1">
+                <p className="text-xs2 text-txt-muted">Asking price</p>
+                <p className={[
+                  'text-sm font-bold data-font',
+                  canAfford ? 'text-pitch-green' : 'text-warn-red',
+                ].join(' ')}>
+                  {formatMoney(askingPrice)}
+                </p>
+              </div>
+
+              {/* Current wage */}
+              <div className="flex items-center justify-between mt-1">
+                <p className="text-xs2 text-txt-muted">Current wage</p>
+                <p className="text-sm font-bold data-font text-txt-primary">
+                  {formatMoney(target.wage)}/wk
+                </p>
+              </div>
+            </div>
+
+            {/* Transfer window note */}
+            <div className="card bg-warn-amber/5 border border-warn-amber/20">
+              <p className="text-xs2 text-txt-muted">
+                <span className="text-warn-amber font-semibold">Transfer window: </span>
+                A successful bid is held until the window opens
+                ({nextWindowLabel(state.currentWeek)}). Scouting and
+                negotiating can happen any time.
+              </p>
+            </div>
+
+            {/* Wage offer input */}
+            {!showChallenge && (
+              <div>
+                <p className="text-xs text-txt-muted uppercase tracking-wide mb-1">
+                  Wage offer (£/week)
+                </p>
+                <input
+                  type="number"
+                  min={0}
+                  step={100}
+                  value={wageOfferedPounds}
+                  onChange={e => setOfferedWage(Number(e.target.value) * 100)}
+                  className="w-full bg-bg-raised border border-bg-raised/50 rounded-card px-3 py-2 text-sm text-txt-primary data-font focus:outline-none focus:border-data-blue/60"
+                />
+                <p className="text-xs2 text-txt-muted mt-1">
+                  Wage room: {formatMoney(wageRoomLeft)}/wk remaining
+                </p>
+              </div>
+            )}
+
+            {/* Math challenge */}
+            {showChallenge && (
+              <div className="flex flex-col gap-3">
+                <p className="text-xs text-txt-muted uppercase tracking-wide">
+                  Negotiate the transfer — solve to proceed
+                </p>
+                <MathChallengeCard challenge={challenge} hintIndex={hintIndex} />
+
+                <div className="flex gap-2">
+                  <input
+                    type="number"
+                    placeholder="Your answer"
+                    value={userAnswer}
+                    onChange={e => setUserAnswer(e.target.value)}
+                    onKeyDown={e => e.key === 'Enter' && handleSubmitAnswer()}
+                    className="flex-1 bg-bg-raised border border-bg-raised/50 rounded-card px-3 py-2 text-sm text-txt-primary data-font focus:outline-none focus:border-data-blue/60"
+                  />
+                  {hintIndex < 3 && (
+                    <button
+                      onClick={() => setHintIndex(h => Math.min(h + 1, 3))}
+                      className="btn-secondary text-xs px-3"
+                    >
+                      Hint
+                    </button>
+                  )}
+                </div>
+
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleSubmitAnswer}
+                    disabled={!userAnswer}
+                    className="btn-primary flex-1 disabled:opacity-40"
+                  >
+                    Submit Answer
+                  </button>
+                  <button
+                    onClick={() => { setShowChallenge(false); setUserAnswer(''); setHintIndex(0); }}
+                    className="btn-secondary px-4"
+                  >
+                    Back
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {error && (
+              <p className="text-xs text-warn-red bg-warn-red/10 border border-warn-red/30 rounded-card px-3 py-2">
+                {error}
+              </p>
+            )}
+
+            {/* CTA row */}
+            {!showChallenge && (
+              <div className="flex flex-col gap-2">
+                <button
+                  onClick={handleNegotiateClick}
+                  disabled={!canAfford || offeredWage > wageRoomLeft}
+                  className="btn-primary w-full disabled:opacity-40"
+                >
+                  {scoutMission.status === 'BID_REJECTED' ? 'Try Again' : 'Negotiate Transfer'}
+                </button>
+                {!canAfford && (
+                  <p className="text-xs2 text-warn-red text-center">
+                    Budget too low for asking price
+                  </p>
+                )}
+                {offeredWage > wageRoomLeft && canAfford && (
+                  <p className="text-xs2 text-warn-red text-center">
+                    Wage offer exceeds remaining wage room
+                  </p>
+                )}
+                <button onClick={handleCancel} className="btn-secondary w-full text-xs">
+                  Abandon Mission
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </SlideOver>
+    );
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // VIEW: BID_PENDING
+  // ────────────────────────────────────────────────────────────────────────────
+  const target      = scoutMission.target!;
+  const scoutedPot  = getScoutedPotential(target, scoutLevel);
+  const potPrefix   = noiseRange >= 10 ? '~' : noiseRange >= 3 ? '≈' : '';
+
+  return (
+    <SlideOver isOpen={isOpen} onClose={onClose} title="🔭 Scout Network">
+      <div className="flex flex-col h-full">
+        <ScoutHeader />
+        <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-4">
+
+          {/* Status banner */}
+          <div className="card bg-pitch-green/10 border border-pitch-green/30">
+            <div className="flex items-center gap-2 mb-1">
+              <span className="text-pitch-green">✓</span>
+              <p className="text-sm font-semibold text-pitch-green">Bid submitted</p>
+            </div>
+            <p className="text-xs2 text-txt-muted">
+              Transfer will complete when the{' '}
+              <span className="text-warn-amber font-semibold">
+                {nextWindowLabel(state.currentWeek)}
+              </span>{' '}
+              opens.
+            </p>
+          </div>
+
+          {/* Target summary card */}
+          <div className="card bg-bg-raised border border-bg-raised/50">
+            <div className="flex items-start justify-between mb-2">
+              <div>
+                <p className="text-sm font-bold text-txt-primary">{target.name}</p>
+                <p className="text-xs2 text-txt-muted mt-0.5">
+                  Age {target.age} · {target.position} · {scoutMission.targetNpcClubName}
+                </p>
+              </div>
+              <div className="text-right">
+                <p className="text-xl font-black data-font text-data-blue">
+                  {target.overallRating}
+                </p>
+                <p className="text-xs2 text-txt-muted">OVR</p>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between border-t border-bg-raised/50 pt-2">
+              <p className="text-xs2 text-txt-muted">Scouted potential</p>
+              <p className="text-sm font-bold data-font text-warn-amber">
+                {potPrefix}{scoutedPot}
+              </p>
+            </div>
+            <div className="flex items-center justify-between mt-1">
+              <p className="text-xs2 text-txt-muted">Agreed fee</p>
+              <p className="text-sm font-bold data-font text-pitch-green">
+                {formatMoney(scoutMission.askingPrice!)}
+              </p>
+            </div>
+            <div className="flex items-center justify-between mt-1">
+              <p className="text-xs2 text-txt-muted">Agreed wage</p>
+              <p className="text-sm font-bold data-font text-pitch-green">
+                {formatMoney(scoutMission.offeredWage!)}/wk
+              </p>
+            </div>
+          </div>
+
+          <button onClick={handleCancel} className="btn-secondary w-full text-xs text-warn-red border-warn-red/40 hover:bg-warn-red/10">
+            Pull Out of Deal
+          </button>
+
+        </div>
+      </div>
+    </SlideOver>
+  );
+}

--- a/packages/frontend/src/components/stadium-view/StadiumView.tsx
+++ b/packages/frontend/src/components/stadium-view/StadiumView.tsx
@@ -27,6 +27,7 @@ import { TrainingFocusSlideOver }           from './TrainingFocusSlideOver';
 import { FixturesSlideOver }                from './FixturesSlideOver';
 import { BoardConfidenceSlideOver }         from './BoardConfidenceSlideOver';
 import { ScoutingSlideOver }                from './ScoutingSlideOver';
+import { ScoutNetworkSlideOver }           from './ScoutNetworkSlideOver';
 
 // Commercial facilities always open the upgrade panel (no dedicated nav destination)
 const COMMERCIAL_TYPES = new Set<FacilityType>([
@@ -50,8 +51,9 @@ export function StadiumView({ state, dispatch, onError }: StadiumViewProps) {
   const [fixturesOpen,  setFixturesOpen]  = useState(false);
   const [trainingOpen,     setTrainingOpen]     = useState(false);
   const [backroomOpen,  setBackroomOpen]  = useState(false);
-  const [boardOpen,     setBoardOpen]     = useState(false);
-  const [scoutingOpen,  setScoutingOpen]  = useState(false);
+  const [boardOpen,        setBoardOpen]        = useState(false);
+  const [scoutingOpen,     setScoutingOpen]     = useState(false);
+  const [scoutNetworkOpen, setScoutNetworkOpen] = useState(false);
 
   // ── Handlers ──────────────────────────────────────────────────────────────
 
@@ -79,8 +81,9 @@ export function StadiumView({ state, dispatch, onError }: StadiumViewProps) {
       case 'STADIUM':         setFixturesOpen(true);  break;
       case 'TRAINING_GROUND': setTrainingOpen(true);     break;
       case 'MEDICAL_CENTER':  setBackroomOpen(true);  break;
-      case 'YOUTH_ACADEMY':   setScoutingOpen(true);  break;
-      case 'CLUB_OFFICE':     setBoardOpen(true);     break;
+      case 'YOUTH_ACADEMY':   setScoutingOpen(true);      break;
+      case 'SCOUT_NETWORK':   setScoutNetworkOpen(true);  break;
+      case 'CLUB_OFFICE':     setBoardOpen(true);         break;
     }
   }
 
@@ -178,6 +181,14 @@ export function StadiumView({ state, dispatch, onError }: StadiumViewProps) {
         isOpen={scoutingOpen}
         onClose={() => setScoutingOpen(false)}
         state={state}
+      />
+
+      {/* SCOUT_NETWORK → Scout Network */}
+      <ScoutNetworkSlideOver
+        isOpen={scoutNetworkOpen}
+        onClose={() => setScoutNetworkOpen(false)}
+        state={state}
+        dispatch={dispatch}
       />
 
       {/* CLUB_OFFICE → Board Confidence */}


### PR DESCRIPTION
## Summary

- **Scout missions**: pay a flat fee (scaled by scout level) to send your scout looking for a contracted player at a chosen position with an optional attribute priority
- **State machine**: `SEARCHING → TARGET_FOUND → BID_PENDING / BID_REJECTED` — failed negotiation allows re-bidding without starting over
- **Maths challenge gate**: to proceed with a bid, the player solves an inline maths question (reuses the existing `MathChallengeCard` + `generateChallenge` infrastructure)
- **Transfer window gating**: PRE_SEASON always open; summer window weeks 1–4; January window weeks 21–24 — a successful bid is held until the window opens, revealed at week start
- **25 new domain tests**, all passing alongside the existing 320+ suite

## What's in this PR

**Domain (`packages/domain`)**
- `ScoutMission` interface + `ScoutMissionStatus` type on `GameState`
- 5 new events, 3 new commands, full reducer coverage
- `scout-target-generator.ts` — deterministic player gen seeded on `baseSeed + season + week`, 6 quality bands, `getScoutFee()` fee ladder
- `isTransferWindowOpen()` / `nextWindowLabel()` helpers on `facility.ts`
- `SCOUT_TRANSFER_COMPLETED` fires inside `handleSimulateWeek` alongside match sim + `WEEK_ADVANCED` (no early return)

**Frontend (`packages/frontend`)**
- `ScoutNetworkSlideOver.tsx` — 5-state slide-over (no mission, searching, target found, bid pending, bid rejected)
- Scout Network tile added to `stadium-layout.ts` (gc:1, gr:7)
- `StadiumView` wired to open `ScoutNetworkSlideOver` on Scout Network tile click (level 1+)

## Test plan

- [ ] Build Scout Network to level 1 (£15,000), click 🔭 tile → NO_MISSION screen
- [ ] Start a mission (pick position, priority, budget) → SEARCHING screen with cancel
- [ ] Advance 1 week → TARGET_FOUND with player card, noisy potential, asking price
- [ ] Click Negotiate → inline maths challenge appears
- [ ] Submit correct answer → BID_PENDING, window label shown
- [ ] Advance to week 21 → player appears in squad, fee deducted
- [ ] Test wrong answer → BID_REJECTED, re-bid available without new search
- [ ] Cancel mission from SEARCHING → returns to NO_MISSION
- [ ] Pull Out of Deal from BID_PENDING → returns to NO_MISSION

🤖 Generated with [Claude Code](https://claude.com/claude-code)