### PR TITLE
feat: practice mode — Marcus Webb drill tile + all-topic picker

### DIFF
--- a/packages/frontend/src/components/command-centre/CommandCentre.tsx
+++ b/packages/frontend/src/components/command-centre/CommandCentre.tsx
@@ -26,6 +26,7 @@ export function CommandCentre({ state, events, dispatch, isLoading, onNavigateTo
   const [error, setError]                     = useState<string | null>(null);
   const [socialOpen, setSocialOpen]           = useState(false);
   const [socialLinkedEvent, setSocialLinked]  = useState<PendingClubEvent | null>(null);
+  const [practiceOpen, setPracticeOpen]       = useState(false);
   const [inboxOpen, setInboxOpen]             = useState(false);
   const [backroomOpen, setBackroomOpen]       = useState(false);
   const [learningOpen, setLearningOpen]       = useState(false);
@@ -116,8 +117,8 @@ export function CommandCentre({ state, events, dispatch, isLoading, onNavigateTo
           {/* RIGHT row 1: DataTiles */}
           <DataTiles state={state} gridMode onBackroomClick={() => setBackroomOpen(true)} onAcumenClick={() => setLearningOpen(true)} />
 
-          {/* RIGHT row 2: Stadium & Facilities + Chats + Transfers */}
-          <div className="grid grid-cols-3 gap-2">
+          {/* RIGHT row 2: 2×2 hub tile grid */}
+          <div className="grid grid-cols-2 gap-2">
             <HubTile
               icon="🏟"
               label="Stadium & Facilities"
@@ -131,14 +132,21 @@ export function CommandCentre({ state, events, dispatch, isLoading, onNavigateTo
             />
             <HubTile
               icon="💬"
-              label="Chats"
+              label="Negotiations"
               sub={
                 unresolvedEvents.some(e => e.choices.some(c => c.requiresMath))
-                  ? 'Negotiations waiting'
-                  : 'Practice sessions available'
+                  ? 'Deals waiting'
+                  : 'No active deals'
               }
               hasEvent={unresolvedEvents.some(e => e.choices.some(c => c.requiresMath))}
               onClick={() => { setSocialLinked(null); setSocialOpen(true); }}
+            />
+            <HubTile
+              icon="🎯"
+              label="Practice"
+              sub="Drill with Marcus Webb"
+              hasEvent={false}
+              onClick={() => setPracticeOpen(true)}
             />
             <HubTile
               icon="🔄"
@@ -209,6 +217,22 @@ export function CommandCentre({ state, events, dispatch, isLoading, onNavigateTo
             events={events}
             dispatch={dispatch}
             linkedEvent={socialLinkedEvent}
+          />
+        )}
+      </SlideOver>
+
+      {/* ── Practice slide-over ──────────────────────────────────────────── */}
+      <SlideOver
+        isOpen={practiceOpen}
+        onClose={() => setPracticeOpen(false)}
+        title="Practice — Marcus Webb"
+      >
+        {practiceOpen && (
+          <SocialFeed
+            state={state}
+            events={events}
+            dispatch={dispatch}
+            practiceMode
           />
         )}
       </SlideOver>

--- a/packages/frontend/src/components/social-feed/InboxView.tsx
+++ b/packages/frontend/src/components/social-feed/InboxView.tsx
@@ -66,57 +66,67 @@ function negotiationPreview(event: PendingClubEvent): string {
   return event.description.slice(0, 80) + (event.description.length > 80 ? '…' : '');
 }
 
+const ALL_TOPICS: ChallengeTopic[] = [
+  'percentage', 'decimals', 'ratios', 'algebra', 'statistics', 'geometry',
+];
+
 // ── Component ──────────────────────────────────────────────────────────────
 
 interface InboxViewProps {
   state: GameState;
   onSelectNegotiation: (event: PendingClubEvent) => void;
   onSelectPractice: (topic: ChallengeTopic) => void;
+  practiceOnly?: boolean;
 }
 
-export function InboxView({ state, onSelectNegotiation, onSelectPractice }: InboxViewProps) {
+export function InboxView({ state, onSelectNegotiation, onSelectPractice, practiceOnly }: InboxViewProps) {
   const mathEvents = state.pendingEvents.filter(
     e => !e.resolved && e.choices.some(c => c.requiresMath)
   );
 
-  const practiceTopics = weakestTopics(state.businessAcumen.recentPerformance);
+  const weakSet = new Set(weakestTopics(state.businessAcumen.recentPerformance));
+  const practiceTopics = practiceOnly ? ALL_TOPICS : [...weakSet];
 
   return (
     <div className="flex flex-col h-full overflow-y-auto px-3 py-4 gap-5">
 
-      {/* ── Active Negotiations ─────────────────────────────────────────── */}
-      <section>
-        <p className="text-xs font-semibold text-txt-muted uppercase tracking-wider mb-2 px-1">
-          Active Negotiations
-        </p>
-        {mathEvents.length === 0 ? (
-          <p className="text-xs2 text-txt-muted px-2 py-3 text-center italic">
-            No active negotiations — all clear for now.
+      {/* ── Active Negotiations (hidden in practiceOnly mode) ───────────── */}
+      {!practiceOnly && (
+        <section>
+          <p className="text-xs font-semibold text-txt-muted uppercase tracking-wider mb-2 px-1">
+            Active Negotiations
           </p>
-        ) : (
-          <div className="flex flex-col gap-2">
-            {mathEvents.map(evt => (
-              <ThreadCard
-                key={evt.id}
-                icon="💼"
-                title={evt.title}
-                sender="Agent Rodriguez"
-                preview={negotiationPreview(evt)}
-                isUrgent={evt.severity === 'major'}
-                onClick={() => onSelectNegotiation(evt)}
-              />
-            ))}
-          </div>
-        )}
-      </section>
+          {mathEvents.length === 0 ? (
+            <p className="text-xs2 text-txt-muted px-2 py-3 text-center italic">
+              No active negotiations — all clear for now.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {mathEvents.map(evt => (
+                <ThreadCard
+                  key={evt.id}
+                  icon="💼"
+                  title={evt.title}
+                  sender="Agent Rodriguez"
+                  preview={negotiationPreview(evt)}
+                  isUrgent={evt.severity === 'major'}
+                  onClick={() => onSelectNegotiation(evt)}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      )}
 
       {/* ── Practice Sessions ────────────────────────────────────────────── */}
       <section>
         <p className="text-xs font-semibold text-txt-muted uppercase tracking-wider mb-2 px-1">
-          Practice Sessions
+          {practiceOnly ? 'Choose a Topic' : 'Practice Sessions'}
         </p>
         <p className="text-xs2 text-txt-muted px-1 mb-2 leading-relaxed">
-          Marcus has flagged your weakest areas. Work through these to sharpen up before your next negotiation.
+          {practiceOnly
+            ? 'Pick any topic and Marcus will run you through a drill. No stakes — just reps.'
+            : 'Marcus has flagged your weakest areas. Work through these to sharpen up before your next negotiation.'}
         </p>
         <div className="flex flex-col gap-2">
           {practiceTopics.map(topic => (
@@ -126,6 +136,7 @@ export function InboxView({ state, onSelectNegotiation, onSelectPractice }: Inbo
               title={TOPIC_CONFIG[topic].label}
               sender="Marcus Webb, Club Analyst"
               preview={TOPIC_CONFIG[topic].preview}
+              badge={weakSet.has(topic) ? 'Recommended' : undefined}
               onClick={() => onSelectPractice(topic)}
             />
           ))}

--- a/packages/frontend/src/components/social-feed/SocialFeed.tsx
+++ b/packages/frontend/src/components/social-feed/SocialFeed.tsx
@@ -97,9 +97,10 @@ interface SocialFeedProps {
   events: GameEvent[];
   dispatch: (cmd: GameCommand) => { error?: string };
   linkedEvent?: PendingClubEvent | null;
+  practiceMode?: boolean;
 }
 
-export function SocialFeed({ state, events, dispatch, linkedEvent }: SocialFeedProps) {
+export function SocialFeed({ state, events, dispatch, linkedEvent, practiceMode }: SocialFeedProps) {
   const [view, setView]                             = useState<SocialView>(linkedEvent ? 'thread' : 'inbox');
   const [messages, setMessages]                     = useState<Message[]>([]);
   const [currentChallenge, setCurrentChallenge]     = useState<MathChallenge | null>(null);
@@ -396,6 +397,7 @@ export function SocialFeed({ state, events, dispatch, linkedEvent }: SocialFeedP
         state={state}
         onSelectNegotiation={handleSelectNegotiation}
         onSelectPractice={handleSelectPractice}
+        practiceOnly={practiceMode}
       />
     );
   }

--- a/packages/frontend/src/components/social-feed/ThreadCard.tsx
+++ b/packages/frontend/src/components/social-feed/ThreadCard.tsx
@@ -4,10 +4,11 @@ interface ThreadCardProps {
   sender: string;
   preview: string;
   isUrgent?: boolean;
+  badge?: string;
   onClick: () => void;
 }
 
-export function ThreadCard({ icon, title, sender, preview, isUrgent, onClick }: ThreadCardProps) {
+export function ThreadCard({ icon, title, sender, preview, isUrgent, badge, onClick }: ThreadCardProps) {
   return (
     <button
       onClick={onClick}
@@ -28,6 +29,11 @@ export function ThreadCard({ icon, title, sender, preview, isUrgent, onClick }: 
           </span>
           {isUrgent && (
             <span className="shrink-0 w-2 h-2 rounded-full bg-alert-red" />
+          )}
+          {badge && !isUrgent && (
+            <span className="shrink-0 text-xs2 font-medium text-warn-amber bg-warn-amber/10 px-1.5 py-0.5 rounded-tag">
+              {badge}
+            </span>
           )}
         </div>
         <p className="text-xs2 text-txt-muted truncate">{sender}</p>


### PR DESCRIPTION
## Summary

- **🎯 Practice HubTile** — dedicated entry point in Command Centre; hub tile grid moves from 3 tiles to 2×2
- **"Chats" → "Negotiations"** — tile renamed to reflect actual purpose (maths challenge deals)
- **Practice slide-over** opens SocialFeed in `practiceMode` — shows all 6 topics, skips the negotiations section entirely
- **Weakest 3 topics** get a "Recommended" amber badge so students get guidance without being locked in
- `ThreadCard` gains an optional `badge` prop for contextual labelling
- `practiceMode` prop on `SocialFeed` → `practiceOnly` on `InboxView`

## Test plan

- [ ] Command Centre shows 4 tiles in a 2×2 grid: Stadium, Negotiations, Practice, Transfers
- [ ] "Negotiations" tile shows "Deals waiting" when there are pending maths events, otherwise "No active deals"
- [ ] Practice tile opens a slide-over titled "Practice — Marcus Webb"
- [ ] Slide-over shows all 6 topics; weakest 3 have an amber "Recommended" badge
- [ ] Clicking a topic starts a Marcus Webb drill (chat thread with challenge card + keyboard)
- [ ] "← Back to inbox" returns to topic picker
- [ ] Chats tile (Negotiations) still opens the negotiation/practice inbox as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)