### PR TITLE
feat: Championship/PL NPC teams, NPC strength evolution, New Game UI

### DIFF
--- a/packages/domain/src/__tests__/reducer-match.test.ts
+++ b/packages/domain/src/__tests__/reducer-match.test.ts
@@ -69,6 +69,7 @@ function makeState(entries: LeagueTableEntry[], playerClubId: string = 'club-1')
     scoutMission: null,
     forcedOut: null,
     division: 'LEAGUE_TWO',
+    npcStrengths: {},
   };
 }
 

--- a/packages/domain/src/commands/handlers.ts
+++ b/packages/domain/src/commands/handlers.ts
@@ -605,15 +605,15 @@ function buildTeamMap(
   season: number
 ): Map<string, Team> {
   const teamMap = new Map<string, Team>();
-  const rng = createRng(`${baseSeed}-S${season}-strengths`);
 
   for (const entry of state.league.entries) {
     if (playerTeam && entry.clubId === state.club.id) {
       teamMap.set(entry.clubId, playerTeam);
     } else {
-      // AI team: base strength spread across League Two range (35-65)
-      // Use the RNG to assign a consistent base strength per team per season
-      const baseStrength = 35 + rng.next() * 30;
+      // Use evolved NPC strength (seeded from static team data, adjusted each season).
+      // Falls back to 50 for any NPC not yet in the strengths map (shouldn't occur
+      // in normal play, but guards against stale saves from before this feature).
+      const baseStrength = state.npcStrengths[entry.clubId] ?? 50;
       const aiTeam = generateAITeam(
         entry.clubId,
         entry.clubName,

--- a/packages/domain/src/data/championship-teams.ts
+++ b/packages/domain/src/data/championship-teams.ts
@@ -1,0 +1,35 @@
+/**
+ * Championship Teams Data
+ *
+ * Fictional Pro-Evo style clubs — recognisable analogues of real Championship
+ * sides, slightly tweaked to sidestep licensing. Strength ratings reflect
+ * rough real-world standing at Championship level (68–88).
+ */
+
+import { LeagueTwoTeam } from './league-two-teams';
+
+export const CHAMPIONSHIP_TEAMS: LeagueTwoTeam[] = [
+  { id: 'leedston-u',   name: 'Leedston United',         baseStrength: 88 },
+  { id: 'leycester',    name: 'Leycester City',           baseStrength: 87 },
+  { id: 'burnfield',    name: 'Burnfield FC',             baseStrength: 85 },
+  { id: 'southhaven',   name: 'Southhaven City',          baseStrength: 84 },
+  { id: 'middlesdale',  name: 'Middlesdale FC',           baseStrength: 83 },
+  { id: 'norwich-v',    name: 'Norwich Vale',             baseStrength: 82 },
+  { id: 'stoketon',     name: 'Stoketon City',            baseStrength: 80 },
+  { id: 'hull-r',       name: 'Hull Rovers',              baseStrength: 79 },
+  { id: 'sunderton',    name: 'Sunderton AFC',            baseStrength: 78 },
+  { id: 'coventworth',  name: 'Coventworth City',         baseStrength: 77 },
+  { id: 'blackbourne',  name: 'Blackbourne Rovers',       baseStrength: 76 },
+  { id: 'prestonfield', name: 'Prestonfield End',         baseStrength: 75 },
+  { id: 'barnford',     name: 'Barnford Town',            baseStrength: 74 },
+  { id: 'derbyfield',   name: 'Derbyfield County',        baseStrength: 73 },
+  { id: 'cardigan-c',   name: 'Cardigan City',            baseStrength: 72 },
+  { id: 'swanswood',    name: 'Swanswood City',           baseStrength: 72 },
+  { id: 'milwall',      name: 'Milwall FC',               baseStrength: 71 },
+  { id: 'lutonbury',    name: 'Lutonbury Town',           baseStrength: 71 },
+  { id: 'birmington',   name: 'Birmington City',          baseStrength: 70 },
+  { id: 'qp-rangers',   name: 'Queens Parkdale Rangers',  baseStrength: 70 },
+  { id: 'watmore',      name: 'Watmore FC',               baseStrength: 69 },
+  { id: 'readington',   name: 'Readington FC',            baseStrength: 68 },
+  { id: 'hudderstone',  name: 'Hudderstone Town',         baseStrength: 68 },
+];

--- a/packages/domain/src/data/division-teams.ts
+++ b/packages/domain/src/data/division-teams.ts
@@ -2,19 +2,21 @@
  * Division-aware team pool lookup.
  *
  * Returns the correct set of 23 NPC opponent clubs for a given division.
- * Championship and Premier League are not yet implemented — they fall back
- * to League One (placeholder; will be replaced when those divisions are built).
  */
 
 import { LEAGUE_TWO_TEAMS, LeagueTwoTeam } from './league-two-teams';
 import { LEAGUE_ONE_TEAMS } from './league-one-teams';
+import { CHAMPIONSHIP_TEAMS } from './championship-teams';
+import { PREMIER_LEAGUE_TEAMS } from './premier-league-teams';
 import { Division } from '../types/game-state-updated';
 
 export function getTeamsForDivision(division: Division): LeagueTwoTeam[] {
   switch (division) {
-    case 'LEAGUE_ONE':
-    case 'CHAMPIONSHIP':
     case 'PREMIER_LEAGUE':
+      return PREMIER_LEAGUE_TEAMS;
+    case 'CHAMPIONSHIP':
+      return CHAMPIONSHIP_TEAMS;
+    case 'LEAGUE_ONE':
       return LEAGUE_ONE_TEAMS;
     case 'LEAGUE_TWO':
     default:

--- a/packages/domain/src/data/premier-league-teams.ts
+++ b/packages/domain/src/data/premier-league-teams.ts
@@ -1,0 +1,35 @@
+/**
+ * Premier League Teams Data
+ *
+ * Fictional Pro-Evo style clubs — recognisable analogues of real Premier League
+ * sides, slightly tweaked to sidestep licensing. Strength ratings reflect
+ * rough real-world standing at Premier League level (82–97).
+ */
+
+import { LeagueTwoTeam } from './league-two-teams';
+
+export const PREMIER_LEAGUE_TEAMS: LeagueTwoTeam[] = [
+  { id: 'mansworth-c',  name: 'Mansworth City',           baseStrength: 97 },
+  { id: 'arsendale',    name: 'Arsendale FC',             baseStrength: 95 },
+  { id: 'liverton',     name: 'Liverton FC',              baseStrength: 94 },
+  { id: 'manchford-u',  name: 'Manchford United',         baseStrength: 91 },
+  { id: 'chelston',     name: 'Chelston FC',              baseStrength: 90 },
+  { id: 'hotsdale',     name: 'Hotsdale Rovers',          baseStrength: 88 },
+  { id: 'newgate-u',    name: 'Newgate United',           baseStrength: 87 },
+  { id: 'aston-crown',  name: 'Aston Crown',              baseStrength: 86 },
+  { id: 'brightmore',   name: 'Brightmore Albion',        baseStrength: 85 },
+  { id: 'leedsworth',   name: 'Leedsworth United',        baseStrength: 84 },
+  { id: 'ipston',       name: 'Ipston Town',              baseStrength: 84 },
+  { id: 'west-hamond',  name: 'West Hamond FC',           baseStrength: 84 },
+  { id: 'wolveston',    name: 'Wolveston Wanderers',      baseStrength: 83 },
+  { id: 'nottingford',  name: 'Nottingford Forest',       baseStrength: 83 },
+  { id: 'fulworth',     name: 'Fulworth FC',              baseStrength: 83 },
+  { id: 'bournebury',   name: 'Bournebury FC',            baseStrength: 83 },
+  { id: 'leyceston',    name: 'Leyceston City',           baseStrength: 83 },
+  { id: 'southmere',    name: 'Southmere City',           baseStrength: 82 },
+  { id: 'crystal-vale', name: 'Crystal Vale',             baseStrength: 82 },
+  { id: 'brentwall',    name: 'Brentwall FC',             baseStrength: 82 },
+  { id: 'everdale',     name: 'Everdale FC',              baseStrength: 82 },
+  { id: 'shefford-u',   name: 'Shefford United',          baseStrength: 82 },
+  { id: 'burnton',      name: 'Burnton FC',               baseStrength: 82 },
+];

--- a/packages/domain/src/reducers/index.ts
+++ b/packages/domain/src/reducers/index.ts
@@ -134,6 +134,7 @@ export function buildState(events: GameEvent[]): GameState {
     scoutMission: null,
     forcedOut:    null,
     division:     'LEAGUE_TWO',
+    npcStrengths: {},
   };
 
   return events.reduce(reduceEvent, initialState);
@@ -192,6 +193,12 @@ function handleGameStarted(state: GameState, event: GameStartedEvent): GameState
   // Generate the manager pool for the season
   const managerPool = generateManagerPool(event.seed);
 
+  // Seed NPC strengths from static League Two team data for the initial season.
+  const initialNpcStrengths: Record<string, number> = {};
+  for (const team of getTeamsForDivision('LEAGUE_TWO')) {
+    initialNpcStrengths[team.id] = team.baseStrength;
+  }
+
   return {
     ...state,
     phase: 'PRE_SEASON',
@@ -212,6 +219,7 @@ function handleGameStarted(state: GameState, event: GameStartedEvent): GameState
     },
     freeAgentPool,
     managerPool,
+    npcStrengths: initialNpcStrengths,
   };
 }
 
@@ -764,6 +772,20 @@ function handlePreSeasonStarted(state: GameState, event: PreSeasonStartedEvent):
   // Snapshot the final standings before resetting — used to display "Last Season" in the UI.
   const previousLeagueTable = state.league;
 
+  // Evolve NPC strengths based on the previous season's final standings.
+  // Top 4 NPCs by position: +2 strength. Bottom 4 NPCs: -2 strength. Clamped 25–99.
+  const evolvedStrengths = { ...state.npcStrengths };
+  const npcEntries = previousLeagueTable.entries
+    .filter(e => e.clubId !== state.club.id)
+    .sort((a, b) => a.position - b.position);
+  const total = npcEntries.length;
+  npcEntries.forEach((entry, idx) => {
+    const rank = idx + 1;
+    const current = evolvedStrengths[entry.clubId] ?? 50;
+    const delta = rank <= 4 ? 2 : rank > total - 4 ? -2 : 0;
+    evolvedStrengths[entry.clubId] = Math.max(25, Math.min(99, current + delta));
+  });
+
   // Rebuild NPC entries from the player's current division (may have changed via
   // promotion/relegation). The player's own entry is preserved and stats cleared.
   const playerEntry = state.league.entries.find(e => e.clubId === state.club.id)!;
@@ -782,6 +804,14 @@ function handlePreSeasonStarted(state: GameState, event: PreSeasonStartedEvent):
   }));
   const freshEntries = sortLeagueTable([freshPlayerEntry, ...freshNpcEntries]);
 
+  // Seed strengths for any NPC team entering the league for the first time
+  // (e.g. after promotion — a new division's clubs won't be in evolvedStrengths yet).
+  for (const team of npcTeams) {
+    if (!(team.id in evolvedStrengths)) {
+      evolvedStrengths[team.id] = team.baseStrength;
+    }
+  }
+
   return {
     ...state,
     phase: 'PRE_SEASON',
@@ -789,6 +819,7 @@ function handlePreSeasonStarted(state: GameState, event: PreSeasonStartedEvent):
     currentWeek: 0,
     previousLeagueTable,
     league: { ...state.league, entries: freshEntries },
+    npcStrengths: evolvedStrengths,
     club: {
       ...state.club,
       squad: updatedSquad,

--- a/packages/domain/src/types/game-state-updated.ts
+++ b/packages/domain/src/types/game-state-updated.ts
@@ -172,6 +172,14 @@ export interface GameState {
 
   /** Which division the club is currently in. Updated at season end. */
   division: Division;
+
+  /**
+   * Evolved NPC team base strengths. Maps clubId → effective baseStrength.
+   * Seeded from static team data on first appearance; adjusted each season
+   * based on final league position (top 4 NPCs: +2, bottom 4 NPCs: −2,
+   * clamped 25–99). Ensures long-running NPCs grow or decline over time.
+   */
+  npcStrengths: Record<string, number>;
 }
 
 /**

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -8,7 +8,7 @@ import { SeasonEndScreen } from './components/season-end/SeasonEndScreen';
 import { ForcedOutScreen } from './components/forced-out/ForcedOutScreen';
 
 export default function App() {
-  const { state, events, dispatch, isLoading } = useGameState();
+  const { state, events, dispatch, isLoading, resetGame } = useGameState();
   const [activeView, setActiveView] = useState<ActiveView>('command');
   const [error, setError] = useState<string | null>(null);
 
@@ -33,6 +33,7 @@ export default function App() {
         isLoading={isLoading}
         dispatch={dispatch}
         onError={setError}
+        onResetGame={resetGame}
       />
 
       {/* Error toast */}

--- a/packages/frontend/src/components/shared/ViewToggle.tsx
+++ b/packages/frontend/src/components/shared/ViewToggle.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { GameState, GameCommand, PendingClubEvent } from '@calculating-glory/domain';
 import { WeekAdvanceButton } from '../command-centre/WeekAdvanceButton';
 
@@ -10,6 +11,7 @@ interface ViewToggleProps {
   isLoading: boolean;
   dispatch: (command: GameCommand) => { error?: string };
   onError: (msg: string) => void;
+  onResetGame: () => void;
 }
 
 export function ViewToggle({
@@ -19,57 +21,102 @@ export function ViewToggle({
   isLoading,
   dispatch,
   onError,
+  onResetGame,
 }: ViewToggleProps) {
+  const [showConfirm, setShowConfirm] = useState(false);
+
   return (
-    <div className="flex items-center justify-between px-4 py-2 border-b border-bg-raised bg-bg-surface">
-      {/* Left: Club info */}
-      <div className="flex items-center gap-4">
-        <div>
-          <h1 className="text-lg font-bold text-txt-primary tracking-tight">
-            {state.club.name}
-          </h1>
-          <p className="text-xs text-txt-muted">
-            Season {state.season} · Week {state.currentWeek} ·{' '}
-            <span className="capitalize">{state.phase.replace('_', ' ').toLowerCase()}</span>
-          </p>
+    <>
+      <div className="flex items-center justify-between px-4 py-2 border-b border-bg-raised bg-bg-surface">
+        {/* Left: Club info */}
+        <div className="flex items-center gap-4">
+          <div>
+            <h1 className="text-lg font-bold text-txt-primary tracking-tight">
+              {state.club.name}
+            </h1>
+            <p className="text-xs text-txt-muted">
+              Season {state.season} · Week {state.currentWeek} ·{' '}
+              <span className="capitalize">{state.phase.replace('_', ' ').toLowerCase()}</span>
+            </p>
+          </div>
+        </div>
+
+        {/* Centre: View toggle */}
+        <div className="flex items-center gap-1 bg-bg-raised rounded-card p-1">
+          <button
+            onClick={() => onViewChange('command')}
+            className={[
+              'px-3 py-1.5 rounded-tag text-xs font-semibold transition-all duration-150',
+              activeView === 'command'
+                ? 'bg-bg-surface text-txt-primary shadow-sm'
+                : 'text-txt-muted hover:text-txt-primary',
+            ].join(' ')}
+          >
+            Command Centre
+          </button>
+          <button
+            onClick={() => onViewChange('stadium')}
+            className={[
+              'px-3 py-1.5 rounded-tag text-xs font-semibold transition-all duration-150',
+              activeView === 'stadium'
+                ? 'bg-bg-surface text-txt-primary shadow-sm'
+                : 'text-txt-muted hover:text-txt-primary',
+            ].join(' ')}
+          >
+            Stadium View
+          </button>
+        </div>
+
+        {/* Right: New game + week advance */}
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => setShowConfirm(true)}
+            className="text-xs text-txt-muted hover:text-txt-primary transition-colors duration-150"
+          >
+            New Game
+          </button>
+          <WeekAdvanceButton
+            pendingEvents={state.pendingEvents}
+            currentWeek={state.currentWeek}
+            season={state.season}
+            isLoading={isLoading}
+            dispatch={dispatch}
+            onError={onError}
+          />
         </div>
       </div>
 
-      {/* Centre: View toggle */}
-      <div className="flex items-center gap-1 bg-bg-raised rounded-card p-1">
-        <button
-          onClick={() => onViewChange('command')}
-          className={[
-            'px-3 py-1.5 rounded-tag text-xs font-semibold transition-all duration-150',
-            activeView === 'command'
-              ? 'bg-bg-surface text-txt-primary shadow-sm'
-              : 'text-txt-muted hover:text-txt-primary',
-          ].join(' ')}
+      {/* New game confirmation modal */}
+      {showConfirm && (
+        <div
+          className="fixed inset-0 bg-bg-deep/80 flex items-center justify-center z-50"
+          onClick={() => setShowConfirm(false)}
         >
-          Command Centre
-        </button>
-        <button
-          onClick={() => onViewChange('stadium')}
-          className={[
-            'px-3 py-1.5 rounded-tag text-xs font-semibold transition-all duration-150',
-            activeView === 'stadium'
-              ? 'bg-bg-surface text-txt-primary shadow-sm'
-              : 'text-txt-muted hover:text-txt-primary',
-          ].join(' ')}
-        >
-          Stadium View
-        </button>
-      </div>
-
-      {/* Right: Week advance */}
-      <WeekAdvanceButton
-        pendingEvents={state.pendingEvents}
-        currentWeek={state.currentWeek}
-        season={state.season}
-        isLoading={isLoading}
-        dispatch={dispatch}
-        onError={onError}
-      />
-    </div>
+          <div
+            className="card max-w-sm w-full mx-4"
+            onClick={e => e.stopPropagation()}
+          >
+            <h2 className="text-base font-bold text-txt-primary mb-1">Start a new game?</h2>
+            <p className="text-sm text-txt-muted mb-4">
+              Your current save will be permanently wiped. This can't be undone.
+            </p>
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={() => setShowConfirm(false)}
+                className="px-4 py-2 rounded-tag text-sm text-txt-muted hover:text-txt-primary transition-colors duration-150"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={onResetGame}
+                className="px-4 py-2 rounded-tag text-sm font-semibold bg-alert-red/20 text-alert-red hover:bg-alert-red/30 transition-colors duration-150"
+              >
+                Start Fresh
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- **Championship + Premier League NPC teams** — `championship-teams.ts` (23 clubs, 68–88 strength) and `premier-league-teams.ts` (23 clubs, 82–97 strength); `getTeamsForDivision()` now has four proper cases — no more L1 fallback for upper divisions
- **NPC strength evolution** — `GameState.npcStrengths` map seeded from static team data at game start, evolved each pre-season: top 4 NPCs +2, bottom 4 −2, clamped 25–99. Also fixes a pre-existing bug where `buildTeamMap()` was using a flat `35 + rng.next() * 30` for all divisions, completely ignoring the division-specific baseStrength values
- **New Game UI** — "New Game" button in the `ViewToggle` right section with a confirmation modal before wiping the save via `resetGame()`

## Test plan

- [x] 441 domain tests passing
- [x] TypeScript clean (only pre-existing `inboxUtils` fixture issue)
- [x] Dev server builds and loads with no console errors
- [ ] Play to end of season 1 — verify NPCs in season 2 have evolved strengths
- [ ] Get promoted to League One — verify new NPC pool loads correctly with L1 strength range
- [ ] Click New Game → confirm modal → verify save wipes and pre-season restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)