### PR TITLE
feat: wire event chains to question bank via bankTopic

### DIFF
--- a/packages/domain/src/data/club-events.ts
+++ b/packages/domain/src/data/club-events.ts
@@ -8,6 +8,8 @@
  * All budget amounts are in pence.
  */
 
+import { MathTopic } from '../curriculum/curriculum-config';
+
 /** NPC voices that can deliver events */
 export type NpcId = 'val' | 'marcus' | 'dani' | 'kev';
 
@@ -57,6 +59,16 @@ export interface ClubEventTemplate {
    * follow-up hop variants.
    */
   mathsChallenge?: MathsChallengeSpec;
+  /**
+   * When set, the math negotiation choice on this event pulls a question from
+   * the question bank for this topic, rather than generating an inline
+   * financial-context percentage question.
+   *
+   * Use when the event's math story maps to a specific curriculum topic
+   * (algebra, ratios, data interpretation, etc.) rather than a simple
+   * percentage comparison between two budget effects.
+   */
+  bankTopic?: MathTopic;
   choices: {
     id: string;
     label: string;
@@ -232,6 +244,7 @@ export const CLUB_EVENT_TEMPLATES: ClubEventTemplate[] = [
     description:
       'Your accountant has found a potential tax break. There might be money to reclaim.',
     severity: 'minor',
+    bankTopic: 'BASIC_ALGEBRA',
     choices: [
       {
         id: 'claim-it',
@@ -281,6 +294,7 @@ export const CLUB_EVENT_TEMPLATES: ClubEventTemplate[] = [
     description:
       'The coaching staff are threatening to strike over wages. This could disrupt preparation.',
     severity: 'major',
+    bankTopic: 'RATIOS',
     choices: [
       {
         id: 'give-raise',
@@ -466,6 +480,7 @@ export const CLUB_EVENT_TEMPLATES: ClubEventTemplate[] = [
     description:
       'Your food upgrades are proving popular! A catering company wants to partner with the club.',
     severity: 'minor',
+    bankTopic: 'DATA_INTERPRETATION',
     prerequisite: {
       eventId: 'hot-dog-complaint',
       choiceId: 'upgrade'
@@ -494,6 +509,7 @@ export const CLUB_EVENT_TEMPLATES: ClubEventTemplate[] = [
     description:
       'Your investor wants a say in transfer decisions. You need to manage this carefully.',
     severity: 'major',
+    bankTopic: 'DATA_INTERPRETATION',
     prerequisite: {
       eventId: 'investment-offer',
       choiceId: 'accept'

--- a/packages/domain/src/simulation/events.ts
+++ b/packages/domain/src/simulation/events.ts
@@ -226,6 +226,7 @@ export function generateWeekEvents(
       hopNumber: template.hopNumber,
       chainLength: template.chainLength,
       mathsChallenge: template.mathsChallenge,
+      bankTopic: template.bankTopic,
       choices: template.choices.map(c => ({
         id: c.id,
         label: c.label,

--- a/packages/domain/src/types/game-state-updated.ts
+++ b/packages/domain/src/types/game-state-updated.ts
@@ -12,6 +12,7 @@ import { CurriculumConfig } from '../curriculum/curriculum-config';
 import { Player, Position } from './player';
 import { Manager } from './staff';
 import { MathsChallengeSpec, NpcId } from '../data/club-events';
+import { MathTopic } from '../curriculum/curriculum-config';
 
 /**
  * A choice available within a club event
@@ -63,6 +64,12 @@ export interface PendingClubEvent {
   chainLength?: number;
   /** Structured maths challenge to evaluate before choices apply */
   mathsChallenge?: MathsChallengeSpec;
+  /**
+   * When set, the math negotiation choice on this event should pull a
+   * question from the question bank for this topic rather than generating
+   * an inline financial-context percentage question.
+   */
+  bankTopic?: MathTopic;
   /**
    * Optional metadata for specialised event types (e.g. NPC poaching).
    * Not present on standard club events.

--- a/packages/frontend/src/components/social-feed/SocialFeed.tsx
+++ b/packages/frontend/src/components/social-feed/SocialFeed.tsx
@@ -123,7 +123,7 @@ export function SocialFeed({ state, dispatch, linkedEvent }: SocialFeedProps) {
     const mathChoice = event.choices.find(c => c.requiresMath);
     if (!mathChoice) return;
 
-    const challenge = generateEventChallenge(event, state.club.transferBudget, state.curriculum?.level);
+    const challenge = generateEventChallenge(event, state);
     if (!challenge) return;
 
     setActiveLinkedEvent({ event, mathChoiceId: mathChoice.id });

--- a/packages/frontend/src/components/social-feed/generateChallenge.ts
+++ b/packages/frontend/src/components/social-feed/generateChallenge.ts
@@ -60,8 +60,9 @@ const CHALLENGE_TOPIC_TO_MATH_TOPICS: Record<ChallengeTopic, MathTopic[]> = {
 /**
  * Maps domain MathTopic → the ChallengeTopic it belongs to.
  * Used to tag resolved challenges for the frontend display system.
+ * Exported so generateEventChallenge can reuse the same mapping.
  */
-const MATH_TOPIC_TO_CHALLENGE: Partial<Record<MathTopic, ChallengeTopic>> = {
+export const MATH_TOPIC_TO_CHALLENGE: Partial<Record<MathTopic, ChallengeTopic>> = {
   BASIC_ARITHMETIC:     'percentage',
   DECIMALS:             'decimals',
   PERCENTAGES:          'percentage',

--- a/packages/frontend/src/components/social-feed/generateEventChallenge.ts
+++ b/packages/frontend/src/components/social-feed/generateEventChallenge.ts
@@ -1,5 +1,13 @@
-import { PendingClubEvent, CurriculumLevel, MAX_DIFFICULTY_BY_LEVEL } from '@calculating-glory/domain';
-import { MathChallenge } from './generateChallenge';
+import {
+  PendingClubEvent,
+  GameState,
+  CurriculumLevel,
+  MAX_DIFFICULTY_BY_LEVEL,
+  pickQuestion,
+  resolveTemplate,
+  extractVariables,
+} from '@calculating-glory/domain';
+import { MathChallenge, ChallengeTopic, MATH_TOPIC_TO_CHALLENGE } from './generateChallenge';
 
 function absGBP(pence: number): number {
   return Math.abs(pence) / 100;
@@ -14,32 +22,80 @@ function round1(n: number) {
 }
 
 /**
- * Given a pending event that has a requiresMath choice, generate a MathChallenge
- * whose question is derived from the actual financial stakes of that negotiation.
- *
- * Returns null if no suitable challenge can be constructed (SocialFeed should
- * fall back to the standard challenge bank in this case).
- */
-/**
  * Clamp a raw difficulty value to what the student's curriculum level allows.
- * Event challenges always produce percentage questions (difficulty 2), so for Year 7
- * students we downgrade those to difficulty 1 with simpler working shown.
  */
 function clampDifficulty(raw: 1 | 2 | 3, curriculumLevel: CurriculumLevel): 1 | 2 | 3 {
   const max = MAX_DIFFICULTY_BY_LEVEL[curriculumLevel];
   return Math.min(raw, max) as 1 | 2 | 3;
 }
 
+/**
+ * Derive a deterministic selection index from an event id string.
+ * Used so bank-topic events always pick the same question for the same event.
+ */
+function idToSeed(id: string): number {
+  return id.split('').reduce((acc, ch) => acc + ch.charCodeAt(0), 0);
+}
+
+/**
+ * Given a pending event that has a requiresMath choice, generate a MathChallenge.
+ *
+ * Two paths:
+ *
+ *   Bank path  — when event.bankTopic is set, a question is pulled from the
+ *                question bank for that topic and resolved against live game
+ *                state. Used for events where the maths story maps to a
+ *                specific curriculum topic (algebra, ratios, data
+ *                interpretation) rather than a simple budget comparison.
+ *
+ *   Financial context path — the original behaviour: derive a percentage
+ *                question from the actual budget stakes of the negotiation
+ *                (saving %, increase %, or % of transfer budget). Used for
+ *                all events without a bankTopic tag.
+ *
+ * Returns null if no suitable challenge can be constructed (SocialFeed should
+ * fall back to the standard challenge bank in that case).
+ */
 export function generateEventChallenge(
   event: PendingClubEvent,
-  transferBudget: number,       // pence
-  curriculumLevel: CurriculumLevel = 'YEAR_7'
+  state: GameState,
 ): MathChallenge | null {
+  const curriculumLevel = state.curriculum?.level ?? 'YEAR_7';
+
+  // ── Bank path: event has a specific topic tag ─────────────────────────────
+  if (event.bankTopic) {
+    const mathChoice = event.choices.find(c => c.requiresMath);
+    if (!mathChoice) return null;
+
+    const template = pickQuestion(curriculumLevel, {
+      topics: [event.bankTopic],
+      selectionIndex: idToSeed(event.id),
+    });
+    if (!template) return null;
+
+    const vars     = extractVariables(state);
+    const resolved = resolveTemplate(template, vars);
+
+    return {
+      id:          `event-${event.id}`,
+      topic:       (MATH_TOPIC_TO_CHALLENGE[resolved.topic] ?? 'percentage') as ChallengeTopic,
+      difficulty:  clampDifficulty(resolved.difficulty, curriculumLevel),
+      question:    resolved.question,
+      answer:      resolved.answer,
+      unit:        resolved.unit,
+      hints:       resolved.hints,
+      explanation: resolved.explanation,
+      context:     `${event.title}: ${event.description}`,
+    };
+  }
+
+  // ── Financial context path: derive question from budget effects ───────────
   const mathChoice = event.choices.find(c => c.requiresMath);
   if (!mathChoice || mathChoice.budgetEffect === undefined) return null;
 
-  const mathEffect = mathChoice.budgetEffect;   // signed pence
-  const mathAmount = absGBP(mathEffect);         // unsigned £
+  const transferBudget = state.club.transferBudget;
+  const mathEffect     = mathChoice.budgetEffect;   // signed pence
+  const mathAmount     = absGBP(mathEffect);        // unsigned £
 
   // Find a comparable non-math choice with the same budget sign (cost vs income)
   const comparable = event.choices.find(
@@ -47,7 +103,7 @@ export function generateEventChallenge(
          Math.sign(c.budgetEffect) === Math.sign(mathEffect)
   );
 
-  // ── COST scenario: math route costs less than the standard option ───────────
+  // ── COST scenario: math route costs less than the standard option ─────────
   if (comparable?.budgetEffect !== undefined && mathEffect < 0) {
     const cmpAmount = absGBP(comparable.budgetEffect);
     const saving    = cmpAmount - mathAmount;
@@ -79,7 +135,7 @@ export function generateEventChallenge(
     };
   }
 
-  // ── INCOME scenario: math route earns more than the standard option ─────────
+  // ── INCOME scenario: math route earns more than the standard option ───────
   if (comparable?.budgetEffect !== undefined && mathEffect > 0) {
     const cmpAmount   = absGBP(comparable.budgetEffect);
     const increase    = mathAmount - cmpAmount;
@@ -111,7 +167,7 @@ export function generateEventChallenge(
     };
   }
 
-  // ── FALLBACK: no comparable budget choice — express as % of transfer budget ─
+  // ── FALLBACK: no comparable budget choice — express as % of transfer budget
   if (mathEffect > 0) {
     const budgetPounds = transferBudget / 100;
     const dealPct      = round1((mathAmount / budgetPounds) * 100);

--- a/packages/frontend/src/hooks/useGameState.ts
+++ b/packages/frontend/src/hooks/useGameState.ts
@@ -19,7 +19,7 @@ interface UseGameStateReturn {
   state: GameState;
   events: GameEvent[];
   dispatch: (command: GameCommand) => { error?: string };
-  resetGame: (curriculumLevel: CurriculumLevel) => void;
+  resetGame: (curriculumLevel?: CurriculumLevel) => void;
   isLoading: boolean;
 }
 
@@ -52,7 +52,7 @@ export function useGameState(): UseGameStateReturn {
     return {};
   }, [state, events]);
 
-  const resetGame = useCallback((curriculumLevel: CurriculumLevel) => {
+  const resetGame = useCallback((curriculumLevel: CurriculumLevel = 'YEAR_7') => {
     clearSave();
     const { state: freshState, events: freshEvents } = createInitialGameState(curriculumLevel);
     setEvents(freshEvents);


### PR DESCRIPTION
## Summary

- Adds `bankTopic?: MathTopic` to `ClubEventTemplate` and `PendingClubEvent` — when set, the math negotiation choice pulls a question from the question bank for that topic instead of generating an inline financial-context percentage question
- Four events tagged with bank topics: `tax-break` (algebra), `staff-wage-dispute` (ratios), `catering-expansion` (data interpretation), `investor-demands` (data interpretation)
- All other events retain the existing financial-context percentage question generation (cost saving %, income increase %, % of budget fallback)
- `generateEventChallenge` signature simplified: now accepts `GameState` directly rather than separate `transferBudget + curriculumLevel` args
- `resetGame` in `useGameState` now defaults `curriculumLevel` to `YEAR_7` so the MenuScreen new-game flow works without requiring a picker

## How it works

Events without `bankTopic` → original financial context path (unchanged behaviour)

Events with `bankTopic` → `pickQuestion(curriculumLevel, { topics: [bankTopic], selectionIndex: idToSeed(event.id) })` → `resolveTemplate(template, vars)` → `MathChallenge`. The selection index is deterministic per event id so the same event always shows the same question.

## Test plan

- [ ] Play through a `tax-break` event with the negotiate choice — should show an algebra question, not a percentage question
- [ ] Play through a `staff-wage-dispute` negotiate — should show a ratios question
- [ ] Play through `burst-pipes` negotiate — should still show a percentage saving question (no bankTopic)
- [ ] Verify Year 7 student gets difficulty-clamped bank questions (D1 only)
- [ ] Start a new game from MenuScreen — should work without selecting a year group (defaults to Year 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)