### PR TITLE
feat: Val financial threshold inbox messages

### DIFF
--- a/packages/domain/src/__tests__/financial-threshold.test.ts
+++ b/packages/domain/src/__tests__/financial-threshold.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Financial Threshold Event Tests
+ *
+ * Tests for generateFinancialThresholdEvents:
+ *   - fires on deterioration (GREEN→AMBER, AMBER→RED, RED→CRITICAL)
+ *   - fires on recovery (CRITICAL/RED→AMBER or better)
+ *   - no-op when band unchanged
+ *   - no-op when unresolved financial event already pending
+ *   - no-op in PRE_SEASON / SEASON_END
+ */
+
+import { buildState } from '../reducers';
+import { GameState, PendingClubEvent } from '../types/game-state-updated';
+import { GameStartedEvent } from '../events/types';
+import { generateFinancialThresholdEvents } from '../simulation/events';
+
+function makeState(overrides: Partial<GameState> = {}): GameState {
+  const base = buildState([
+    {
+      type: 'GAME_STARTED',
+      timestamp: Date.now(),
+      clubId: 'test-club',
+      clubName: 'Test FC',
+      initialBudget: 500_000_00,
+      difficulty: 'MEDIUM',
+      seed: 'test-seed',
+    } as GameStartedEvent,
+  ]);
+  return { ...base, ...overrides };
+}
+
+function pendingFinancialEvent(templateId: string): PendingClubEvent {
+  return {
+    id: 'evt-existing',
+    templateId,
+    week: 1,
+    title: 'Test',
+    description: 'Test',
+    severity: 'minor',
+    choices: [],
+    resolved: false,
+  };
+}
+
+describe('generateFinancialThresholdEvents', () => {
+  // ── Deterioration ──────────────────────────────────────────────────────────
+
+  test('fires val-runway-amber when crossing GREEN → AMBER', () => {
+    const state = makeState({ lastRunwayBand: 'GREEN', phase: 'EARLY_SEASON' });
+    const events = generateFinancialThresholdEvents(state, 5, 1, 'AMBER', 15);
+    expect(events).toHaveLength(1);
+    expect(events[0].templateId).toBe('val-runway-amber');
+    expect(events[0].npc).toBe('val');
+    expect(events[0].severity).toBe('minor');
+  });
+
+  test('fires val-runway-amber when crossing SURPLUS → AMBER', () => {
+    const state = makeState({ lastRunwayBand: 'SURPLUS', phase: 'EARLY_SEASON' });
+    const events = generateFinancialThresholdEvents(state, 5, 1, 'AMBER', 15);
+    expect(events).toHaveLength(1);
+    expect(events[0].templateId).toBe('val-runway-amber');
+  });
+
+  test('fires val-runway-red when crossing AMBER → RED', () => {
+    const state = makeState({ lastRunwayBand: 'AMBER', phase: 'MID_SEASON' });
+    const events = generateFinancialThresholdEvents(state, 10, 1, 'RED', 7);
+    expect(events).toHaveLength(1);
+    expect(events[0].templateId).toBe('val-runway-red');
+    expect(events[0].severity).toBe('major');
+  });
+
+  test('fires val-runway-red when crossing GREEN → RED (skipped a band)', () => {
+    const state = makeState({ lastRunwayBand: 'GREEN', phase: 'MID_SEASON' });
+    const events = generateFinancialThresholdEvents(state, 10, 1, 'RED', 7);
+    expect(events).toHaveLength(1);
+    expect(events[0].templateId).toBe('val-runway-red');
+  });
+
+  test('fires val-runway-critical when crossing RED → CRITICAL', () => {
+    const state = makeState({ lastRunwayBand: 'RED', phase: 'LATE_SEASON' });
+    const events = generateFinancialThresholdEvents(state, 15, 1, 'CRITICAL', 3);
+    expect(events).toHaveLength(1);
+    expect(events[0].templateId).toBe('val-runway-critical');
+    expect(events[0].severity).toBe('major');
+  });
+
+  // ── Recovery ───────────────────────────────────────────────────────────────
+
+  test('fires val-runway-recovery when crossing CRITICAL → AMBER', () => {
+    const state = makeState({ lastRunwayBand: 'CRITICAL', phase: 'MID_SEASON' });
+    const events = generateFinancialThresholdEvents(state, 20, 1, 'AMBER', 12);
+    expect(events).toHaveLength(1);
+    expect(events[0].templateId).toBe('val-runway-recovery');
+    expect(events[0].severity).toBe('minor');
+  });
+
+  test('fires val-runway-recovery when crossing RED → GREEN', () => {
+    const state = makeState({ lastRunwayBand: 'RED', phase: 'MID_SEASON' });
+    const events = generateFinancialThresholdEvents(state, 20, 1, 'GREEN', 25);
+    expect(events).toHaveLength(1);
+    expect(events[0].templateId).toBe('val-runway-recovery');
+  });
+
+  test('fires val-runway-recovery when crossing RED → SURPLUS', () => {
+    const state = makeState({ lastRunwayBand: 'RED', phase: 'MID_SEASON' });
+    const events = generateFinancialThresholdEvents(state, 20, 1, 'SURPLUS', Infinity);
+    expect(events).toHaveLength(1);
+    expect(events[0].templateId).toBe('val-runway-recovery');
+  });
+
+  // ── No-op cases ────────────────────────────────────────────────────────────
+
+  test('no event when band unchanged', () => {
+    const state = makeState({ lastRunwayBand: 'AMBER', phase: 'EARLY_SEASON' });
+    const events = generateFinancialThresholdEvents(state, 5, 1, 'AMBER', 12);
+    expect(events).toHaveLength(0);
+  });
+
+  test('no event when lastRunwayBand is undefined and band is GREEN (first run)', () => {
+    const state = makeState({ lastRunwayBand: undefined, phase: 'EARLY_SEASON' });
+    const events = generateFinancialThresholdEvents(state, 1, 1, 'GREEN', 30);
+    expect(events).toHaveLength(0);
+  });
+
+  test('no event when an unresolved financial threshold card is already pending', () => {
+    const state = makeState({
+      lastRunwayBand: 'GREEN',
+      phase: 'EARLY_SEASON',
+      pendingEvents: [pendingFinancialEvent('val-runway-amber')],
+    });
+    const events = generateFinancialThresholdEvents(state, 5, 1, 'AMBER', 15);
+    expect(events).toHaveLength(0);
+  });
+
+  test('fires even when unrelated pending events exist', () => {
+    const state = makeState({
+      lastRunwayBand: 'GREEN',
+      phase: 'EARLY_SEASON',
+      pendingEvents: [pendingFinancialEvent('morale-unrest')],
+    });
+    const events = generateFinancialThresholdEvents(state, 5, 1, 'AMBER', 15);
+    expect(events).toHaveLength(1);
+  });
+
+  test('no event during PRE_SEASON', () => {
+    const state = makeState({ lastRunwayBand: 'GREEN', phase: 'PRE_SEASON' });
+    const events = generateFinancialThresholdEvents(state, 1, 1, 'AMBER', 15);
+    expect(events).toHaveLength(0);
+  });
+
+  test('no event during SEASON_END', () => {
+    const state = makeState({ lastRunwayBand: 'GREEN', phase: 'SEASON_END' });
+    const events = generateFinancialThresholdEvents(state, 46, 1, 'AMBER', 15);
+    expect(events).toHaveLength(0);
+  });
+
+  // ── Content checks ─────────────────────────────────────────────────────────
+
+  test('amber card has 2 choices', () => {
+    const state = makeState({ lastRunwayBand: 'GREEN', phase: 'EARLY_SEASON' });
+    const events = generateFinancialThresholdEvents(state, 5, 1, 'AMBER', 15);
+    expect(events[0].choices).toHaveLength(2);
+  });
+
+  test('red card has 3 choices', () => {
+    const state = makeState({ lastRunwayBand: 'AMBER', phase: 'MID_SEASON' });
+    const events = generateFinancialThresholdEvents(state, 10, 1, 'RED', 7);
+    expect(events[0].choices).toHaveLength(3);
+  });
+
+  test('critical card has 3 choices including emergency board funding', () => {
+    const state = makeState({ lastRunwayBand: 'RED', phase: 'LATE_SEASON' });
+    const events = generateFinancialThresholdEvents(state, 15, 1, 'CRITICAL', 3);
+    const choices = events[0].choices;
+    expect(choices).toHaveLength(3);
+    const boardChoice = choices.find(c => c.id === 'board-emergency');
+    expect(boardChoice).toBeDefined();
+    expect(boardChoice!.budgetEffect).toBeGreaterThan(0);
+  });
+
+  test('event id includes season and week', () => {
+    const state = makeState({ lastRunwayBand: 'GREEN', phase: 'EARLY_SEASON' });
+    const events = generateFinancialThresholdEvents(state, 12, 3, 'AMBER', 15);
+    expect(events[0].id).toContain('S3');
+    expect(events[0].id).toContain('W12');
+  });
+});

--- a/packages/domain/src/commands/handlers.ts
+++ b/packages/domain/src/commands/handlers.ts
@@ -11,7 +11,8 @@ import { validateTransfer, validateFacilityUpgrade, validateStaffHire } from '..
 import { simulateMatch, clubToTeam, generateAITeam, Team } from '../simulation/match';
 import { generateSeasonFixtures, getWeekFixtures, matchSeed } from '../simulation/season';
 import { createRng } from '../simulation/rng';
-import { generateWeekEvents, generatePoachAttempts, generateMoraleThresholdEvents } from '../simulation/events';
+import { generateWeekEvents, generatePoachAttempts, generateMoraleThresholdEvents, generateFinancialThresholdEvents } from '../simulation/events';
+import { computeWeeklyFinancials, computeRunwayBand } from '../simulation/revenue';
 import { getTeamsForDivision } from '../data/division-teams';
 import { Player, computeOverallRating } from '../types/player';
 import { shouldRetire, getRetirementFlavour } from '../simulation/progression';
@@ -357,6 +358,41 @@ function handleSimulateWeek(command: any, state: GameState): CommandResult {
         clubId: state.club.id,
         pendingEvent
       });
+    }
+  }
+
+  // ── Financial threshold detection ────────────────────────────────────────────
+
+  // Detect runway band crossings and emit Val's inbox card + a RUNWAY_BAND_CHANGED event.
+  // Financial threshold events fire independently of morale/club event stacking rules
+  // because they signal a genuine change in state (not just a nudge).
+  {
+    const { weeklyIncome, weeklyWages, runway } = computeWeeklyFinancials(state);
+    const isSurplus  = weeklyIncome >= weeklyWages;
+    const currentBand = computeRunwayBand(isFinite(runway) ? runway : Infinity, isSurplus);
+    const previousBand = state.lastRunwayBand ?? currentBand;
+
+    if (currentBand !== previousBand) {
+      events.push({
+        type: 'RUNWAY_BAND_CHANGED',
+        timestamp: now,
+        band: currentBand,
+      });
+
+      const financialEvents = generateFinancialThresholdEvents(
+        state, week, season, currentBand, isFinite(runway) ? runway : Infinity
+      );
+      for (const pendingEvent of financialEvents) {
+        events.push({
+          type: 'CLUB_EVENT_OCCURRED',
+          timestamp: now,
+          eventId: pendingEvent.id,
+          templateId: pendingEvent.templateId,
+          week,
+          clubId: state.club.id,
+          pendingEvent,
+        });
+      }
     }
   }
 

--- a/packages/domain/src/events/types.ts
+++ b/packages/domain/src/events/types.ts
@@ -45,7 +45,8 @@ export type GameEvent =
   | OwnerForcedOutEvent
   | TakeoverAcceptedEvent
   | ParachuteOfferedEvent
-  | CurriculumUpgradedEvent;
+  | CurriculumUpgradedEvent
+  | RunwayBandChangedEvent;
 
 export interface TransferCompletedEvent {
   type: 'TRANSFER_COMPLETED';
@@ -392,4 +393,11 @@ export interface TakeoverAcceptedEvent {
   takeoverClubName: string;
   seed: string;
   week: number;
+}
+
+/** Emitted whenever the runway band crosses a threshold (for Val's inbox messages). */
+export interface RunwayBandChangedEvent {
+  type: 'RUNWAY_BAND_CHANGED';
+  timestamp: number;
+  band: 'SURPLUS' | 'GREEN' | 'AMBER' | 'RED' | 'CRITICAL';
 }

--- a/packages/domain/src/reducers/index.ts
+++ b/packages/domain/src/reducers/index.ts
@@ -95,6 +95,8 @@ export function reduceEvent(state: GameState, event: GameEvent): GameState {
       return handleTakeoverAccepted(state, event);
     case 'CURRICULUM_UPGRADED':
       return handleCurriculumUpgraded(state, event);
+    case 'RUNWAY_BAND_CHANGED':
+      return { ...state, lastRunwayBand: event.band };
     default:
       return state;
   }

--- a/packages/domain/src/simulation/events.ts
+++ b/packages/domain/src/simulation/events.ts
@@ -532,3 +532,173 @@ export function generateMoraleThresholdEvents(
 
   return [];
 }
+
+// ── Financial threshold event IDs ────────────────────────────────────────────
+
+export const FINANCIAL_THRESHOLD_TEMPLATE_IDS = new Set([
+  'val-runway-amber',
+  'val-runway-red',
+  'val-runway-critical',
+  'val-runway-recovery',
+]);
+
+// Band severity order: higher index = better financial health
+const BAND_ORDER = ['CRITICAL', 'RED', 'AMBER', 'GREEN', 'SURPLUS'] as const;
+type RunwayBand = 'SURPLUS' | 'GREEN' | 'AMBER' | 'RED' | 'CRITICAL';
+
+function bandIndex(b: RunwayBand): number {
+  return BAND_ORDER.indexOf(b);
+}
+
+/**
+ * Generate 0–1 Val Okoro inbox cards when the runway band crosses a threshold.
+ *
+ * Fires on:
+ *   - deterioration:  SURPLUS/GREEN → AMBER, AMBER → RED, RED → CRITICAL
+ *   - recovery:       CRITICAL/RED → AMBER or better
+ *
+ * "Once per crossing" — skips if an unresolved financial threshold card is already pending.
+ */
+export function generateFinancialThresholdEvents(
+  state: GameState,
+  week: number,
+  season: number,
+  currentBand: RunwayBand,
+  runway: number
+): PendingClubEvent[] {
+  if (state.phase === 'PRE_SEASON' || state.phase === 'SEASON_END') return [];
+
+  const previousBand: RunwayBand = state.lastRunwayBand ?? currentBand;
+  if (previousBand === currentBand) return [];
+
+  // Don't stack — skip if an unresolved financial threshold card is already in the inbox
+  if (state.pendingEvents.some(
+    e => FINANCIAL_THRESHOLD_TEMPLATE_IDS.has(e.templateId) && !e.resolved
+  )) return [];
+
+  const prevIdx = bandIndex(previousBand);
+  const currIdx = bandIndex(currentBand);
+  const deteriorating = currIdx < prevIdx;
+  const recovering    = currIdx > prevIdx;
+
+  const runwayDisplay = isFinite(runway) ? `${Math.round(runway)} weeks` : 'a surplus';
+
+  if (deteriorating) {
+    if (currentBand === 'AMBER') {
+      return [{
+        id: `evt-S${season}-W${week}-val-runway-amber`,
+        templateId: 'val-runway-amber',
+        week,
+        title: 'Financial warning — amber zone',
+        description: `Our runway is down to ${runwayDisplay} at current burn rate. We're not in crisis yet, but if the wage bill stays where it is we'll be in the red within a few months. Time to keep a close eye on the spend.`,
+        severity: 'minor',
+        npc: 'val',
+        choices: [
+          {
+            id: 'acknowledge',
+            label: 'Noted — I\'ll watch the wage bill',
+            description: 'Acknowledge the warning. No immediate action required.',
+          },
+          {
+            id: 'review-wages',
+            label: 'Ask Val for a full wage review',
+            description: 'Request a detailed breakdown to identify where savings can be made.',
+            reputationEffect: -2,
+          },
+        ],
+        resolved: false,
+      }];
+    }
+
+    if (currentBand === 'RED') {
+      return [{
+        id: `evt-S${season}-W${week}-val-runway-red`,
+        templateId: 'val-runway-red',
+        week,
+        title: 'Financial alert — red zone',
+        description: `Runway has dropped to ${runwayDisplay}. At current burn rate we're less than 10 weeks from running dry. We need to make some decisions — either cut costs or bring money in.`,
+        severity: 'major',
+        npc: 'val',
+        choices: [
+          {
+            id: 'sell-player',
+            label: 'I\'ll look at selling a player',
+            description: 'Commit to listing a player — transfer income could buy several more months of runway.',
+            reputationEffect: -3,
+          },
+          {
+            id: 'cut-wages',
+            label: 'Start wage negotiations',
+            description: 'Attempt to renegotiate contracts. Some players may push back.',
+            moraleEffect: -5,
+          },
+          {
+            id: 'hold-nerve',
+            label: 'Hold for now — form will turn it around',
+            description: 'Results on the pitch drive morale and attendance. Risky if form doesn\'t improve.',
+          },
+        ],
+        resolved: false,
+      }];
+    }
+
+    if (currentBand === 'CRITICAL') {
+      return [{
+        id: `evt-S${season}-W${week}-val-runway-critical`,
+        templateId: 'val-runway-critical',
+        week,
+        title: 'URGENT — less than 5 weeks of cash',
+        description: `Runway has collapsed to ${runwayDisplay}. I'm not being dramatic — we are weeks from not being able to pay wages. Emergency action is needed now.`,
+        severity: 'major',
+        npc: 'val',
+        choices: [
+          {
+            id: 'emergency-sale',
+            label: 'Authorise an emergency player sale',
+            description: 'Accept below-value offers to generate cash fast. The market knows you\'re desperate.',
+            reputationEffect: -5,
+            budgetEffect: 0,
+          },
+          {
+            id: 'board-emergency',
+            label: 'Request emergency board funding',
+            description: 'The board may step in — but they\'ll expect results and will monitor everything more closely.',
+            reputationEffect: -8,
+            budgetEffect: 50000_00, // £50k emergency injection
+          },
+          {
+            id: 'hope',
+            label: 'Hold on — we just need one big result',
+            description: 'The gambler\'s last stand. If things don\'t turn around, this is how clubs get taken over.',
+          },
+        ],
+        resolved: false,
+      }];
+    }
+  }
+
+  if (recovering) {
+    const newBandLabel = currentBand === 'SURPLUS' ? 'a surplus' :
+                         currentBand === 'GREEN'   ? 'the green zone' :
+                         'the amber zone';
+    return [{
+      id: `evt-S${season}-W${week}-val-runway-recovery`,
+      templateId: 'val-runway-recovery',
+      week,
+      title: 'Financial update — runway improving',
+      description: `Good news — we\'re back in ${newBandLabel} (${runwayDisplay} runway). The finances are looking more stable. Keep it up.`,
+      severity: 'minor',
+      npc: 'val',
+      choices: [
+        {
+          id: 'acknowledge',
+          label: 'Good to hear',
+          description: 'Note the improvement and continue as planned.',
+        },
+      ],
+      resolved: false,
+    }];
+  }
+
+  return [];
+}

--- a/packages/domain/src/simulation/revenue.ts
+++ b/packages/domain/src/simulation/revenue.ts
@@ -126,3 +126,15 @@ export function computeWeeklyFinancials(state: GameState): {
 
   return { weeklyIncome, weeklyWages, runway };
 }
+
+/** Maps a runway value (weeks) to the colour band shown in the Financial Health Bar. */
+export function computeRunwayBand(
+  runway: number,
+  isSurplus: boolean
+): 'SURPLUS' | 'GREEN' | 'AMBER' | 'RED' | 'CRITICAL' {
+  if (isSurplus) return 'SURPLUS';
+  if (runway >= 20) return 'GREEN';
+  if (runway >= 10) return 'AMBER';
+  if (runway >= 5)  return 'RED';
+  return 'CRITICAL';
+}

--- a/packages/domain/src/types/game-state-updated.ts
+++ b/packages/domain/src/types/game-state-updated.ts
@@ -187,6 +187,13 @@ export interface GameState {
   moraleEventCooldowns: Record<string, number>;
 
   /**
+   * The runway band recorded at the end of the last simulated week.
+   * Used to detect threshold crossings (e.g. GREEN → AMBER) for Val's inbox messages.
+   * Undefined until the first RUNWAY_BAND_CHANGED event is emitted.
+   */
+  lastRunwayBand?: 'SURPLUS' | 'GREEN' | 'AMBER' | 'RED' | 'CRITICAL';
+
+  /**
    * Active scout mission, if any.
    * Only one mission can be active at a time.
    */


### PR DESCRIPTION
## Summary

Val Okoro sends inbox cards when the Financial Health Bar crosses a band boundary — once per crossing, in either direction.

- **Amber** (minor): GREEN/SURPLUS → AMBER — "not in crisis yet, but watch the spend"
- **Red** (major, 3 choices): AMBER → RED — sell a player / negotiate wages / hold nerve
- **Critical** (major, 3 choices): RED → CRITICAL — emergency sale / request board funding (£50k injection) / gambler's last stand
- **Recovery** (minor): any deteriorated band → AMBER/GREEN/SURPLUS — "back in the green zone"

No-ops: band unchanged, unresolved financial card already pending, PRE_SEASON, SEASON_END.

## Implementation

- `RunwayBandChangedEvent` — new event type; emitted once per band change after SIMULATE_WEEK
- `GameState.lastRunwayBand` — persists last recorded band for crossing detection
- `computeRunwayBand()` in `revenue.ts` — maps runway weeks + isSurplus to 5-band enum
- `generateFinancialThresholdEvents()` in `events.ts` — pure function, testable in isolation
- Reducer handles `RUNWAY_BAND_CHANGED` → updates `state.lastRunwayBand`
- 18 unit tests: all crossing directions, no-op cases, content checks

## Test plan

- [ ] Start new game, advance weeks until wages eat budget — Val amber card appears in inbox
- [ ] Resolve it, continue — red card appears if runway keeps dropping  
- [ ] Critical card fires with board funding choice (positive budgetEffect)
- [ ] Sell a player / get revenue → recovery card fires when band improves
- [ ] No duplicate cards while one is unresolved
- [ ] No cards during pre-season

🤖 Generated with [Claude Code](https://claude.com/claude-code)