### PR TITLE
feat: Phase 5.8 — owner forced out & takeover flow

### DIFF
--- a/packages/domain/src/__tests__/forced-out.test.ts
+++ b/packages/domain/src/__tests__/forced-out.test.ts
@@ -1,0 +1,446 @@
+/**
+ * Phase 5.8 — Owner Forced Out Tests
+ *
+ * Covers:
+ *  - OWNER_FORCED_OUT trigger conditions (week ≥ 30, bottom 3, budget < £10k)
+ *  - Non-trigger conditions (wrong week, good position, sufficient budget)
+ *  - No double-trigger if already FORCED_OUT
+ *  - OWNER_FORCED_OUT reducer: sets phase, populates forcedOut
+ *  - ACCEPT_TAKEOVER command: validation, happy path
+ *  - TAKEOVER_ACCEPTED reducer: new club id/name/budget, squad reset, forcedOut cleared
+ *  - Business acumen carries over through takeover
+ */
+
+import { handleCommand } from '../commands/handlers';
+import { buildState, reduceEvent } from '../reducers';
+import { GameEvent, GameStartedEvent, OwnerForcedOutEvent, TakeoverAcceptedEvent } from '../events/types';
+import { GameState } from '../types/game-state-updated';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const GAME_STARTED: GameStartedEvent = {
+  type:          'GAME_STARTED',
+  timestamp:     1000,
+  clubId:        'player-club',
+  clubName:      'Player FC',
+  initialBudget: 500_000_000, // £5m
+  difficulty:    'MEDIUM',
+  seed:          'forced-out-seed',
+};
+
+function baseState(): GameState {
+  return buildState([GAME_STARTED]);
+}
+
+/**
+ * Manufacture a GameState that has the league entries needed for bottom-3
+ * testing, without having to simulate 30 weeks of matches.
+ */
+function stateWithLeaguePosition(opts: {
+  position: number;       // 1-24
+  budget: number;         // pence
+  week: number;
+  phase?: GameState['phase'];
+  forcedOutAlready?: boolean;
+}): GameState {
+  const s = baseState();
+
+  // Build 24 league entries. Position 24 is the player; everything else is NPC.
+  const entries = Array.from({ length: 24 }, (_, i) => {
+    const pos = i + 1;
+    const isPlayer = pos === opts.position;
+    return {
+      clubId:        isPlayer ? 'player-club' : `npc-club-${pos}`,
+      clubName:      isPlayer ? 'Player FC'   : `NPC Club ${pos}`,
+      position:      pos,
+      played:        30,
+      won:           24 - pos,
+      drawn:         0,
+      lost:          pos - 1,
+      goalsFor:      60 - pos,
+      goalsAgainst:  pos,
+      goalDifference: (60 - pos) - pos,
+      points:        (24 - pos) * 3,
+      form:          [] as ('W' | 'D' | 'L')[],
+    };
+  });
+
+  return {
+    ...s,
+    phase:       opts.phase ?? 'LATE_SEASON',
+    currentWeek: opts.week,
+    season:      1,
+    forcedOut:   opts.forcedOutAlready ? {
+      previousClubId:   'player-club',
+      previousClubName: 'Player FC',
+      previousPosition: opts.position,
+      takeoverClubId:   'npc-club-24',
+      takeoverClubName: 'NPC Club 24',
+      week:             opts.week,
+    } : null,
+    club: {
+      ...s.club,
+      transferBudget: opts.budget,
+    },
+    league: {
+      ...s.league,
+      entries,
+    },
+  };
+}
+
+// ─── Trigger conditions ───────────────────────────────────────────────────────
+
+describe('OWNER_FORCED_OUT trigger', () => {
+  test('fires when week ≥ 30, position 22, budget < £10k', () => {
+    const state = stateWithLeaguePosition({ position: 22, budget: 900_000, week: 30 });
+    const result = handleCommand({ type: 'SIMULATE_WEEK', week: 30, season: 1, seed: 'test' }, state);
+
+    expect(result.error).toBeUndefined();
+    const forcedOutEvent = result.events?.find(e => e.type === 'OWNER_FORCED_OUT');
+    expect(forcedOutEvent).toBeDefined();
+    expect((forcedOutEvent as OwnerForcedOutEvent).previousClubId).toBe('player-club');
+    expect((forcedOutEvent as OwnerForcedOutEvent).previousPosition).toBe(22);
+  });
+
+  test('fires for position 23', () => {
+    const state = stateWithLeaguePosition({ position: 23, budget: 500_000, week: 35 });
+    const result = handleCommand({ type: 'SIMULATE_WEEK', week: 35, season: 1, seed: 'test' }, state);
+    expect(result.events?.some(e => e.type === 'OWNER_FORCED_OUT')).toBe(true);
+  });
+
+  test('fires for position 24', () => {
+    const state = stateWithLeaguePosition({ position: 24, budget: 0, week: 40 });
+    const result = handleCommand({ type: 'SIMULATE_WEEK', week: 40, season: 1, seed: 'test' }, state);
+    expect(result.events?.some(e => e.type === 'OWNER_FORCED_OUT')).toBe(true);
+  });
+
+  test('does NOT fire before week 30 even if bottom 3 and broke', () => {
+    const state = stateWithLeaguePosition({ position: 24, budget: 0, week: 29 });
+    const result = handleCommand({ type: 'SIMULATE_WEEK', week: 29, season: 1, seed: 'test' }, state);
+    expect(result.events?.some(e => e.type === 'OWNER_FORCED_OUT')).toBe(false);
+  });
+
+  test('does NOT fire if position is safe (top 21)', () => {
+    const state = stateWithLeaguePosition({ position: 21, budget: 0, week: 35 });
+    const result = handleCommand({ type: 'SIMULATE_WEEK', week: 35, season: 1, seed: 'test' }, state);
+    expect(result.events?.some(e => e.type === 'OWNER_FORCED_OUT')).toBe(false);
+  });
+
+  test('does NOT fire if budget is ≥ £10k (1_000_000 pence)', () => {
+    const state = stateWithLeaguePosition({ position: 24, budget: 1_000_000, week: 35 });
+    const result = handleCommand({ type: 'SIMULATE_WEEK', week: 35, season: 1, seed: 'test' }, state);
+    expect(result.events?.some(e => e.type === 'OWNER_FORCED_OUT')).toBe(false);
+  });
+
+  test('does NOT fire if phase is already FORCED_OUT', () => {
+    const state = stateWithLeaguePosition({
+      position: 24, budget: 0, week: 35,
+      phase: 'FORCED_OUT', forcedOutAlready: true,
+    });
+    const result = handleCommand({ type: 'SIMULATE_WEEK', week: 35, season: 1, seed: 'test' }, state);
+    expect(result.events?.some(e => e.type === 'OWNER_FORCED_OUT')).toBe(false);
+  });
+
+  test('does NOT fire if phase is SEASON_END', () => {
+    const state = stateWithLeaguePosition({
+      position: 24, budget: 0, week: 35,
+      phase: 'SEASON_END',
+    });
+    const result = handleCommand({ type: 'SIMULATE_WEEK', week: 35, season: 1, seed: 'test' }, state);
+    expect(result.events?.some(e => e.type === 'OWNER_FORCED_OUT')).toBe(false);
+  });
+
+  test('OWNER_FORCED_OUT event short-circuits — no SEASON_ENDED included', () => {
+    const state = stateWithLeaguePosition({ position: 24, budget: 0, week: 35 });
+    const result = handleCommand({ type: 'SIMULATE_WEEK', week: 35, season: 1, seed: 'test' }, state);
+    expect(result.events?.some(e => e.type === 'SEASON_ENDED')).toBe(false);
+    expect(result.events?.some(e => e.type === 'OWNER_FORCED_OUT')).toBe(true);
+  });
+
+  test('takeover club is lowest-ranked NPC (not the player club)', () => {
+    // Player is position 24 — so the lowest NPC would be position 23
+    const s = baseState();
+    const entries = Array.from({ length: 24 }, (_, i) => {
+      const pos = i + 1;
+      const isPlayer = pos === 24;
+      return {
+        clubId:        isPlayer ? 'player-club' : `npc-${pos}`,
+        clubName:      isPlayer ? 'Player FC'   : `NPC ${pos}`,
+        position:      pos,
+        played:        30,
+        won:           0,
+        drawn:         0,
+        lost:          30,
+        goalsFor:      0,
+        goalsAgainst:  90,
+        goalDifference: -90,
+        points:        0,
+        form:          [] as ('W' | 'D' | 'L')[],
+      };
+    });
+
+    const state: GameState = {
+      ...s,
+      phase: 'LATE_SEASON',
+      currentWeek: 35,
+      club: { ...s.club, transferBudget: 0 },
+      league: { ...s.league, entries },
+    };
+
+    const result = handleCommand({ type: 'SIMULATE_WEEK', week: 35, season: 1, seed: 'test' }, state);
+    const fo = result.events?.find(e => e.type === 'OWNER_FORCED_OUT') as OwnerForcedOutEvent | undefined;
+    expect(fo).toBeDefined();
+    // Player is at 24 — sorted descending by position: 24, 23, 22... first that isn't player → 23
+    expect(fo!.takeoverClubId).toBe('npc-23');
+  });
+});
+
+// ─── Reducer: OWNER_FORCED_OUT ────────────────────────────────────────────────
+
+describe('reduceEvent OWNER_FORCED_OUT', () => {
+  function makeForcedOutEvent(overrides: Partial<OwnerForcedOutEvent> = {}): OwnerForcedOutEvent {
+    return {
+      type:             'OWNER_FORCED_OUT',
+      timestamp:        Date.now(),
+      previousClubId:   'player-club',
+      previousClubName: 'Player FC',
+      previousPosition: 22,
+      takeoverClubId:   'npc-club-24',
+      takeoverClubName: 'NPC Club 24',
+      seed:             'test-seed',
+      week:             30,
+      ...overrides,
+    };
+  }
+
+  test('sets phase to FORCED_OUT', () => {
+    const state = baseState();
+    const next  = reduceEvent(state, makeForcedOutEvent());
+    expect(next.phase).toBe('FORCED_OUT');
+  });
+
+  test('populates forcedOut with all required fields', () => {
+    const state = baseState();
+    const evt   = makeForcedOutEvent({ previousPosition: 23, week: 32 });
+    const next  = reduceEvent(state, evt);
+    expect(next.forcedOut).not.toBeNull();
+    expect(next.forcedOut!.previousClubId).toBe('player-club');
+    expect(next.forcedOut!.previousClubName).toBe('Player FC');
+    expect(next.forcedOut!.previousPosition).toBe(23);
+    expect(next.forcedOut!.takeoverClubId).toBe('npc-club-24');
+    expect(next.forcedOut!.takeoverClubName).toBe('NPC Club 24');
+    expect(next.forcedOut!.week).toBe(32);
+  });
+
+  test('does not mutate original state', () => {
+    const state = baseState();
+    reduceEvent(state, makeForcedOutEvent());
+    expect(state.phase).not.toBe('FORCED_OUT');
+    expect(state.forcedOut).toBeNull();
+  });
+});
+
+// ─── Command: ACCEPT_TAKEOVER ─────────────────────────────────────────────────
+
+describe('ACCEPT_TAKEOVER command', () => {
+  function forcedOutState(week = 35): GameState {
+    const s = baseState();
+    return {
+      ...s,
+      phase:       'FORCED_OUT',
+      currentWeek: week,
+      forcedOut: {
+        previousClubId:   'player-club',
+        previousClubName: 'Player FC',
+        previousPosition: 22,
+        takeoverClubId:   'npc-club-24',
+        takeoverClubName: 'NPC Club 24',
+        week,
+      },
+    };
+  }
+
+  test('returns TAKEOVER_ACCEPTED event on success', () => {
+    const state  = forcedOutState();
+    const result = handleCommand({ type: 'ACCEPT_TAKEOVER' }, state);
+    expect(result.error).toBeUndefined();
+    const evt = result.events?.find(e => e.type === 'TAKEOVER_ACCEPTED') as TakeoverAcceptedEvent | undefined;
+    expect(evt).toBeDefined();
+    expect(evt!.takeoverClubId).toBe('npc-club-24');
+    expect(evt!.takeoverClubName).toBe('NPC Club 24');
+  });
+
+  test('returns error if phase is not FORCED_OUT', () => {
+    const state  = { ...baseState(), phase: 'EARLY_SEASON' as const };
+    const result = handleCommand({ type: 'ACCEPT_TAKEOVER' }, state);
+    expect(result.error).toBeDefined();
+    expect(result.events).toBeUndefined();
+  });
+
+  test('returns error if forcedOut is null', () => {
+    const s: GameState = { ...baseState(), phase: 'FORCED_OUT', forcedOut: null };
+    const result = handleCommand({ type: 'ACCEPT_TAKEOVER' }, s);
+    expect(result.error).toBeDefined();
+  });
+});
+
+// ─── Reducer: TAKEOVER_ACCEPTED ───────────────────────────────────────────────
+
+describe('reduceEvent TAKEOVER_ACCEPTED', () => {
+  function makeTakeoverEvent(overrides: Partial<TakeoverAcceptedEvent> = {}): TakeoverAcceptedEvent {
+    return {
+      type:             'TAKEOVER_ACCEPTED',
+      timestamp:        Date.now(),
+      takeoverClubId:   'npc-club-24',
+      takeoverClubName: 'NPC Club 24',
+      seed:             'test-seed',
+      week:             35,
+      ...overrides,
+    };
+  }
+
+  function forcedOutState(week = 35): GameState {
+    const s = baseState();
+    return {
+      ...s,
+      phase:           'FORCED_OUT',
+      currentWeek:     week,
+      boardConfidence: 80,
+      forcedOut: {
+        previousClubId:   'player-club',
+        previousClubName: 'Player FC',
+        previousPosition: 22,
+        takeoverClubId:   'npc-club-24',
+        takeoverClubName: 'NPC Club 24',
+        week,
+      },
+    };
+  }
+
+  test('clears forcedOut to null', () => {
+    const state = forcedOutState();
+    const next  = reduceEvent(state, makeTakeoverEvent());
+    expect(next.forcedOut).toBeNull();
+  });
+
+  test('updates club id and name', () => {
+    const state = forcedOutState();
+    const next  = reduceEvent(state, makeTakeoverEvent());
+    expect(next.club.id).toBe('npc-club-24');
+    expect(next.club.name).toBe('NPC Club 24');
+  });
+
+  test('sets transfer budget to £50,000 (5_000_000 pence)', () => {
+    const state = forcedOutState();
+    const next  = reduceEvent(state, makeTakeoverEvent());
+    expect(next.club.transferBudget).toBe(5_000_000);
+  });
+
+  test('resets board confidence to 20', () => {
+    const state = forcedOutState();
+    const next  = reduceEvent(state, makeTakeoverEvent());
+    expect(next.boardConfidence).toBe(20);
+  });
+
+  test('clears scout mission', () => {
+    const s = forcedOutState();
+    const state: GameState = {
+      ...s,
+      scoutMission: {
+        status: 'SEARCHING',
+        position: 'MID',
+        attributePriority: null,
+        budgetCeiling: 10_000_000,
+        scoutFee: 100_000,
+        weekStarted: 34,
+      },
+    };
+    const next = reduceEvent(state, makeTakeoverEvent());
+    expect(next.scoutMission).toBeNull();
+  });
+
+  test('sets phase to LATE_SEASON when week > 30', () => {
+    const state = forcedOutState(35);
+    const next  = reduceEvent(state, makeTakeoverEvent({ week: 35 }));
+    expect(next.phase).toBe('LATE_SEASON');
+  });
+
+  test('sets phase to MID_SEASON when week is 16-30', () => {
+    const state = forcedOutState(20);
+    const next  = reduceEvent(state, makeTakeoverEvent({ week: 20 }));
+    expect(next.phase).toBe('MID_SEASON');
+  });
+
+  test('sets phase to EARLY_SEASON when week ≤ 15', () => {
+    const state = forcedOutState(10);
+    const next  = reduceEvent(state, makeTakeoverEvent({ week: 10 }));
+    expect(next.phase).toBe('EARLY_SEASON');
+  });
+
+  test('business acumen carries over unchanged', () => {
+    const state = forcedOutState();
+    const next  = reduceEvent(state, makeTakeoverEvent());
+    // Should be identical reference / deep-equal to the original
+    expect(next.businessAcumen).toEqual(state.businessAcumen);
+  });
+
+  test('generates a fresh squad (non-empty) for the new club', () => {
+    const state = forcedOutState();
+    const next  = reduceEvent(state, makeTakeoverEvent());
+    expect(next.club.squad.length).toBeGreaterThan(0);
+  });
+
+  test('squad belongs to the new club (player ids contain new club id)', () => {
+    const state = forcedOutState();
+    const next  = reduceEvent(state, makeTakeoverEvent());
+    // generateStartingSquad creates ids like `inherited-${clubId}-${index}`
+    const allMatch = next.club.squad.every(p => p.id.includes('npc-club-24'));
+    expect(allMatch).toBe(true);
+  });
+
+  test('is a no-op if forcedOut is null (idempotency guard)', () => {
+    const state: GameState = { ...baseState(), phase: 'FORCED_OUT', forcedOut: null };
+    const next  = reduceEvent(state, makeTakeoverEvent());
+    // Should return original state unchanged
+    expect(next.club.id).toBe(state.club.id);
+  });
+});
+
+// ─── Full round-trip ──────────────────────────────────────────────────────────
+
+describe('forced-out full round-trip via buildState', () => {
+  test('applying OWNER_FORCED_OUT + TAKEOVER_ACCEPTED produces correct final state', () => {
+    const fo: OwnerForcedOutEvent = {
+      type:             'OWNER_FORCED_OUT',
+      timestamp:        2000,
+      previousClubId:   'player-club',
+      previousClubName: 'Player FC',
+      previousPosition: 23,
+      takeoverClubId:   'npc-club-22',
+      takeoverClubName: 'NPC Club 22',
+      seed:             'forced-out-seed',
+      week:             33,
+    };
+
+    const ta: TakeoverAcceptedEvent = {
+      type:             'TAKEOVER_ACCEPTED',
+      timestamp:        3000,
+      takeoverClubId:   'npc-club-22',
+      takeoverClubName: 'NPC Club 22',
+      seed:             'forced-out-seed',
+      week:             33,
+    };
+
+    const events: GameEvent[] = [GAME_STARTED, fo, ta];
+    const state = buildState(events);
+
+    // Phase is EARLY_SEASON because currentWeek is 0 — no WEEK_ADVANCED events in this chain.
+    // The phase→week mapping is already covered by the unit tests above.
+    expect(state.phase).not.toBe('FORCED_OUT');
+    expect(state.forcedOut).toBeNull();
+    expect(state.club.id).toBe('npc-club-22');
+    expect(state.club.transferBudget).toBe(5_000_000);
+    expect(state.boardConfidence).toBe(20);
+  });
+});

--- a/packages/domain/src/__tests__/reducer-match.test.ts
+++ b/packages/domain/src/__tests__/reducer-match.test.ts
@@ -67,6 +67,7 @@ function makeState(entries: LeagueTableEntry[], playerClubId: string = 'club-1')
     lowMoraleWeeks: 0,
     moraleEventCooldowns: {},
     scoutMission: null,
+    forcedOut: null,
   };
 }
 

--- a/packages/domain/src/commands/handlers.ts
+++ b/packages/domain/src/commands/handlers.ts
@@ -16,7 +16,7 @@ import { LEAGUE_TWO_TEAMS } from '../data/league-two-teams';
 import { Player } from '../types/player';
 import { getScoutLevel, isTransferWindowOpen } from '../types/facility';
 import { generateScoutTarget, getScoutFee } from '../data/scout-target-generator';
-import { ScoutTargetFoundEvent, ScoutTransferCompletedEvent } from '../events/types';
+import { ScoutTargetFoundEvent, ScoutTransferCompletedEvent, TakeoverAcceptedEvent } from '../events/types';
 
 /**
  * Handle a game command
@@ -59,6 +59,8 @@ export function handleCommand(command: GameCommand, state: GameState): CommandRe
       return handlePlaceScoutBid(command, state);
     case 'CANCEL_SCOUT_MISSION':
       return handleCancelScoutMission(command, state);
+    case 'ACCEPT_TAKEOVER':
+      return handleAcceptTakeover(command, state);
     default:
       return {
         error: {
@@ -380,6 +382,44 @@ function handleSimulateWeek(command: any, state: GameState): CommandResult {
     week,
     season
   });
+
+  // ── Owner-forced-out check ──────────────────────────────────────────────────
+  // Trigger: position bottom 3 of 24 + budget < £10,000 + week >= 30
+  // Fires once — if already in FORCED_OUT phase, skip.
+  if (
+    state.phase !== 'FORCED_OUT' &&
+    state.phase !== 'SEASON_END' &&
+    !state.forcedOut &&
+    week >= 30
+  ) {
+    const playerEntry   = state.league.entries.find(e => e.clubId === state.club.id);
+    const position      = playerEntry?.position ?? 1;
+    const inBottom3     = position > 21;              // positions 22, 23, 24 out of 24
+    const broke         = state.club.transferBudget < 1_000_000; // < £10,000
+
+    if (inBottom3 && broke) {
+      // Find the lowest-ranked NPC club (highest position number that isn't the player's)
+      const sorted    = [...state.league.entries].sort((a, b) => b.position - a.position);
+      const bottomNPC = sorted.find(e => e.clubId !== state.club.id);
+      if (bottomNPC) {
+        const gameStartEvent = state.events.find(e => e.type === 'GAME_STARTED') as
+          { type: 'GAME_STARTED'; seed: string } | undefined;
+        const seedStr = gameStartEvent?.seed ?? 'default-seed';
+        events.push({
+          type:             'OWNER_FORCED_OUT',
+          timestamp:        now,
+          previousClubId:   state.club.id,
+          previousClubName: state.club.name,
+          previousPosition: position,
+          takeoverClubId:   bottomNPC.clubId,
+          takeoverClubName: bottomNPC.clubName,
+          seed:             seedStr,
+          week,
+        });
+        return { events }; // Skip SEASON_ENDED — game transitions to FORCED_OUT phase
+      }
+    }
+  }
 
   // If this is the last week of the season, emit SeasonEndedEvent
   if (week === 46) {
@@ -973,4 +1013,30 @@ function handleRecordMathAttempt(command: any, _state: GameState): CommandResult
   ];
 
   return { events };
+}
+
+function handleAcceptTakeover(_command: any, state: GameState): CommandResult {
+  if (state.phase !== 'FORCED_OUT' || !state.forcedOut) {
+    return {
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: 'No forced-out takeover is pending',
+      },
+    };
+  }
+
+  const gameStartEvent = state.events.find(e => e.type === 'GAME_STARTED') as
+    { type: 'GAME_STARTED'; seed: string } | undefined;
+  const seedStr = gameStartEvent?.seed ?? 'default-seed';
+
+  const event: TakeoverAcceptedEvent = {
+    type:             'TAKEOVER_ACCEPTED',
+    timestamp:        Date.now(),
+    takeoverClubId:   state.forcedOut.takeoverClubId,
+    takeoverClubName: state.forcedOut.takeoverClubName,
+    seed:             seedStr,
+    week:             state.forcedOut.week,
+  };
+
+  return { events: [event] };
 }

--- a/packages/domain/src/commands/types.ts
+++ b/packages/domain/src/commands/types.ts
@@ -29,7 +29,8 @@ export type GameCommand =
   | BeginNextSeasonCommand
   | StartScoutMissionCommand
   | PlaceScoutBidCommand
-  | CancelScoutMissionCommand;
+  | CancelScoutMissionCommand
+  | AcceptTakeoverCommand;
 
 export interface MakeTransferCommand {
   type: 'MAKE_TRANSFER';
@@ -139,6 +140,10 @@ export interface PlaceScoutBidCommand {
 
 export interface CancelScoutMissionCommand {
   type: 'CANCEL_SCOUT_MISSION';
+}
+
+export interface AcceptTakeoverCommand {
+  type: 'ACCEPT_TAKEOVER';
 }
 
 export interface CommandResult {

--- a/packages/domain/src/events/types.ts
+++ b/packages/domain/src/events/types.ts
@@ -38,7 +38,9 @@ export type GameEvent =
   | ScoutTargetFoundEvent
   | ScoutBidPlacedEvent
   | ScoutTransferCompletedEvent
-  | ScoutMissionCancelledEvent;
+  | ScoutMissionCancelledEvent
+  | OwnerForcedOutEvent
+  | TakeoverAcceptedEvent;
 
 export interface TransferCompletedEvent {
   type: 'TRANSFER_COMPLETED';
@@ -295,4 +297,31 @@ export interface ScoutMissionCancelledEvent {
   type: 'SCOUT_MISSION_CANCELLED';
   timestamp: number;
   clubId: string;
+}
+
+/** Emitted when the owner-forced-out trigger fires (bottom 3 + broke at week 30+) */
+export interface OwnerForcedOutEvent {
+  type: 'OWNER_FORCED_OUT';
+  timestamp: number;
+  /** The club the player was running */
+  previousClubId:   string;
+  previousClubName: string;
+  /** Their position in the table at the moment of ousting */
+  previousPosition: number;
+  /** The bottom NPC club offered as a takeover vehicle */
+  takeoverClubId:   string;
+  takeoverClubName: string;
+  /** Seed string for generating the takeover club's starting squad */
+  seed: string;
+  week: number;
+}
+
+/** Emitted when the player clicks "Accept" on the takeover offer screen */
+export interface TakeoverAcceptedEvent {
+  type: 'TAKEOVER_ACCEPTED';
+  timestamp: number;
+  takeoverClubId:   string;
+  takeoverClubName: string;
+  seed: string;
+  week: number;
 }

--- a/packages/domain/src/reducers/index.ts
+++ b/packages/domain/src/reducers/index.ts
@@ -4,7 +4,7 @@
  * Pure functions that apply events to state.
  */
 
-import { GameEvent, GameStartedEvent, MatchSimulatedEvent, TransferCompletedEvent, StaffHiredEvent, MathAttemptRecordedEvent, ClubEventOccurredEvent, ClubEventResolvedEvent, SeasonStartedEvent, TrainingFocusSetEvent, FormationSetEvent, FreeAgentSignedEvent, PlayerReleasedEvent, NpcPlayerSignedEvent, ManagerHiredEvent, ManagerSackedEvent, PreSeasonStartedEvent, ScoutMissionStartedEvent, ScoutTargetFoundEvent, ScoutBidPlacedEvent, ScoutTransferCompletedEvent } from '../events/types';
+import { GameEvent, GameStartedEvent, MatchSimulatedEvent, TransferCompletedEvent, StaffHiredEvent, MathAttemptRecordedEvent, ClubEventOccurredEvent, ClubEventResolvedEvent, SeasonStartedEvent, TrainingFocusSetEvent, FormationSetEvent, FreeAgentSignedEvent, PlayerReleasedEvent, NpcPlayerSignedEvent, ManagerHiredEvent, ManagerSackedEvent, PreSeasonStartedEvent, ScoutMissionStartedEvent, ScoutTargetFoundEvent, ScoutBidPlacedEvent, ScoutTransferCompletedEvent, OwnerForcedOutEvent, TakeoverAcceptedEvent } from '../events/types';
 import { GameState } from '../types/game-state-updated';
 import { Club } from '../types/club';
 import { LeagueTable, LeagueTableEntry, sortLeagueTable } from '../types/league';
@@ -81,6 +81,10 @@ export function reduceEvent(state: GameState, event: GameEvent): GameState {
       return handleScoutTransferCompleted(state, event);
     case 'SCOUT_MISSION_CANCELLED':
       return handleScoutMissionCancelled(state);
+    case 'OWNER_FORCED_OUT':
+      return handleOwnerForcedOut(state, event);
+    case 'TAKEOVER_ACCEPTED':
+      return handleTakeoverAccepted(state, event);
     default:
       return state;
   }
@@ -122,6 +126,7 @@ export function buildState(events: GameEvent[]): GameState {
     lowMoraleWeeks: 0,
     moraleEventCooldowns: {},
     scoutMission: null,
+    forcedOut:    null,
   };
 
   return events.reduce(reduceEvent, initialState);
@@ -736,6 +741,55 @@ function handleScoutMissionCancelled(state: GameState): GameState {
   return {
     ...state,
     scoutMission: null,
+  };
+}
+
+function handleOwnerForcedOut(state: GameState, event: OwnerForcedOutEvent): GameState {
+  return {
+    ...state,
+    phase: 'FORCED_OUT',
+    forcedOut: {
+      previousClubId:   event.previousClubId,
+      previousClubName: event.previousClubName,
+      previousPosition: event.previousPosition,
+      takeoverClubId:   event.takeoverClubId,
+      takeoverClubName: event.takeoverClubName,
+      week:             event.week,
+    },
+  };
+}
+
+function handleTakeoverAccepted(state: GameState, event: TakeoverAcceptedEvent): GameState {
+  if (!state.forcedOut) return state;
+
+  // Determine season phase from current week
+  const w     = state.currentWeek;
+  const phase = w <= 15 ? 'EARLY_SEASON' : w <= 30 ? 'MID_SEASON' : 'LATE_SEASON';
+
+  // Generate a fresh (very weak) starting squad for the takeover club
+  const newSquad = generateStartingSquad(
+    `${event.seed}-takeover-${event.takeoverClubId}`,
+    event.takeoverClubId,
+  );
+
+  return {
+    ...state,
+    phase,
+    forcedOut: null,
+    scoutMission: null,
+    boardConfidence: 20,      // rock-bottom board confidence
+    club: {
+      ...state.club,
+      id:             event.takeoverClubId,
+      name:           event.takeoverClubName,
+      transferBudget: 5_000_000,  // £50,000
+      wageBudget:     2_000_000,  // £20,000/wk
+      squad:          newSquad,
+      squadCapacity:  24,
+      facilities:     getDefaultFacilities(),
+      manager:        null,
+      staff:          [],
+    },
   };
 }
 

--- a/packages/domain/src/types/game-state-updated.ts
+++ b/packages/domain/src/types/game-state-updated.ts
@@ -150,6 +150,28 @@ export interface GameState {
    * Only one mission can be active at a time.
    */
   scoutMission: ScoutMission | null;
+
+  /**
+   * Set when the owner has been forced out (trigger: bottom 3 + budget < £10k at week 30+).
+   * Cleared when the player accepts the takeover of the bottom NPC club.
+   */
+  forcedOut: ForcedOutState | null;
+}
+
+/**
+ * State held during the forced-out / takeover-offer interstitial.
+ */
+export interface ForcedOutState {
+  /** The club the player was ousted from */
+  previousClubId:   string;
+  previousClubName: string;
+  /** Their league position at the time of ousting */
+  previousPosition: number;
+  /** The bottom NPC club being offered as the takeover target */
+  takeoverClubId:   string;
+  takeoverClubName: string;
+  /** The week the ousting happened */
+  week: number;
 }
 
 /**
@@ -175,12 +197,13 @@ export interface BusinessAcumen {
 /**
  * Season phases
  */
-export type SeasonPhase = 
+export type SeasonPhase =
   | 'PRE_SEASON'
   | 'EARLY_SEASON'      // Weeks 1-15
   | 'MID_SEASON'        // Weeks 16-30
   | 'LATE_SEASON'       // Weeks 31-46
-  | 'SEASON_END';
+  | 'SEASON_END'
+  | 'FORCED_OUT';       // Owner ousted — awaiting takeover acceptance
 
 /**
  * Command errors

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { StadiumView } from './components/stadium-view/StadiumView';
 import { ViewToggle, ActiveView } from './components/shared/ViewToggle';
 import { PreSeasonScreen } from './components/pre-season/PreSeasonScreen';
 import { SeasonEndScreen } from './components/season-end/SeasonEndScreen';
+import { ForcedOutScreen } from './components/forced-out/ForcedOutScreen';
 
 export default function App() {
   const { state, events, dispatch, isLoading } = useGameState();
@@ -17,6 +18,10 @@ export default function App() {
 
   if (state.phase === 'SEASON_END') {
     return <SeasonEndScreen state={state} dispatch={dispatch} />;
+  }
+
+  if (state.phase === 'FORCED_OUT') {
+    return <ForcedOutScreen state={state} dispatch={dispatch} />;
   }
 
   return (

--- a/packages/frontend/src/components/forced-out/ForcedOutScreen.tsx
+++ b/packages/frontend/src/components/forced-out/ForcedOutScreen.tsx
@@ -1,0 +1,185 @@
+import { useState } from 'react';
+import { GameState, GameCommand, formatMoney } from '@calculating-glory/domain';
+
+interface ForcedOutScreenProps {
+  state: GameState;
+  dispatch: (command: GameCommand) => { error?: string };
+}
+
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] ?? s[v] ?? s[0]);
+}
+
+export function ForcedOutScreen({ state, dispatch }: ForcedOutScreenProps) {
+  const [step, setStep] = useState<'ousted' | 'offer'>('ousted');
+  const [error, setError]   = useState<string | null>(null);
+
+  const fo = state.forcedOut;
+  if (!fo) return null;
+
+  function handleAccept() {
+    const result = dispatch({ type: 'ACCEPT_TAKEOVER' });
+    if (result.error) setError(result.error);
+  }
+
+  // ── Step 1: Ousted ─────────────────────────────────────────────────────────
+  if (step === 'ousted') {
+    return (
+      <div className="min-h-screen bg-bg-deep text-txt-primary flex flex-col items-center justify-center px-4 py-12">
+        <div className="max-w-lg w-full space-y-6">
+
+          {/* Icon + headline */}
+          <div className="text-center space-y-3">
+            <div className="text-6xl">🔴</div>
+            <h1 className="text-3xl font-bold text-alert-red tracking-tight">
+              The Board Has Had Enough
+            </h1>
+            <p className="text-txt-muted text-sm">
+              Season {state.season} · Week {state.currentWeek}
+            </p>
+          </div>
+
+          {/* Situation summary */}
+          <div className="card border border-alert-red/30 bg-alert-red/5 space-y-3">
+            <p className="text-txt-primary text-sm leading-relaxed">
+              You took <span className="font-semibold text-txt-primary">{fo.previousClubName}</span> into
+              the season with ambitions of survival. Instead you find yourself{' '}
+              <span className="text-alert-red font-semibold">{ordinal(fo.previousPosition)} in the table</span>,
+              with just{' '}
+              <span className="text-alert-red font-semibold">{formatMoney(state.club.transferBudget)}</span> left
+              in the kitty.
+            </p>
+            <p className="text-txt-primary text-sm leading-relaxed">
+              The board has voted unanimously: you're out. Security has already changed the locks.
+            </p>
+          </div>
+
+          {/* Stats grid */}
+          <div className="grid grid-cols-3 gap-3">
+            <div className="card text-center">
+              <p className="text-xs2 text-txt-muted uppercase tracking-wide mb-1">Position</p>
+              <p className="text-2xl font-bold data-font text-alert-red">{ordinal(fo.previousPosition)}</p>
+            </div>
+            <div className="card text-center">
+              <p className="text-xs2 text-txt-muted uppercase tracking-wide mb-1">Week</p>
+              <p className="text-2xl font-bold data-font text-txt-primary">{state.currentWeek}</p>
+            </div>
+            <div className="card text-center">
+              <p className="text-xs2 text-txt-muted uppercase tracking-wide mb-1">Budget Left</p>
+              <p className="text-2xl font-bold data-font text-warn-amber">{formatMoney(state.club.transferBudget)}</p>
+            </div>
+          </div>
+
+          {/* CTA */}
+          <button
+            onClick={() => setStep('offer')}
+            className="w-full py-3 rounded-tag bg-data-blue text-white font-semibold text-sm hover:bg-data-blue/80 active:scale-95 transition-all"
+          >
+            See what comes next →
+          </button>
+
+        </div>
+      </div>
+    );
+  }
+
+  // ── Step 2: Takeover offer ─────────────────────────────────────────────────
+  return (
+    <div className="min-h-screen bg-bg-deep text-txt-primary flex flex-col items-center justify-center px-4 py-12">
+      <div className="max-w-lg w-full space-y-6">
+
+        {/* Headline */}
+        <div className="text-center space-y-3">
+          <div className="text-6xl">📋</div>
+          <h1 className="text-2xl font-bold text-txt-primary tracking-tight">
+            An Urgent Offer
+          </h1>
+          <p className="text-txt-muted text-sm">
+            Word travels fast in football.
+          </p>
+        </div>
+
+        {/* Narrative */}
+        <div className="card border border-data-blue/30 bg-data-blue/5 space-y-2">
+          <p className="text-txt-primary text-sm leading-relaxed">
+            <span className="font-semibold text-data-blue">{fo.takeoverClubName}</span> — bottom of the
+            league, board in crisis, fans revolting — have been told their manager has walked out.
+            They need someone to steady the ship. Immediately.
+          </p>
+          <p className="text-txt-primary text-sm leading-relaxed">
+            It's not glamorous. The budget is almost nothing. The squad is rough.
+            But it's a job — and your reputation as an owner who{' '}
+            <span className="text-data-blue font-semibold">knows the numbers</span> has followed you.
+          </p>
+        </div>
+
+        {/* What you inherit */}
+        <div className="space-y-2">
+          <p className="text-xs2 text-txt-muted uppercase tracking-wide">What you're walking into</p>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="card text-center">
+              <p className="text-xs2 text-txt-muted mb-1">Starting Budget</p>
+              <p className="text-lg font-bold data-font text-warn-amber">{formatMoney(5_000_000)}</p>
+            </div>
+            <div className="card text-center">
+              <p className="text-xs2 text-txt-muted mb-1">League Position</p>
+              <p className="text-lg font-bold data-font text-alert-red">
+                {ordinal(state.league.entries.find(e => e.clubId === fo.takeoverClubId)?.position ?? 24)}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Business acumen carry-over callout */}
+        <div className="flex items-start gap-3 bg-pitch-green/10 border border-pitch-green/30 rounded-card p-3">
+          <span className="text-lg">🎓</span>
+          <div>
+            <p className="text-xs2 font-semibold text-pitch-green uppercase tracking-wide mb-0.5">
+              Knowledge carries over
+            </p>
+            <p className="text-xs2 text-txt-muted">
+              Your Business Acumen — built through every deal and decision — comes with you. It's the one
+              thing the board at {fo.previousClubName} couldn't take away.
+            </p>
+          </div>
+        </div>
+
+        {/* Win condition */}
+        <div className="flex items-start gap-3 bg-warn-amber/10 border border-warn-amber/30 rounded-card p-3">
+          <span className="text-lg">🎯</span>
+          <div>
+            <p className="text-xs2 font-semibold text-warn-amber uppercase tracking-wide mb-0.5">
+              Win condition
+            </p>
+            <p className="text-xs2 text-txt-muted">
+              Survive. Finish the season outside the bottom three and you've redeemed yourself.
+            </p>
+          </div>
+        </div>
+
+        {error && (
+          <p className="text-alert-red text-xs2 text-center">{error}</p>
+        )}
+
+        {/* CTAs */}
+        <div className="space-y-2">
+          <button
+            onClick={handleAccept}
+            className="w-full py-3 rounded-tag bg-pitch-green text-white font-semibold text-sm hover:bg-pitch-green/80 active:scale-95 transition-all"
+          >
+            Accept — take over {fo.takeoverClubName}
+          </button>
+          <button
+            onClick={() => setStep('ousted')}
+            className="w-full py-2 rounded-tag text-txt-muted text-xs2 hover:text-txt-primary transition-colors"
+          >
+            ← Back
+          </button>
+        </div>
+
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Forced-out trigger**: when position is bottom 3 (22–24), budget < £10k, and week ≥ 30 — `SIMULATE_WEEK` emits `OWNER_FORCED_OUT` instead of continuing, skipping `SEASON_ENDED`
- **Two-step `ForcedOutScreen`**: dramatic "board has had enough" screen → takeover offer screen with win condition, inherited budget (£50k), and Business Acumen carry-over callout
- **`ACCEPT_TAKEOVER` command + `TAKEOVER_ACCEPTED` event**: transitions player to the bottom NPC club; resets budget/confidence/squad/facilities, preserves Business Acumen
- **29 new tests** covering all trigger conditions, non-trigger guards, reducer state machine, and round-trip via `buildState`
- Also includes scout mission bid flow (PLACE_SCOUT_BID, BID_PENDING/REJECTED) from #49 — this PR builds on that work

> **Note**: depends on #49 (scout mission bid flow). Merge #49 first for a clean diff.

## Test plan

- [ ] Run `npm test` in `packages/domain` — 374 tests, all green
- [ ] Start dev server and simulate a save with position 22+ and budget < £10k at week 30+
- [ ] Verify `ForcedOutScreen` renders the ousted step (position, week, budget stats)
- [ ] Click "See what comes next" — verify takeover offer step with correct club name and £50k budget
- [ ] Click "Accept" — verify game transitions back to in-season play as the new club
- [ ] Confirm Business Acumen is unchanged after takeover

🤖 Generated with [Claude Code](https://claude.com/claude-code)