### PR TITLE
feat: menu screen + financial health bar

### DIFF
--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -45,7 +45,7 @@ export * from './data/scout-target-generator';
 export { isUnsettled, avgSquadMorale, UNSETTLED_THRESHOLD } from './simulation/morale';
 
 // Simulation helpers
-export { playerCharismaRevenue, squadCharismaRevenue } from './simulation/revenue';
+export { playerCharismaRevenue, squadCharismaRevenue, computeWeeklyFinancials } from './simulation/revenue';
 
 // Attribute progression
 export {

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -6,11 +6,36 @@ import { ViewToggle, ActiveView } from './components/shared/ViewToggle';
 import { PreSeasonScreen } from './components/pre-season/PreSeasonScreen';
 import { SeasonEndScreen } from './components/season-end/SeasonEndScreen';
 import { ForcedOutScreen } from './components/forced-out/ForcedOutScreen';
+import { MenuScreen } from './components/menu/MenuScreen';
 
 export default function App() {
   const { state, events, dispatch, isLoading, resetGame } = useGameState();
+  const [screen, setScreen] = useState<'menu' | 'game'>('menu');
   const [activeView, setActiveView] = useState<ActiveView>('command');
   const [error, setError] = useState<string | null>(null);
+
+  // A save exists if there's more than the initial GAME_STARTED event
+  const hasSave = events.length > 1;
+
+  function handleContinue() {
+    setScreen('game');
+  }
+
+  function handleNewGame() {
+    resetGame();
+    setScreen('game');
+  }
+
+  if (screen === 'menu') {
+    return (
+      <MenuScreen
+        state={state}
+        hasSave={hasSave}
+        onContinue={handleContinue}
+        onNewGame={handleNewGame}
+      />
+    );
+  }
 
   if (state.phase === 'PRE_SEASON') {
     return <PreSeasonScreen state={state} dispatch={dispatch} />;

--- a/packages/frontend/src/components/command-centre/CommandCentre.tsx
+++ b/packages/frontend/src/components/command-centre/CommandCentre.tsx
@@ -12,6 +12,7 @@ import { SocialFeed } from '../social-feed/SocialFeed';
 import { BackroomTeamSlideOver } from './BackroomTeamSlideOver';
 import { LearningProgressSlideOver } from './LearningProgressSlideOver';
 import { TransferMarketSlideOver } from '../transfer-market/TransferMarketSlideOver';
+import { FinancialHealthBar } from '../shared/FinancialHealthBar';
 
 interface CommandCentreProps {
   state: GameState;
@@ -69,6 +70,9 @@ export function CommandCentre({ state, events, dispatch, isLoading, onNavigateTo
         squad={state.club.squad}
         form={state.club.form}
       />
+
+      {/* ── Financial Health Bar ─────────────────────────────────────────── */}
+      <FinancialHealthBar state={state} />
 
       {/* ── Error toast ──────────────────────────────────────────────────── */}
       {error && (

--- a/packages/frontend/src/components/command-centre/__tests__/inboxUtils.test.ts
+++ b/packages/frontend/src/components/command-centre/__tests__/inboxUtils.test.ts
@@ -243,6 +243,7 @@ describe('buildNotableMatches', () => {
       goalsAgainst: 10,
       goalDifference: 5,
       points: 17,
+      form: [],
     }));
   }
 

--- a/packages/frontend/src/components/menu/MenuScreen.tsx
+++ b/packages/frontend/src/components/menu/MenuScreen.tsx
@@ -1,0 +1,97 @@
+import { GameState, formatMoney } from '@calculating-glory/domain';
+
+interface Props {
+  state: GameState;
+  hasSave: boolean;
+  onContinue: () => void;
+  onNewGame: () => void;
+}
+
+function phaseLabel(phase: GameState['phase']): string {
+  switch (phase) {
+    case 'PRE_SEASON':    return 'Pre-Season';
+    case 'EARLY_SEASON':  return 'Early Season';
+    case 'MID_SEASON':    return 'Mid Season';
+    case 'LATE_SEASON':   return 'Late Season';
+    case 'SEASON_END':    return 'Season End';
+    default:              return 'In Progress';
+  }
+}
+
+export function MenuScreen({ state, hasSave, onContinue, onNewGame }: Props) {
+  return (
+    <div className="min-h-screen bg-bg-deep flex flex-col items-center justify-center px-6">
+
+      {/* Title block */}
+      <div className="text-center mb-12">
+        <div className="text-xs uppercase tracking-[0.3em] text-data-blue mb-3 font-semibold">
+          Football Finance Simulator
+        </div>
+        <h1 className="text-5xl font-bold text-txt-primary tracking-tight leading-none mb-4">
+          Calculating<br />Glory
+        </h1>
+        <p className="text-txt-muted text-sm max-w-xs mx-auto leading-relaxed">
+          You're the owner. Every decision comes back to money. Keep the bar green.
+        </p>
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex flex-col gap-3 w-full max-w-xs">
+
+        {/* Continue — only shown when save exists */}
+        {hasSave && (
+          <button
+            onClick={onContinue}
+            className="w-full bg-data-blue hover:bg-data-blue/90 active:scale-[0.98] text-white
+                       rounded-card px-6 py-4 text-left transition-all duration-150 group"
+          >
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="font-semibold text-base leading-tight">Continue</div>
+                <div className="text-blue-200 text-xs mt-0.5 font-mono">
+                  {state.club.name}
+                  {' · '}
+                  {phaseLabel(state.phase)}
+                  {['EARLY_SEASON', 'MID_SEASON', 'LATE_SEASON'].includes(state.phase) ? ` · Wk ${state.currentWeek}` : ''}
+                  {' · '}
+                  S{state.season}
+                </div>
+              </div>
+              <div className="text-white/60 group-hover:text-white/90 transition-colors text-lg">→</div>
+            </div>
+            <div className="mt-2 text-blue-200/70 text-xs font-mono">
+              Budget: {formatMoney(state.club.transferBudget)}
+            </div>
+          </button>
+        )}
+
+        {/* New Game */}
+        <button
+          onClick={onNewGame}
+          className={`w-full rounded-card px-6 py-4 text-left transition-all duration-150 group
+            ${hasSave
+              ? 'bg-bg-surface hover:bg-bg-raised border border-bg-raised text-txt-primary'
+              : 'bg-data-blue hover:bg-data-blue/90 active:scale-[0.98] text-white'
+            }`}
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="font-semibold text-base leading-tight">New Game</div>
+              <div className={`text-xs mt-0.5 ${hasSave ? 'text-txt-muted' : 'text-blue-200'}`}>
+                {hasSave ? 'Overwrites your current save' : 'Start your first season'}
+              </div>
+            </div>
+            <div className={`text-lg transition-colors ${hasSave ? 'text-txt-muted group-hover:text-txt-primary' : 'text-white/60 group-hover:text-white/90'}`}>→</div>
+          </div>
+        </button>
+
+      </div>
+
+      {/* Footer */}
+      <div className="mt-16 text-txt-muted text-xs text-center opacity-40">
+        Calculating Glory
+      </div>
+
+    </div>
+  );
+}

--- a/packages/frontend/src/components/shared/FinancialHealthBar.tsx
+++ b/packages/frontend/src/components/shared/FinancialHealthBar.tsx
@@ -1,0 +1,83 @@
+import { GameState, computeWeeklyFinancials, formatMoney } from '@calculating-glory/domain';
+
+interface Props {
+  state: GameState;
+}
+
+interface RunwayStyle {
+  barClass: string;
+  textClass: string;
+  pulse: boolean;
+}
+
+function getRunwayStyle(runway: number, isSurplus: boolean): RunwayStyle {
+  if (isSurplus) {
+    return { barClass: 'bg-data-blue', textClass: 'text-data-blue', pulse: false };
+  }
+  if (runway >= 20) {
+    return { barClass: 'bg-pitch-green', textClass: 'text-pitch-green', pulse: false };
+  }
+  if (runway >= 10) {
+    return { barClass: 'bg-warn-amber', textClass: 'text-warn-amber', pulse: false };
+  }
+  if (runway >= 5) {
+    return { barClass: 'bg-alert-red', textClass: 'text-alert-red', pulse: false };
+  }
+  return { barClass: 'bg-alert-red', textClass: 'text-alert-red', pulse: true };
+}
+
+export function FinancialHealthBar({ state }: Props) {
+  const { weeklyIncome, weeklyWages, runway } = computeWeeklyFinancials(state);
+  const budget = state.club.transferBudget;
+  const burn = weeklyWages - weeklyIncome;
+  const isSurplus = burn <= 0;
+
+  const runwayWeeks = isSurplus ? Infinity : Math.min(Math.floor(runway), 99);
+  const { barClass, textClass, pulse } = getRunwayStyle(runway, isSurplus);
+
+  // Bar fills proportionally up to 52 weeks (one full season = full bar)
+  const fillPct = isSurplus ? 100 : Math.min((runway / 52) * 100, 100);
+
+  const burnLabel = isSurplus
+    ? `+${formatMoney(-burn)}/wk`
+    : `${formatMoney(burn)}/wk`;
+
+  const runwayLabel = isSurplus ? 'Surplus' : `${runwayWeeks} wks`;
+
+  return (
+    <div className="mx-4 mt-1 px-3 py-1.5 bg-bg-surface rounded-card flex items-center gap-3 text-sm">
+
+      {/* Budget */}
+      <div className="flex items-center gap-1.5 shrink-0">
+        <span className="text-txt-muted text-xs uppercase tracking-wide leading-none">Budget</span>
+        <span className="text-txt-primary font-mono font-semibold tabular-nums">{formatMoney(budget)}</span>
+      </div>
+
+      <div className="h-3.5 w-px bg-bg-raised shrink-0" />
+
+      {/* Burn rate */}
+      <div className="flex items-center gap-1.5 shrink-0">
+        <span className="text-txt-muted text-xs uppercase tracking-wide leading-none">Burn</span>
+        <span className={`font-mono font-semibold tabular-nums ${isSurplus ? 'text-data-blue' : 'text-txt-primary'}`}>
+          {burnLabel}
+        </span>
+      </div>
+
+      <div className="h-3.5 w-px bg-bg-raised shrink-0" />
+
+      {/* Runway bar */}
+      <div className="flex items-center gap-2 flex-1 min-w-0">
+        <div className="flex-1 h-1.5 bg-bg-raised rounded-full overflow-hidden min-w-[60px]">
+          <div
+            className={`h-full rounded-full transition-[width] duration-500 ${barClass} ${pulse ? 'animate-pulse' : ''}`}
+            style={{ width: `${fillPct}%` }}
+          />
+        </div>
+        <span className={`font-mono font-semibold text-xs shrink-0 tabular-nums ${textClass} ${runway < 10 && !isSurplus ? 'font-bold' : ''}`}>
+          {runwayLabel}
+        </span>
+      </div>
+
+    </div>
+  );
+}

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -20,5 +20,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
## Summary

- **Menu screen** — shown on every load before entering the game. Shows "Continue" (with club name, phase, week, budget) when a save exists, "New Game" otherwise. New Game clears the save and starts fresh.
- **Financial Health Bar** — persistent bar below the news ticker in the Command Centre. Shows Budget · Burn/wk · colour-coded runway bar (green/amber/red/teal). Pulses when runway < 5 weeks. Reads from existing `computeWeeklyFinancials` in the domain (exported for the first time).
- Also carries the `tsconfig.json` test-exclude fix and `inboxUtils.test.ts` form field fix from main.

## Test plan

- [ ] Fresh visit (no localStorage): only "New Game" shown on menu
- [ ] Click New Game → pre-season screen appears
- [ ] Play through pre-season and advance a week, refresh → "Continue" now shows with club name/week/budget
- [ ] Click Continue → drops into game at correct week
- [ ] Financial bar visible in Command Centre, updates each week advance
- [ ] Bar turns amber/red at low runway (can test by hiring expensive manager)
- [ ] TypeScript: `npx tsc --noEmit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)