### PR TITLE
feat: how-to-play intro journey

### DIFF
--- a/packages/domain/src/commands/handlers.ts
+++ b/packages/domain/src/commands/handlers.ts
@@ -62,6 +62,16 @@ export function handleCommand(command: GameCommand, state: GameState): CommandRe
       return handleCancelScoutMission(command, state);
     case 'ACCEPT_TAKEOVER':
       return handleAcceptTakeover(command, state);
+    case 'ACCEPT_INTRO_SPONSOR_DEAL':
+      return {
+        events: [{
+          type: 'BUDGET_UPDATED',
+          timestamp: Date.now(),
+          clubId: command.clubId,
+          amount: command.amount,
+          reason: `intro-sponsor-deal-option-${command.choice.toLowerCase()}`,
+        }],
+      };
     default:
       return {
         error: {

--- a/packages/domain/src/commands/types.ts
+++ b/packages/domain/src/commands/types.ts
@@ -30,7 +30,8 @@ export type GameCommand =
   | StartScoutMissionCommand
   | PlaceScoutBidCommand
   | CancelScoutMissionCommand
-  | AcceptTakeoverCommand;
+  | AcceptTakeoverCommand
+  | AcceptIntroSponsorDealCommand;
 
 export interface MakeTransferCommand {
   type: 'MAKE_TRANSFER';
@@ -149,6 +150,14 @@ export interface CancelScoutMissionCommand {
 
 export interface AcceptTakeoverCommand {
   type: 'ACCEPT_TAKEOVER';
+}
+
+export interface AcceptIntroSponsorDealCommand {
+  type: 'ACCEPT_INTRO_SPONSOR_DEAL';
+  clubId: string;
+  choice: 'A' | 'B';
+  /** Amount to credit in pence */
+  amount: number;
 }
 
 export interface CommandResult {

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { CurriculumLevel } from '@calculating-glory/domain';
 import { useGameState } from './hooks/useGameState';
 import { CommandCentre } from './components/command-centre/CommandCentre';
 import { StadiumView } from './components/stadium-view/StadiumView';
@@ -7,22 +8,30 @@ import { PreSeasonScreen } from './components/pre-season/PreSeasonScreen';
 import { SeasonEndScreen } from './components/season-end/SeasonEndScreen';
 import { ForcedOutScreen } from './components/forced-out/ForcedOutScreen';
 import { MenuScreen } from './components/menu/MenuScreen';
+import { IntroScreen } from './components/intro/IntroScreen';
+import { isIntroCompleted, clearIntroCompleted } from './lib/introState';
+
+type Screen = 'menu' | 'intro' | 'game';
 
 export default function App() {
   const { state, events, dispatch, isLoading, resetGame } = useGameState();
-  const [screen, setScreen] = useState<'menu' | 'game'>('menu');
+  const [screen, setScreen] = useState<Screen>('menu');
   const [activeView, setActiveView] = useState<ActiveView>('command');
   const [error, setError] = useState<string | null>(null);
 
-  // A save exists if there's more than the initial GAME_STARTED event
   const hasSave = events.length > 1;
 
   function handleContinue() {
     setScreen('game');
   }
 
-  function handleNewGame() {
-    resetGame();
+  function handleNewGame(level: CurriculumLevel) {
+    clearIntroCompleted();
+    resetGame(level);
+    setScreen('intro');
+  }
+
+  function handleIntroComplete() {
     setScreen('game');
   }
 
@@ -33,6 +42,17 @@ export default function App() {
         hasSave={hasSave}
         onContinue={handleContinue}
         onNewGame={handleNewGame}
+      />
+    );
+  }
+
+  if (screen === 'intro') {
+    return (
+      <IntroScreen
+        state={state}
+        events={events}
+        dispatch={dispatch}
+        onComplete={handleIntroComplete}
       />
     );
   }
@@ -61,7 +81,6 @@ export default function App() {
         onResetGame={resetGame}
       />
 
-      {/* Error toast */}
       {error && (
         <div
           className="mx-4 mt-2 bg-alert-red/10 border border-alert-red/40 rounded-card px-4 py-2
@@ -93,7 +112,6 @@ export default function App() {
         />
       )}
 
-      {/* Loading overlay */}
       {isLoading && (
         <div className="fixed inset-0 bg-bg-deep/60 flex items-center justify-center z-50">
           <div className="card flex items-center gap-3 text-sm text-txt-primary">

--- a/packages/frontend/src/components/intro/IntroScreen.tsx
+++ b/packages/frontend/src/components/intro/IntroScreen.tsx
@@ -1,0 +1,356 @@
+import { useState, useEffect, useRef } from 'react';
+import { GameState, GameCommand, formatMoney, toPence } from '@calculating-glory/domain';
+import { CommandCentre } from '../command-centre/CommandCentre';
+import { FinancialHealthBar } from '../shared/FinancialHealthBar';
+import { NpcMessage } from './NpcMessage';
+import { MathsChallenge } from './MathsChallenge';
+import { markIntroCompleted } from '../../lib/introState';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface Props {
+  state: GameState;
+  events: import('@calculating-glory/domain').GameEvent[];
+  dispatch: (command: GameCommand) => { error?: string };
+  onComplete: () => void;
+}
+
+// ── Step definitions ──────────────────────────────────────────────────────────
+
+// Steps 0–3:  Beat 1 — Arrival         blur(10) brightness(0.15)
+// Steps 4–6:  Beat 2 — Meet the team   blur(7)  brightness(0.25)
+// Steps 7–8:  Beat 3 — Stadium tour    blur(5)  brightness(0.40)
+// Steps 9–11: Beat 4 — Squad check     blur(3)  brightness(0.55)
+// Steps 12–17:Beat 5 — First decision  blur(1)  brightness(0.75)
+
+const BLUR_BY_STEP: Record<number, string> = {
+  0:  'blur(10px) brightness(0.15)',
+  1:  'blur(10px) brightness(0.15)',
+  2:  'blur(10px) brightness(0.15)',
+  3:  'blur(10px) brightness(0.15)',
+  4:  'blur(7px)  brightness(0.25)',
+  5:  'blur(7px)  brightness(0.25)',
+  6:  'blur(7px)  brightness(0.25)',
+  7:  'blur(5px)  brightness(0.40)',
+  8:  'blur(5px)  brightness(0.40)',
+  9:  'blur(3px)  brightness(0.55)',
+  10: 'blur(3px)  brightness(0.55)',
+  11: 'blur(3px)  brightness(0.55)',
+};
+const DEFAULT_BLUR = 'blur(1px) brightness(0.75)';
+
+// ── NPC avatars ───────────────────────────────────────────────────────────────
+
+const NPC = {
+  val:    { name: 'Val Okoro',   role: 'Finance Director',    avatar: '📊' },
+  kev:    { name: 'Kev Mulligan',role: 'Head of Football',    avatar: '⚽' },
+  marcus: { name: 'Marcus Webb', role: 'Commercial Director', avatar: '📣' },
+  dani:   { name: 'Dani Lopes',  role: 'Head of Operations',  avatar: '🔧' },
+};
+
+// ── Sponsor deal constants ────────────────────────────────────────────────────
+
+const OPTION_A_AMOUNT = toPence(2000);   // £2,000 flat fee
+const OPTION_B_AMOUNT = toPence(2700);   // £2,700 per-attendance (pre-calculated)
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function IntroScreen({ state, events, dispatch, onComplete }: Props) {
+  const [step, setStep] = useState(0);
+  const [mathsCorrect, setMathsCorrect] = useState<boolean | null>(null);
+  const [choice, setChoice] = useState<'A' | 'B' | null>(null);
+  const [showFinancialBar, setShowFinancialBar] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const clubName = state.club.name;
+  const runwayWeeks = Math.floor(
+    state.club.transferBudget /
+    Math.max(1,
+      state.club.squad.reduce((s, p) => s + p.wage, 0) +
+      state.club.staff.reduce((s, p) => s + p.salary, 0) +
+      (state.club.manager?.wage ?? 0)
+    )
+  );
+
+  // Auto-scroll messages into view
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [step]);
+
+  // Animate Financial Health Bar in on step 2
+  useEffect(() => {
+    if (step === 2) {
+      const t = setTimeout(() => setShowFinancialBar(true), 400);
+      return () => clearTimeout(t);
+    }
+  }, [step]);
+
+  function advance() {
+    setStep(s => s + 1);
+  }
+
+  function handleMathsResult(correct: boolean) {
+    setMathsCorrect(correct);
+    setStep(15); // Val response
+  }
+
+  function handleChoice(picked: 'A' | 'B') {
+    setChoice(picked);
+    const amount = picked === 'A' ? OPTION_A_AMOUNT : OPTION_B_AMOUNT;
+    dispatch({
+      type: 'ACCEPT_INTRO_SPONSOR_DEAL',
+      clubId: state.club.id,
+      choice: picked,
+      amount,
+    });
+    setStep(17); // Marcus confirms
+  }
+
+  function handleComplete() {
+    markIntroCompleted();
+    onComplete();
+  }
+
+  const filter = BLUR_BY_STEP[step] ?? DEFAULT_BLUR;
+
+  return (
+    <div className="fixed inset-0 flex flex-col overflow-hidden bg-bg-deep">
+
+      {/* ── Blurred Command Centre backdrop ─────────────────────────────────── */}
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{ filter, transition: 'filter 1s ease-in-out' }}
+      >
+        {/* Financial Health Bar sits above the CC in the real layout */}
+        {showFinancialBar && <FinancialHealthBar state={state} />}
+        <div className="flex flex-col flex-1 h-full overflow-hidden">
+          <CommandCentre
+            state={state}
+            events={events}
+            dispatch={() => ({})}
+            isLoading={false}
+            onNavigateToStadium={() => {}}
+          />
+        </div>
+      </div>
+
+      {/* ── Dark gradient scrim ──────────────────────────────────────────────── */}
+      <div className="absolute inset-0 bg-gradient-to-t from-bg-deep via-bg-deep/70 to-transparent pointer-events-none" />
+
+      {/* ── Beat 1, Step 0: Arrival title ───────────────────────────────────── */}
+      {step === 0 && (
+        <div
+          className="absolute inset-0 flex flex-col items-center justify-center text-center px-8 cursor-pointer"
+          onClick={advance}
+        >
+          <div className="animate-fade-in space-y-3">
+            <p className="text-txt-muted text-sm uppercase tracking-widest">Day One</p>
+            <h1 className="text-3xl font-bold text-txt-primary leading-tight">
+              Welcome to<br />{clubName}.
+            </h1>
+            <p className="text-lg text-txt-muted">You are the new owner.</p>
+          </div>
+          <p className="absolute bottom-10 text-xs text-txt-muted/50 animate-pulse">
+            Tap to continue
+          </p>
+        </div>
+      )}
+
+      {/* ── Steps 1+: Chat interface ─────────────────────────────────────────── */}
+      {step >= 1 && (
+        <div className="absolute inset-0 flex flex-col">
+          {/* Scrollable message log */}
+          <div className="flex-1 overflow-y-auto px-4 pt-8 pb-4 flex flex-col justify-end">
+            <div className="space-y-4 max-w-lg mx-auto w-full">
+
+              {/* Beat 1 — Val introduces herself */}
+              {step >= 1 && (
+                <NpcMessage {...NPC.val} delay={step === 1}>
+                  Morning. I'm Val — I handle the money. I should warn you: the previous owner didn't leave us in great shape. Let me show you where we stand.
+                </NpcMessage>
+              )}
+
+              {/* Beat 1 — Financial bar explanation */}
+              {step >= 2 && (
+                <NpcMessage {...NPC.val} delay={step === 2}>
+                  This is your financial overview. The number on the left is how much cash we have. The number on the right is how many weeks it'll last at our current spending rate. Right now we've got roughly <strong>{runwayWeeks} weeks</strong> of runway. That sounds like a lot, but it goes fast when you're paying wages, maintaining facilities, and trying to win football matches.
+                </NpcMessage>
+              )}
+
+              {/* Beat 1 — Rule one */}
+              {step >= 3 && (
+                <NpcMessage {...NPC.val} delay={step === 3}>
+                  Rule number one of this job: <strong>keep this bar green.</strong> If it turns amber, be careful. If it turns red... well, let's not find out.
+                </NpcMessage>
+              )}
+
+              {/* Beat 2 — Kev */}
+              {step >= 4 && (
+                <NpcMessage {...NPC.kev} delay={step === 4}>
+                  Alright boss. I'm Kev — I look after the football side. The squad I've got is... well, it's what it is. We'll need to be smart in the market. I'll handle tactics and training — you just make sure I've got something to work with.
+                </NpcMessage>
+              )}
+
+              {/* Beat 2 — Marcus */}
+              {step >= 5 && (
+                <NpcMessage {...NPC.marcus} delay={step === 5}>
+                  Hey! Marcus here. Commercial and fan engagement. I've got some ideas to get revenue moving but we'll need to invest a bit to make money. I'll bring you opportunities — you decide what's worth backing.
+                </NpcMessage>
+              )}
+
+              {/* Beat 2 — Dani */}
+              {step >= 6 && (
+                <NpcMessage {...NPC.dani} delay={step === 6}>
+                  Dani. I run the day-to-day — facilities, suppliers, logistics. The stadium needs work. I'll keep you posted on what's urgent and what can wait. Just so you know: everything takes longer and costs more than Marcus thinks it will.
+                </NpcMessage>
+              )}
+
+              {/* Beat 3 — Stadium prompt */}
+              {step >= 7 && (
+                <NpcMessage {...NPC.dani} delay={step === 7}>
+                  See those buildings behind me? Each one does something for the club — generates revenue, improves the squad, keeps the fans happy. Upgrading them costs money, but it's how you build something that sustains itself.
+                </NpcMessage>
+              )}
+
+              {/* Beat 3 — Stadium follow-up */}
+              {step >= 8 && (
+                <NpcMessage {...NPC.dani} delay={step === 8}>
+                  No rush on any of that today. Let's focus on getting through pre-season first.
+                </NpcMessage>
+              )}
+
+              {/* Beat 4 — Kev squad reality check */}
+              {step >= 9 && (
+                <NpcMessage {...NPC.kev} delay={step === 9}>
+                  Right, let me give you the honest picture. We've got {state.club.squad.length} players on the books. Most of them are... okay. League Two level, just about. We've got capacity for 24, so there's room to bring people in. But every signing costs wages, and Val's going to have something to say about that.
+                </NpcMessage>
+              )}
+
+              {/* Beat 4 — Val interjects */}
+              {step >= 10 && (
+                <NpcMessage {...NPC.val} delay={step === 10}>
+                  I always do.
+                </NpcMessage>
+              )}
+
+              {/* Beat 4 — Kev on transfers */}
+              {step >= 11 && (
+                <NpcMessage {...NPC.kev} delay={step === 11}>
+                  The transfer window's open for the first few weeks of the season. We've also got a free agent pool — players without a club. Some bargains, some traps. I'll flag who I think is worth looking at, but the budget calls are yours.
+                </NpcMessage>
+              )}
+
+              {/* Beat 5 — Marcus presents the deal */}
+              {step >= 12 && (
+                <NpcMessage {...NPC.marcus} delay={step === 12}>
+                  Boss, before the season starts, I've got something that needs a decision. A local company has offered to sponsor our pre-season friendlies — three warm-up matches, their branding on the programme and pitch-side boards. They're offering two options:
+                  <ul className="mt-2 space-y-1 text-xs text-txt-muted">
+                    <li><strong className="text-txt-primary">Option A:</strong> Flat fee — {formatMoney(OPTION_A_AMOUNT)} for all three matches. Simple, guaranteed money.</li>
+                    <li><strong className="text-txt-primary">Option B:</strong> Per-attendance deal — £0.60 per fan per match. More money if attendance is good, less if it isn't.</li>
+                  </ul>
+                </NpcMessage>
+              )}
+
+              {/* Beat 5 — Val gives context */}
+              {step >= 13 && (
+                <NpcMessage {...NPC.val} delay={step === 13}>
+                  Our pre-season friendlies typically attract between 1,200 and 1,800 fans. Last year averaged about 1,500 across the three games.
+                </NpcMessage>
+              )}
+
+              {/* Beat 5 — Maths challenge */}
+              {step >= 14 && mathsCorrect === null && (
+                <div className="animate-fade-in">
+                  <MathsChallenge onResult={handleMathsResult} />
+                </div>
+              )}
+
+              {/* Beat 5 — Val responds to maths */}
+              {step >= 15 && mathsCorrect !== null && (
+                <NpcMessage {...NPC.val} delay={step === 15}>
+                  {mathsCorrect
+                    ? `That's right — £2,700 versus the flat £2,000. Option B looks better on paper, but attendance isn't guaranteed. Your call.`
+                    : `I make it £2,700 — 1,500 fans, times 3 matches, times 60p each. So Option B is worth more if attendance holds up. But it's a gamble.`}
+                </NpcMessage>
+              )}
+
+              {/* Beat 5 — Choice buttons */}
+              {step >= 16 && choice === null && (
+                <div className="animate-fade-in space-y-2">
+                  <p className="text-xs text-txt-muted px-1">Which deal do you want?</p>
+                  <div className="grid grid-cols-2 gap-3">
+                    <button
+                      onClick={() => handleChoice('A')}
+                      className="bg-bg-surface hover:bg-bg-raised border border-bg-raised hover:border-data-blue/40
+                                 rounded-card px-4 py-3 text-left transition-all duration-150 group"
+                    >
+                      <div className="text-sm font-semibold text-txt-primary">Option A</div>
+                      <div className="text-xs text-txt-muted mt-0.5">
+                        {formatMoney(OPTION_A_AMOUNT)} guaranteed
+                      </div>
+                    </button>
+                    <button
+                      onClick={() => handleChoice('B')}
+                      className="bg-bg-surface hover:bg-bg-raised border border-bg-raised hover:border-data-blue/40
+                                 rounded-card px-4 py-3 text-left transition-all duration-150 group"
+                    >
+                      <div className="text-sm font-semibold text-txt-primary">Option B</div>
+                      <div className="text-xs text-txt-muted mt-0.5">
+                        £0.60/fan · est. {formatMoney(OPTION_B_AMOUNT)}
+                      </div>
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {/* Beat 5 — Marcus confirms */}
+              {step >= 17 && choice !== null && (
+                <NpcMessage {...NPC.marcus} delay={step === 17}>
+                  Done. I'll let them know. {choice === 'B' ? "Fingers crossed on the attendance." : "Nice and clean."}
+                </NpcMessage>
+              )}
+
+              {step >= 18 && choice !== null && (
+                <NpcMessage {...NPC.val} delay={step === 18}>
+                  First decision made. Let's see how it plays out. Now — let's get the squad ready for the season.
+                </NpcMessage>
+              )}
+
+              <div ref={messagesEndRef} />
+            </div>
+          </div>
+
+          {/* ── Action bar ────────────────────────────────────────────────────── */}
+          <div className="shrink-0 px-4 pb-6 pt-2 max-w-lg mx-auto w-full">
+            {/* Steps that need explicit "continue" (not handled by inline interaction) */}
+            {shouldShowContinue(step, mathsCorrect, choice) && (
+              <button
+                onClick={step >= 18 ? handleComplete : advance}
+                className="w-full bg-data-blue hover:bg-data-blue/90 active:scale-[0.99]
+                           text-white font-semibold text-sm rounded-card py-3 px-6
+                           transition-all duration-150 animate-fade-in"
+              >
+                {step >= 18 ? "Let's go →" : 'Continue →'}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function shouldShowContinue(
+  step: number,
+  mathsCorrect: boolean | null,
+  choice: 'A' | 'B' | null,
+): boolean {
+  if (step === 0) return false;           // handled by full-screen click
+  if (step === 14) return false;          // maths challenge handles its own flow
+  if (step === 15 && mathsCorrect === null) return false; // waiting for maths
+  if (step === 16 && choice === null) return false;       // waiting for choice
+  if (step === 17 && choice === null) return false;       // waiting for choice
+  return true;
+}

--- a/packages/frontend/src/components/intro/MathsChallenge.tsx
+++ b/packages/frontend/src/components/intro/MathsChallenge.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+
+interface Props {
+  onResult: (correct: boolean) => void;
+}
+
+const CORRECT_ANSWER = 2700; // £2,700 in pounds
+const QUESTION = 'If average attendance is 1,500 per match across 3 friendlies, what is the total income from Option B at £0.60 per fan per match?';
+const HINT = 'Think about it: 1,500 fans × 3 matches × £0.60 each. Work it out step by step.';
+
+function isClose(value: number): boolean {
+  return Math.abs(value - CORRECT_ANSWER) <= 100;
+}
+
+export function MathsChallenge({ onResult }: Props) {
+  const [input, setInput] = useState('');
+  const [attempt, setAttempt] = useState(0); // 0 = fresh, 1 = first wrong, 2 = revealed
+  const [feedback, setFeedback] = useState<'correct' | 'wrong' | 'revealed' | null>(null);
+
+  function handleSubmit() {
+    const raw = input.replace(/[£,\s]/g, '');
+    const value = parseFloat(raw);
+    if (isNaN(value)) return;
+
+    if (Math.abs(value - CORRECT_ANSWER) < 1) {
+      setFeedback('correct');
+      setTimeout(() => onResult(true), 1200);
+    } else if (attempt === 0) {
+      setFeedback('wrong');
+      setAttempt(1);
+      setInput('');
+    } else {
+      setFeedback('revealed');
+      setTimeout(() => onResult(false), 2000);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter') handleSubmit();
+  }
+
+  return (
+    <div className="bg-bg-surface border border-bg-raised rounded-card p-4 space-y-3">
+      <p className="text-sm text-txt-primary leading-relaxed">{QUESTION}</p>
+
+      {feedback === 'correct' && (
+        <div className="text-sm text-pitch-green font-semibold animate-fade-in">
+          Correct — £2,700. Option B is better on paper, but attendance isn't guaranteed.
+        </div>
+      )}
+
+      {feedback === 'wrong' && (
+        <div className="text-sm text-warn-amber animate-fade-in">
+          Not quite. {HINT}
+        </div>
+      )}
+
+      {feedback === 'revealed' && (
+        <div className="text-sm text-txt-muted animate-fade-in">
+          The answer is <span className="text-txt-primary font-semibold">£2,700</span> — 1,500 × 3 × £0.60. So Option B is worth more if attendance holds up.
+        </div>
+      )}
+
+      {feedback !== 'correct' && feedback !== 'revealed' && (
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-txt-muted text-sm">£</span>
+            <input
+              type="number"
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="0"
+              className="w-full bg-bg-raised border border-bg-raised focus:border-data-blue outline-none
+                         rounded-card pl-7 pr-3 py-2 text-sm text-txt-primary tabular-nums
+                         transition-colors duration-150"
+            />
+          </div>
+          <button
+            onClick={handleSubmit}
+            disabled={!input.trim()}
+            className="px-4 py-2 rounded-card text-sm font-semibold bg-data-blue text-white
+                       disabled:opacity-40 disabled:cursor-not-allowed
+                       hover:bg-data-blue/90 transition-colors duration-150"
+          >
+            {attempt === 1 ? 'Try again' : 'Submit'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/intro/NpcMessage.tsx
+++ b/packages/frontend/src/components/intro/NpcMessage.tsx
@@ -1,0 +1,26 @@
+interface Props {
+  name: string;
+  role: string;
+  avatar: string;
+  children: React.ReactNode;
+  delay?: boolean;
+}
+
+export function NpcMessage({ name, role, avatar, children, delay = false }: Props) {
+  return (
+    <div className={`flex gap-3 ${delay ? 'animate-fade-in' : ''}`}>
+      <div className="w-8 h-8 rounded-full bg-bg-raised flex items-center justify-center text-base shrink-0 mt-0.5">
+        {avatar}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-baseline gap-2 mb-1">
+          <span className="text-xs font-semibold text-txt-primary">{name}</span>
+          <span className="text-xs2 text-txt-muted">{role}</span>
+        </div>
+        <div className="bg-bg-raised rounded-bubble rounded-tl-tag px-3 py-2 text-sm text-txt-primary leading-relaxed">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/menu/MenuScreen.tsx
+++ b/packages/frontend/src/components/menu/MenuScreen.tsx
@@ -1,11 +1,14 @@
-import { GameState, formatMoney } from '@calculating-glory/domain';
+import { useState } from 'react';
+import { GameState, formatMoney, CurriculumLevel, CURRICULUM_LEVELS } from '@calculating-glory/domain';
 
 interface Props {
   state: GameState;
   hasSave: boolean;
   onContinue: () => void;
-  onNewGame: () => void;
+  onNewGame: (level: CurriculumLevel) => void;
 }
+
+type MenuStep = 'main' | 'yearGroup';
 
 function phaseLabel(phase: GameState['phase']): string {
   switch (phase) {
@@ -18,7 +21,61 @@ function phaseLabel(phase: GameState['phase']): string {
   }
 }
 
+const LEVEL_ORDER: CurriculumLevel[] = ['YEAR_7', 'YEAR_8'];
+
 export function MenuScreen({ state, hasSave, onContinue, onNewGame }: Props) {
+  const [menuStep, setMenuStep] = useState<MenuStep>('main');
+  const [selected, setSelected] = useState<CurriculumLevel>('YEAR_7');
+
+  if (menuStep === 'yearGroup') {
+    return (
+      <div className="min-h-screen bg-bg-deep flex flex-col items-center justify-center px-6">
+        <div className="w-full max-w-xs">
+          <button
+            onClick={() => setMenuStep('main')}
+            className="text-xs text-txt-muted hover:text-txt-primary mb-6 flex items-center gap-1 transition-colors duration-150"
+          >
+            ← Back
+          </button>
+
+          <h2 className="text-xl font-bold text-txt-primary mb-1">Choose your year group</h2>
+          <p className="text-sm text-txt-muted mb-6 leading-relaxed">
+            This sets your maths difficulty and starting budget. You can always start again.
+          </p>
+
+          <div className="flex flex-col gap-2 mb-6">
+            {LEVEL_ORDER.map(level => {
+              const config = CURRICULUM_LEVELS[level];
+              const isSelected = selected === level;
+              return (
+                <button
+                  key={level}
+                  onClick={() => setSelected(level)}
+                  className={`px-4 py-3 rounded-card border text-left transition-all duration-150
+                    ${isSelected
+                      ? 'border-data-blue bg-data-blue/10 text-txt-primary'
+                      : 'border-bg-raised bg-bg-surface text-txt-muted hover:border-data-blue/40 hover:text-txt-primary'
+                    }`}
+                >
+                  <div className="font-semibold text-sm">{config.displayName}</div>
+                  <div className="text-xs mt-0.5 opacity-70">{config.displayName} maths level</div>
+                </button>
+              );
+            })}
+          </div>
+
+          <button
+            onClick={() => onNewGame(selected)}
+            className="w-full bg-data-blue hover:bg-data-blue/90 active:scale-[0.99] text-white
+                       font-semibold text-sm rounded-card py-3 transition-all duration-150"
+          >
+            Start game →
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen bg-bg-deep flex flex-col items-center justify-center px-6">
 
@@ -38,7 +95,6 @@ export function MenuScreen({ state, hasSave, onContinue, onNewGame }: Props) {
       {/* Action buttons */}
       <div className="flex flex-col gap-3 w-full max-w-xs">
 
-        {/* Continue — only shown when save exists */}
         {hasSave && (
           <button
             onClick={onContinue}
@@ -65,9 +121,8 @@ export function MenuScreen({ state, hasSave, onContinue, onNewGame }: Props) {
           </button>
         )}
 
-        {/* New Game */}
         <button
-          onClick={onNewGame}
+          onClick={() => setMenuStep('yearGroup')}
           className={`w-full rounded-card px-6 py-4 text-left transition-all duration-150 group
             ${hasSave
               ? 'bg-bg-surface hover:bg-bg-raised border border-bg-raised text-txt-primary'
@@ -87,7 +142,6 @@ export function MenuScreen({ state, hasSave, onContinue, onNewGame }: Props) {
 
       </div>
 
-      {/* Footer */}
       <div className="mt-16 text-txt-muted text-xs text-center opacity-40">
         Calculating Glory
       </div>

--- a/packages/frontend/src/lib/introState.ts
+++ b/packages/frontend/src/lib/introState.ts
@@ -1,0 +1,25 @@
+const INTRO_KEY = 'cg-intro-v1-completed';
+
+export function isIntroCompleted(): boolean {
+  try {
+    return localStorage.getItem(INTRO_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function markIntroCompleted(): void {
+  try {
+    localStorage.setItem(INTRO_KEY, 'true');
+  } catch {
+    // unavailable — carry on
+  }
+}
+
+export function clearIntroCompleted(): void {
+  try {
+    localStorage.removeItem(INTRO_KEY);
+  } catch {
+    // unavailable — carry on
+  }
+}


### PR DESCRIPTION
## Summary

- 18-step NPC narrative intro that plays once on every new game, using the real Command Centre as a blurred/progressively-revealed backdrop (blur reduces and brightness lifts beat-by-beat as the world \"comes alive\")
- Five beats: Arrival → Meet the team → Stadium tour → Squad reality check → First decision (sponsor deal)
- Beat 5 includes a maths challenge (1,500 × 3 × £0.60 = £2,700) — one retry with hint, then answer revealed; player then picks Option A (£2,000 flat) or Option B (£2,700 per-attendance), credited immediately via `BUDGET_UPDATED`
- Menu screen is now two-step: main screen → year group picker (Year 7 / Year 8) before starting a game
- Intro skipped on Continue; `localStorage` flag (`cg-intro-v1-completed`) gates replays

## New files
- `packages/frontend/src/components/intro/IntroScreen.tsx` — orchestrator
- `packages/frontend/src/components/intro/NpcMessage.tsx` — NPC chat bubble
- `packages/frontend/src/components/intro/MathsChallenge.tsx` — Beat 5 maths card
- `packages/frontend/src/lib/introState.ts` — localStorage helpers

## Domain changes
- New command `ACCEPT_INTRO_SPONSOR_DEAL` → emits `BUDGET_UPDATED`

## Test plan
- [ ] Fresh load (no save): Menu shows only "New Game"
- [ ] New Game → year group picker appears; selecting Year 7 starts intro
- [ ] Intro Beat 1: blurred CC backdrop, click anywhere to advance
- [ ] Beats 2–4: NPC messages appear one-by-one with Continue button
- [ ] Beat 5: maths challenge; wrong answer shows hint; correct advances to choice
- [ ] Pick Option A → £2,000 added to budget; Pick Option B → £2,700 added
- [ ] "Let's go →" lands on game screen (Command Centre, no intro)
- [ ] Subsequent new games re-run the intro; Continue skips it

🤖 Generated with [Claude Code](https://claude.com/claude-code)