### PR TITLE
feat: adaptive curriculum advancement nudge

### DIFF
--- a/packages/domain/src/commands/handlers.ts
+++ b/packages/domain/src/commands/handlers.ts
@@ -17,7 +17,8 @@ import { Player, computeOverallRating } from '../types/player';
 import { shouldRetire, getRetirementFlavour } from '../simulation/progression';
 import { getScoutLevel, isTransferWindowOpen, constructionDuration } from '../types/facility';
 import { generateScoutTarget, getScoutFee } from '../data/scout-target-generator';
-import { ScoutTargetFoundEvent, ScoutTransferCompletedEvent, TakeoverAcceptedEvent } from '../events/types';
+import { ScoutTargetFoundEvent, ScoutTransferCompletedEvent, TakeoverAcceptedEvent, CurriculumUpgradedEvent } from '../events/types';
+import { CURRICULUM_LEVEL_ORDER, CURRICULUM_LEVELS } from '../curriculum/curriculum-config';
 
 /**
  * Handle a game command
@@ -72,6 +73,8 @@ export function handleCommand(command: GameCommand, state: GameState): CommandRe
           reason: `intro-sponsor-deal-option-${command.choice.toLowerCase()}`,
         }],
       };
+    case 'UPGRADE_CURRICULUM':
+      return handleUpgradeCurriculum(command, state);
     default:
       return {
         error: {
@@ -1116,6 +1119,43 @@ function handleAcceptTakeover(_command: any, state: GameState): CommandResult {
     takeoverClubName: state.forcedOut.takeoverClubName,
     seed:             seedStr,
     week:             state.forcedOut.week,
+  };
+
+  return { events: [event] };
+}
+
+function handleUpgradeCurriculum(command: any, state: GameState): CommandResult {
+  const toLevel = command.toLevel as string;
+
+  // Validate toLevel is a known curriculum level
+  if (!CURRICULUM_LEVELS[toLevel as keyof typeof CURRICULUM_LEVELS]) {
+    return {
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: `Unknown curriculum level: ${toLevel}`,
+      },
+    };
+  }
+
+  // Validate it's actually an advancement (not a downgrade)
+  const currentLevel = state.curriculum?.level ?? 'YEAR_7';
+  const currentIdx = CURRICULUM_LEVEL_ORDER.indexOf(currentLevel);
+  const targetIdx  = CURRICULUM_LEVEL_ORDER.indexOf(toLevel as any);
+
+  if (targetIdx <= currentIdx) {
+    return {
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: 'Can only upgrade to a higher curriculum level',
+      },
+    };
+  }
+
+  const event: CurriculumUpgradedEvent = {
+    type:      'CURRICULUM_UPGRADED',
+    timestamp: Date.now(),
+    fromLevel: currentLevel,
+    toLevel,
   };
 
   return { events: [event] };

--- a/packages/domain/src/commands/types.ts
+++ b/packages/domain/src/commands/types.ts
@@ -31,7 +31,8 @@ export type GameCommand =
   | PlaceScoutBidCommand
   | CancelScoutMissionCommand
   | AcceptTakeoverCommand
-  | AcceptIntroSponsorDealCommand;
+  | AcceptIntroSponsorDealCommand
+  | UpgradeCurriculumCommand;
 
 export interface MakeTransferCommand {
   type: 'MAKE_TRANSFER';
@@ -158,6 +159,11 @@ export interface AcceptIntroSponsorDealCommand {
   choice: 'A' | 'B';
   /** Amount to credit in pence */
   amount: number;
+}
+
+export interface UpgradeCurriculumCommand {
+  type: 'UPGRADE_CURRICULUM';
+  toLevel: string;
 }
 
 export interface CommandResult {

--- a/packages/domain/src/curriculum/mastery.ts
+++ b/packages/domain/src/curriculum/mastery.ts
@@ -1,0 +1,51 @@
+/**
+ * Mastery detection for curriculum advancement.
+ *
+ * Checks whether a student has demonstrated sufficient mastery at their
+ * current curriculum level to be nudged toward stepping up.
+ *
+ * Criteria (last 20 MATH_ATTEMPT_RECORDED events):
+ *   - At least 20 attempts recorded
+ *   - ≥ 85% correct
+ *   - Not already at GCSE_HIGHER (no further level to advance to)
+ */
+
+import { GameEvent, MathAttemptRecordedEvent } from '../events/types';
+import { CurriculumLevel, CURRICULUM_LEVEL_ORDER, CURRICULUM_LEVELS } from './curriculum-config';
+
+const MASTERY_MIN_ATTEMPTS = 20;
+const MASTERY_ACCURACY_THRESHOLD = 0.85;
+
+/**
+ * Returns the next curriculum level if the student has demonstrated mastery,
+ * or null if they haven't hit the threshold or are already at the top level.
+ */
+export function checkMastery(
+  events: GameEvent[],
+  currentLevel: CurriculumLevel,
+): CurriculumLevel | null {
+  // No level above GCSE_HIGHER
+  const currentIdx = CURRICULUM_LEVEL_ORDER.indexOf(currentLevel);
+  if (currentIdx === -1 || currentIdx === CURRICULUM_LEVEL_ORDER.length - 1) {
+    return null;
+  }
+
+  // Collect last N math attempts
+  const mathAttempts = events
+    .filter((e): e is MathAttemptRecordedEvent => e.type === 'MATH_ATTEMPT_RECORDED')
+    .slice(-MASTERY_MIN_ATTEMPTS);
+
+  if (mathAttempts.length < MASTERY_MIN_ATTEMPTS) return null;
+
+  const correct = mathAttempts.filter(e => e.correct).length;
+  if (correct / mathAttempts.length < MASTERY_ACCURACY_THRESHOLD) return null;
+
+  return CURRICULUM_LEVEL_ORDER[currentIdx + 1];
+}
+
+/**
+ * Human-readable display name for a curriculum level.
+ */
+export function curriculumDisplayName(level: CurriculumLevel): string {
+  return CURRICULUM_LEVELS[level].displayName;
+}

--- a/packages/domain/src/events/types.ts
+++ b/packages/domain/src/events/types.ts
@@ -44,7 +44,8 @@ export type GameEvent =
   | ScoutMissionCancelledEvent
   | OwnerForcedOutEvent
   | TakeoverAcceptedEvent
-  | ParachuteOfferedEvent;
+  | ParachuteOfferedEvent
+  | CurriculumUpgradedEvent;
 
 export interface TransferCompletedEvent {
   type: 'TRANSFER_COMPLETED';
@@ -373,6 +374,14 @@ export interface ParachuteOfferedEvent {
   takeoverBudget:   number;
   reputationMalus:  number;
   week: number;
+}
+
+/** Emitted when the player voluntarily upgrades their curriculum level */
+export interface CurriculumUpgradedEvent {
+  type: 'CURRICULUM_UPGRADED';
+  timestamp: number;
+  fromLevel: string;
+  toLevel: string;
 }
 
 /** Emitted when the player clicks "Accept" on the takeover offer screen */

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -10,6 +10,7 @@
 // Curriculum system
 export * from './curriculum/curriculum-config';
 export * from './curriculum/curriculum-progression';
+export * from './curriculum/mastery';
 
 // Question bank schema
 export * from './content/questions';

--- a/packages/domain/src/reducers/index.ts
+++ b/packages/domain/src/reducers/index.ts
@@ -4,7 +4,7 @@
  * Pure functions that apply events to state.
  */
 
-import { GameEvent, GameStartedEvent, MatchSimulatedEvent, TransferCompletedEvent, StaffHiredEvent, MathAttemptRecordedEvent, ClubEventOccurredEvent, ClubEventResolvedEvent, SeasonStartedEvent, TrainingFocusSetEvent, FormationSetEvent, FreeAgentSignedEvent, PlayerReleasedEvent, NpcPlayerSignedEvent, ManagerHiredEvent, ManagerSackedEvent, PreSeasonStartedEvent, ScoutMissionStartedEvent, ScoutTargetFoundEvent, ScoutBidPlacedEvent, ScoutTransferCompletedEvent, OwnerForcedOutEvent, TakeoverAcceptedEvent, ParachuteOfferedEvent } from '../events/types';
+import { GameEvent, GameStartedEvent, MatchSimulatedEvent, TransferCompletedEvent, StaffHiredEvent, MathAttemptRecordedEvent, ClubEventOccurredEvent, ClubEventResolvedEvent, SeasonStartedEvent, TrainingFocusSetEvent, FormationSetEvent, FreeAgentSignedEvent, PlayerReleasedEvent, NpcPlayerSignedEvent, ManagerHiredEvent, ManagerSackedEvent, PreSeasonStartedEvent, ScoutMissionStartedEvent, ScoutTargetFoundEvent, ScoutBidPlacedEvent, ScoutTransferCompletedEvent, OwnerForcedOutEvent, TakeoverAcceptedEvent, ParachuteOfferedEvent, CurriculumUpgradedEvent } from '../events/types';
 import { GameState, Division } from '../types/game-state-updated';
 import { Club } from '../types/club';
 import { LeagueTable, LeagueTableEntry, sortLeagueTable } from '../types/league';
@@ -93,6 +93,8 @@ export function reduceEvent(state: GameState, event: GameEvent): GameState {
       return handleParachuteOffered(state, event);
     case 'TAKEOVER_ACCEPTED':
       return handleTakeoverAccepted(state, event);
+    case 'CURRICULUM_UPGRADED':
+      return handleCurriculumUpgraded(state, event);
     default:
       return state;
   }
@@ -1026,5 +1028,16 @@ function createEmptyLeague(): LeagueTable {
     automaticPromotion: 3,
     playoffPositions: [4, 5, 6, 7],
     relegation: [23, 24]
+  };
+}
+
+function handleCurriculumUpgraded(state: GameState, event: CurriculumUpgradedEvent): GameState {
+  const toLevel = event.toLevel as keyof typeof CURRICULUM_LEVELS;
+  const newCurriculum = CURRICULUM_LEVELS[toLevel];
+  if (!newCurriculum) return state;
+
+  return {
+    ...state,
+    curriculum: newCurriculum,
   };
 }

--- a/packages/frontend/src/components/command-centre/CommandCentre.tsx
+++ b/packages/frontend/src/components/command-centre/CommandCentre.tsx
@@ -206,6 +206,7 @@ export function CommandCentre({ state, events, dispatch, isLoading, onNavigateTo
         {socialOpen && (
           <SocialFeed
             state={state}
+            events={events}
             dispatch={dispatch}
             linkedEvent={socialLinkedEvent}
           />

--- a/packages/frontend/src/components/social-feed/SocialFeed.tsx
+++ b/packages/frontend/src/components/social-feed/SocialFeed.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { GameState, GameCommand, PendingClubEvent } from '@calculating-glory/domain';
+import { GameState, GameCommand, GameEvent, PendingClubEvent, CurriculumLevel, checkMastery, curriculumDisplayName, CURRICULUM_LEVELS } from '@calculating-glory/domain';
 import { ChatBubble } from './ChatBubble';
 import { NegotiationKeyboard } from './NegotiationKeyboard';
 import { MathChallengeCard } from './MathChallengeCard';
@@ -94,11 +94,12 @@ function getPerformance(state: GameState): TopicPerformance {
 
 interface SocialFeedProps {
   state: GameState;
+  events: GameEvent[];
   dispatch: (cmd: GameCommand) => { error?: string };
   linkedEvent?: PendingClubEvent | null;
 }
 
-export function SocialFeed({ state, dispatch, linkedEvent }: SocialFeedProps) {
+export function SocialFeed({ state, events, dispatch, linkedEvent }: SocialFeedProps) {
   const [view, setView]                             = useState<SocialView>(linkedEvent ? 'thread' : 'inbox');
   const [messages, setMessages]                     = useState<Message[]>([]);
   const [currentChallenge, setCurrentChallenge]     = useState<MathChallenge | null>(null);
@@ -111,6 +112,7 @@ export function SocialFeed({ state, dispatch, linkedEvent }: SocialFeedProps) {
   const [activeLinkedEvent, setActiveLinkedEvent]   = useState<LinkedEvent | null>(null);
   const [practiceTopicOverride, setPracticeTopic]   = useState<ChallengeTopic | null>(null);
   const [wasNegotiation, setWasNegotiation]         = useState(false);
+  const [masteryNudge, setMasteryNudge]             = useState<CurriculumLevel | null>(null);
   const bottomRef   = useRef<HTMLDivElement>(null);
   const seededRef   = useRef(false);
 
@@ -220,6 +222,23 @@ export function SocialFeed({ state, dispatch, linkedEvent }: SocialFeedProps) {
       startTime:      now - 5000,
       endTime:        now,
     });
+
+    // Check mastery after every answer (append synthetic event to get up-to-date picture)
+    if (!masteryNudge) {
+      const syntheticAttempt = {
+        type: 'MATH_ATTEMPT_RECORDED' as const,
+        timestamp: now,
+        studentId: state.club.id,
+        topic: currentChallenge.topic,
+        difficulty: currentChallenge.difficulty,
+        correct,
+        timeSpent: 5000,
+      };
+      const updatedEvents = [...events, syntheticAttempt];
+      const currentLevel = state.curriculum?.level ?? 'YEAR_7';
+      const nudgeLevel = checkMastery(updatedEvents, currentLevel);
+      if (nudgeLevel) setMasteryNudge(nudgeLevel);
+    }
 
     if (correct) {
       setAwaitingAnswer(false);
@@ -493,6 +512,42 @@ export function SocialFeed({ state, dispatch, linkedEvent }: SocialFeedProps) {
           </div>
         ) : solved ? (
           <div className="p-3 flex flex-col gap-2">
+            {/* Mastery nudge — shown when student has hit the advancement threshold */}
+            {masteryNudge && (
+              <div className="rounded-card border border-accent-gold/40 bg-accent-gold/10 p-3 flex flex-col gap-2">
+                <p className="text-xs font-semibold text-accent-gold">
+                  Val Webb · Level Up?
+                </p>
+                <p className="text-xs2 text-txt-primary">
+                  You've been nailing {curriculumDisplayName(state.curriculum?.level ?? 'YEAR_7')} maths
+                  consistently. Ready to step up to {curriculumDisplayName(masteryNudge)}?
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => {
+                      dispatch({ type: 'UPGRADE_CURRICULUM', toLevel: masteryNudge });
+                      setMasteryNudge(null);
+                      addMsg({
+                        kind: 'npc',
+                        text: `Brilliant — we've stepped things up to ${curriculumDisplayName(masteryNudge)}. The questions will be tougher now, but so will the rewards.`,
+                        sender: 'Val Webb',
+                      });
+                    }}
+                    className="flex-1 py-1.5 rounded-card bg-accent-gold text-white text-xs font-semibold
+                               hover:bg-accent-gold/80 active:scale-95 transition-all duration-150"
+                  >
+                    Step up to {CURRICULUM_LEVELS[masteryNudge].displayName}
+                  </button>
+                  <button
+                    onClick={() => setMasteryNudge(null)}
+                    className="px-3 py-1.5 rounded-card border border-bg-raised text-txt-muted text-xs
+                               hover:text-txt-primary transition-colors"
+                  >
+                    Not yet
+                  </button>
+                </div>
+              </div>
+            )}
             {!linkedEvent && !wasNegotiation && (
               <button
                 onClick={handleNextChallenge}


### PR DESCRIPTION
## Summary

- Students who hit ≥85% accuracy across their last 20 maths attempts see a **Val Webb nudge card** in the solved footer: *"You've been nailing Year 7 maths consistently. Ready to step up to Year 8?"*
- Upgrading dispatches a `UPGRADE_CURRICULUM` command → emits `CURRICULUM_UPGRADED` event → reducer updates `state.curriculum` — **no save reset, no loss of progress**
- The event is recorded in the log so the upgrade is part of the player's history
- Dismissing with "Not yet" clears the nudge; it'll reappear the next time mastery is detected

## What's in domain

| Addition | Purpose |
|----------|---------|
| `CurriculumUpgradedEvent` | Immutable record of when and from/to which level |
| `UPGRADE_CURRICULUM` command | Validated: must be genuine advancement, not downgrade |
| `checkMastery(events, level)` | Pure helper — last 20 attempts, ≥85% correct → next level |
| `curriculumDisplayName(level)` | UI helper — "Year 7", "GCSE Higher" etc |

## Test plan

- [ ] Answer 20 maths questions with ≥85% correct — Val Webb nudge card appears after the 20th correct answer
- [ ] Click "Step up to Year 8" — state.curriculum.level becomes YEAR_7 → YEAR_8, question bank now pulls up to D2 difficulty, no save reset
- [ ] Click "Not yet" — card dismisses, no upgrade dispatched
- [ ] Verify students already at GCSE_HIGHER never see the nudge
- [ ] Verify a student who upgrades mid-game keeps their squad/season progress intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)