### PR TITLE
Polish: matchday event flow — pre-match, Owner's Box, post-match (#81)

### DIFF
--- a/.build/NEXT.md
+++ b/.build/NEXT.md
@@ -8,8 +8,9 @@ lastUpdated: "2026-03-30"
 
 ## Immediate (Next Session)
 
-1. **Open PR for nifty-ride branch** — morale ticker milestones + Groundskeeper's Drill; both browser-verified.
-2. **Balance pass** — full L2 → L1 play-through; observe growth/retirement rates, budget scaling, question difficulty progression; compare Year 7 vs Year 9 starting experience.
+1. **Open PR for pensive-kapitsa branch** — matchday event flow (issue #81); pre-match + post-match screens, three-phase MatchdayState.
+2. **Open PR for nifty-ride branch** — morale ticker milestones + Groundskeeper's Drill; both browser-verified.
+3. **Balance pass** — full L2 → L1 play-through; observe growth/retirement rates, budget scaling, question difficulty progression; compare Year 7 vs Year 9 starting experience.
 
 ## Short Term (Next 2–4 Weeks)
 

--- a/.build/STATUS.md
+++ b/.build/STATUS.md
@@ -3,7 +3,7 @@ project: "Calculating Glory"
 type: "build"
 priority: 2
 phase: "Phase 8 — Polish"
-progress: 94
+progress: 96
 lastUpdated: "2026-03-30"
 lastTouched: "2026-03-30"
 status: "in-progress"
@@ -11,7 +11,7 @@ status: "in-progress"
 
 # Calculating Glory - Current Status
 
-**Phase:** Phase 8 — Polish (94% complete)
+**Phase:** Phase 8 — Polish (96% complete)
 **Last Updated:** 2026-03-30
 
 ## What's Done
@@ -53,6 +53,12 @@ status: "in-progress"
 - Architecture futureproofing for CIRCLES + VOLUME_AND_SURFACE_AREA (GCSE Higher)
 - `DiagramLibrary` + `diagram?` field threaded through QuestionTemplate → MathChallenge
 
+*pensive-kapitsa worktree — issue #81 (open, not yet PR'd):*
+- **Pre-match screen**: full-screen overlay between "Advance to Week" and Owner's Box; shows home/away team cards with league position + last-5 form strip; "Kick Off" CTA
+- **Post-match screen**: result banner (Victory/Draw/Defeat) with colour treatment (green/amber/red); final score; morale milestone if one fired that week; NPC reaction (Val on wins+losses, Marcus on draws)
+- **Three-phase matchday flow**: `MatchdayState` in App.tsx tracks `pre-match → live → post-match`; Owner's Box `onComplete` now transitions to post-match instead of dismissing directly
+- New components: `PreMatchScreen.tsx`, `PostMatchScreen.tsx` in `components/matchday/`
+
 *nifty-ride worktree (open, not yet PR'd):*
 - **Intro spotlight**: each NPC beat reveals its corresponding CC section at full brightness; all others dimmed via per-section overlay divs (CSS opacity transition, not global filter)
 - **Single-message intro**: one card at a time, bottom-anchored — never covers the spotlighted section
@@ -63,7 +69,8 @@ status: "in-progress"
 ## What's In Progress
 
 - nifty-ride worktree — polish batch 1, ready to PR
-- Open polish issues: #81 (match day), #82 (transfers), #83 (season arc), #85 (NPC cast), #86 (mobile)
+- pensive-kapitsa worktree — issue #81 (matchday event flow), ready to PR
+- Open polish issues: #82 (transfers), #83 (season arc), #85 (NPC cast), #86 (mobile)
 - Balance pass — passive, during play-testing
 
 ## Blockers

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -15,14 +15,25 @@ import { ForcedOutScreen } from './components/forced-out/ForcedOutScreen';
 import { MenuScreen } from './components/menu/MenuScreen';
 import { IntroScreen } from './components/intro/IntroScreen';
 import { OwnerBox } from './components/owner-box/OwnerBox';
+import { PreMatchScreen } from './components/matchday/PreMatchScreen';
+import { PostMatchScreen } from './components/matchday/PostMatchScreen';
 import { isIntroCompleted, clearIntroCompleted } from './lib/introState';
 
 type Screen = 'menu' | 'intro' | 'game';
+type MatchdayPhase = 'pre-match' | 'live' | 'post-match';
 
-interface OwnerBoxData {
+interface MatchdayState {
+  phase: MatchdayPhase;
   timeline: MatchTimeline;
   playerTeamName: string;
   opponentTeamName: string;
+  isHome: boolean;
+  myPosition: number;
+  myForm: ('W' | 'D' | 'L')[];
+  opponentPosition: number;
+  opponentForm: ('W' | 'D' | 'L')[];
+  week: number;
+  moraleEvent: { headline: string; milestoneKey: string } | null;
 }
 
 export default function App() {
@@ -30,7 +41,7 @@ export default function App() {
   const [screen, setScreen] = useState<Screen>('menu');
   const [activeView, setActiveView] = useState<ActiveView>('command');
   const [error, setError] = useState<string | null>(null);
-  const [ownerBoxData, setOwnerBoxData] = useState<OwnerBoxData | null>(null);
+  const [matchdayState, setMatchdayState] = useState<MatchdayState | null>(null);
   const processedEventCount = useRef<number | null>(null);
 
   // Detect new MATCH_SIMULATED events after simulation completes
@@ -57,6 +68,7 @@ export default function App() {
     const opponentId = isHome ? matchEvent.awayTeamId : matchEvent.homeTeamId;
     const opponentEntry = state.league.entries.find(e => e.clubId === opponentId);
     const opponentTeamName = opponentEntry?.clubName ?? 'Opponents';
+    const myEntry = state.league.entries.find(e => e.clubId === state.club.id);
 
     const gk = state.club.squad.find(p => p.position === 'GK');
     const keeperName = gk ? gk.name.split(' ')[0] : 'Keeper';
@@ -73,10 +85,22 @@ export default function App() {
       keeperName,
     };
 
-    setOwnerBoxData({
+    const moraleEvent = newEvents.find(e => e.type === 'MORALE_TICKER_EVENT');
+
+    setMatchdayState({
+      phase: 'pre-match',
       timeline: generateMatchTimeline(ctx),
       playerTeamName: state.club.name,
       opponentTeamName,
+      isHome,
+      myPosition: myEntry?.position ?? 0,
+      myForm: (myEntry?.form ?? []) as ('W' | 'D' | 'L')[],
+      opponentPosition: opponentEntry?.position ?? 0,
+      opponentForm: (opponentEntry?.form ?? []) as ('W' | 'D' | 'L')[],
+      week: state.currentWeek,
+      moraleEvent: moraleEvent && moraleEvent.type === 'MORALE_TICKER_EVENT'
+        ? { headline: moraleEvent.headline, milestoneKey: moraleEvent.milestoneKey }
+        : null,
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [events, isLoading]);
@@ -183,12 +207,37 @@ export default function App() {
         </div>
       )}
 
-      {ownerBoxData && (
+      {matchdayState?.phase === 'pre-match' && (
+        <PreMatchScreen
+          week={matchdayState.week}
+          playerTeamName={matchdayState.playerTeamName}
+          opponentTeamName={matchdayState.opponentTeamName}
+          isHome={matchdayState.isHome}
+          myPosition={matchdayState.myPosition}
+          myForm={matchdayState.myForm}
+          opponentPosition={matchdayState.opponentPosition}
+          opponentForm={matchdayState.opponentForm}
+          onKickOff={() => setMatchdayState(s => s ? { ...s, phase: 'live' } : s)}
+        />
+      )}
+
+      {matchdayState?.phase === 'live' && (
         <OwnerBox
-          timeline={ownerBoxData.timeline}
-          playerTeamName={ownerBoxData.playerTeamName}
-          opponentTeamName={ownerBoxData.opponentTeamName}
-          onComplete={() => setOwnerBoxData(null)}
+          timeline={matchdayState.timeline}
+          playerTeamName={matchdayState.playerTeamName}
+          opponentTeamName={matchdayState.opponentTeamName}
+          onComplete={() => setMatchdayState(s => s ? { ...s, phase: 'post-match' } : s)}
+        />
+      )}
+
+      {matchdayState?.phase === 'post-match' && (
+        <PostMatchScreen
+          finalScore={matchdayState.timeline.finalScore}
+          isHome={matchdayState.isHome}
+          playerTeamName={matchdayState.playerTeamName}
+          opponentTeamName={matchdayState.opponentTeamName}
+          moraleEvent={matchdayState.moraleEvent}
+          onDismiss={() => setMatchdayState(null)}
         />
       )}
     </div>

--- a/packages/frontend/src/components/matchday/PostMatchScreen.tsx
+++ b/packages/frontend/src/components/matchday/PostMatchScreen.tsx
@@ -1,0 +1,170 @@
+/**
+ * PostMatchScreen — shown after the Owner's Box completes.
+ *
+ * Win/draw/loss each get a distinct visual treatment so the result has weight.
+ * Includes morale event if one fired this week, plus a brief NPC reaction.
+ */
+
+import { MatchScore } from '@calculating-glory/domain';
+
+interface PostMatchScreenProps {
+  finalScore: MatchScore;
+  isHome: boolean;
+  playerTeamName: string;
+  opponentTeamName: string;
+  moraleEvent: { headline: string; milestoneKey: string } | null;
+  onDismiss: () => void;
+}
+
+type Outcome = 'WIN' | 'DRAW' | 'LOSS';
+
+function getOutcome(score: MatchScore, isHome: boolean): Outcome {
+  const myGoals  = isHome ? score.home : score.away;
+  const oppGoals = isHome ? score.away : score.home;
+  if (myGoals > oppGoals) return 'WIN';
+  if (myGoals < oppGoals) return 'LOSS';
+  return 'DRAW';
+}
+
+const OUTCOME_CONFIG: Record<Outcome, {
+  label: string;
+  labelColor: string;
+  bgAccent: string;
+  border: string;
+  scoreColor: string;
+  npcName: string;
+  npcReaction: string;
+  buttonBg: string;
+}> = {
+  WIN: {
+    label: 'Victory',
+    labelColor: 'text-pitch-green',
+    bgAccent: 'bg-pitch-green/5',
+    border: 'border-pitch-green/20',
+    scoreColor: 'text-pitch-green',
+    npcName: 'Val',
+    npcReaction: "The numbers are moving. Keep this going and the board will notice.",
+    buttonBg: 'bg-pitch-green hover:bg-pitch-green/80',
+  },
+  DRAW: {
+    label: 'Draw',
+    labelColor: 'text-warn-amber',
+    bgAccent: 'bg-warn-amber/5',
+    border: 'border-warn-amber/20',
+    scoreColor: 'text-warn-amber',
+    npcName: 'Marcus',
+    npcReaction: "A point on the road is a point. We move on and reset for next week.",
+    buttonBg: 'bg-warn-amber hover:bg-warn-amber/80 text-bg-deep',
+  },
+  LOSS: {
+    label: 'Defeat',
+    labelColor: 'text-alert-red',
+    bgAccent: 'bg-alert-red/5',
+    border: 'border-alert-red/20',
+    scoreColor: 'text-alert-red',
+    npcName: 'Val',
+    npcReaction: "Tough one. We review, we reset. There are still points to play for.",
+    buttonBg: 'bg-bg-raised hover:bg-bg-raised/80 border border-bg-raised/60',
+  },
+};
+
+const MORALE_LABEL: Record<string, string> = {
+  W3: '3 wins on the bounce',
+  W5: '5-match winning streak',
+  L3: '3 losses in a row',
+  L5: '5-match losing run',
+};
+
+export function PostMatchScreen({
+  finalScore,
+  isHome,
+  playerTeamName,
+  opponentTeamName,
+  moraleEvent,
+  onDismiss,
+}: PostMatchScreenProps) {
+  const outcome = getOutcome(finalScore, isHome);
+  const cfg = OUTCOME_CONFIG[outcome];
+
+  const homeTeam  = isHome ? playerTeamName : opponentTeamName;
+  const awayTeam  = isHome ? opponentTeamName : playerTeamName;
+
+  return (
+    <div className="fixed inset-0 bg-bg-deep flex flex-col z-50 overflow-hidden">
+
+      {/* Header */}
+      <div className="shrink-0 flex items-center justify-between px-4 py-2.5 border-b border-bg-raised">
+        <span className="text-xs font-semibold text-txt-muted uppercase tracking-widest">
+          Full Time
+        </span>
+      </div>
+
+      {/* Main content */}
+      <div className="flex-1 flex flex-col items-center justify-center px-4 gap-6">
+
+        {/* Outcome banner */}
+        <div className={`w-full max-w-sm rounded-card px-6 py-5 text-center ${cfg.bgAccent} border ${cfg.border}`}>
+          <p className={`text-xs2 uppercase tracking-widest font-semibold text-txt-muted mb-2`}>
+            Result
+          </p>
+          <p className={`text-4xl font-black tracking-tight mb-4 ${cfg.labelColor}`}>
+            {cfg.label}
+          </p>
+
+          {/* Score */}
+          <div className="flex items-center justify-center gap-4">
+            <span className="text-xs font-semibold text-txt-muted max-w-[90px] text-right truncate">
+              {homeTeam}
+            </span>
+            <div className="flex items-center gap-2 shrink-0">
+              <span className={`text-3xl font-bold tabular-nums ${cfg.scoreColor}`}>
+                {finalScore.home}
+              </span>
+              <span className="text-lg text-txt-muted">—</span>
+              <span className={`text-3xl font-bold tabular-nums ${cfg.scoreColor}`}>
+                {finalScore.away}
+              </span>
+            </div>
+            <span className="text-xs font-semibold text-txt-muted max-w-[90px] text-left truncate">
+              {awayTeam}
+            </span>
+          </div>
+        </div>
+
+        {/* Morale event (if fired this week) */}
+        {moraleEvent && (
+          <div className="w-full max-w-sm rounded-card px-4 py-3 bg-bg-raised border border-bg-raised/50">
+            <p className="text-xs2 uppercase tracking-widest text-txt-muted font-semibold mb-1">
+              Morale
+            </p>
+            <p className="text-xs text-txt-primary font-medium">
+              {MORALE_LABEL[moraleEvent.milestoneKey] ?? moraleEvent.headline}
+            </p>
+          </div>
+        )}
+
+        {/* NPC reaction */}
+        <div className="w-full max-w-sm flex items-start gap-3">
+          <div className="shrink-0 w-7 h-7 rounded-full bg-warn-amber/20 flex items-center justify-center text-xs font-bold text-warn-amber">
+            V
+          </div>
+          <div className="bg-bg-raised rounded-card px-3 py-2.5 flex-1">
+            <p className="text-xs2 font-semibold text-warn-amber mb-0.5">{cfg.npcName}</p>
+            <p className="text-xs leading-relaxed text-txt-primary">{cfg.npcReaction}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Dismiss */}
+      <div className="shrink-0 px-4 py-6 border-t border-bg-raised">
+        <button
+          onClick={onDismiss}
+          className={`w-full py-3 rounded-card text-white text-sm font-semibold
+                     active:scale-95 transition-all duration-150 ${cfg.buttonBg}`}
+        >
+          Back to Command Centre
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/matchday/PreMatchScreen.tsx
+++ b/packages/frontend/src/components/matchday/PreMatchScreen.tsx
@@ -1,0 +1,181 @@
+/**
+ * PreMatchScreen — shown between "Advance to Week" and the Owner's Box.
+ *
+ * Gives the player a moment of anticipation before the result lands:
+ * your side, their side, current form, and a "Kick Off" button.
+ */
+
+interface PreMatchScreenProps {
+  week: number;
+  playerTeamName: string;
+  opponentTeamName: string;
+  isHome: boolean;
+  myPosition: number;
+  myForm: ('W' | 'D' | 'L')[];
+  opponentPosition: number;
+  opponentForm: ('W' | 'D' | 'L')[];
+  onKickOff: () => void;
+}
+
+const FORM_BG: Record<'W' | 'D' | 'L', string> = {
+  W: 'bg-pitch-green text-white',
+  D: 'bg-warn-amber text-bg-deep',
+  L: 'bg-alert-red text-white',
+};
+
+function FormStrip({ form }: { form: ('W' | 'D' | 'L')[] }) {
+  if (form.length === 0) {
+    return <span className="text-xs text-txt-muted italic">No results yet</span>;
+  }
+  return (
+    <div className="flex gap-1">
+      {form.map((r, i) => (
+        <span
+          key={i}
+          className={`w-5 h-5 rounded-sm flex items-center justify-center text-xs2 font-bold ${FORM_BG[r]}`}
+        >
+          {r}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function TeamCard({
+  name,
+  position,
+  form,
+  isPlayerTeam,
+  side,
+}: {
+  name: string;
+  position: number;
+  form: ('W' | 'D' | 'L')[];
+  isPlayerTeam: boolean;
+  side: 'home' | 'away';
+}) {
+  const sideLabel = side === 'home' ? 'HOME' : 'AWAY';
+  return (
+    <div
+      className={[
+        'flex-1 rounded-card p-4 flex flex-col gap-3',
+        isPlayerTeam
+          ? 'bg-data-blue/10 border border-data-blue/30'
+          : 'bg-bg-raised border border-bg-raised/50',
+        side === 'away' ? 'items-end text-right' : 'items-start text-left',
+      ].join(' ')}
+    >
+      <span className="text-xs2 uppercase tracking-widest text-txt-muted font-semibold">
+        {sideLabel}
+      </span>
+      <p
+        className={`text-sm font-bold leading-tight ${isPlayerTeam ? 'text-data-blue' : 'text-txt-primary'}`}
+      >
+        {name}
+      </p>
+      <div className={`flex flex-col gap-1.5 ${side === 'away' ? 'items-end' : 'items-start'}`}>
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs text-txt-muted">Pos</span>
+          <span className="text-xs font-bold text-txt-primary data-font">{position}</span>
+        </div>
+        <div className={`flex gap-1 ${side === 'away' ? 'flex-row-reverse' : ''}`}>
+          {form.length === 0 ? (
+            <span className="text-xs2 text-txt-muted italic">—</span>
+          ) : (
+            form.map((r, i) => (
+              <span
+                key={i}
+                className={`w-5 h-5 rounded-sm flex items-center justify-center text-xs2 font-bold ${FORM_BG[r]}`}
+              >
+                {r}
+              </span>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function PreMatchScreen({
+  week,
+  playerTeamName,
+  opponentTeamName,
+  isHome,
+  myPosition,
+  myForm,
+  opponentPosition,
+  opponentForm,
+  onKickOff,
+}: PreMatchScreenProps) {
+  const homeTeam = isHome ? playerTeamName : opponentTeamName;
+  const awayTeam = isHome ? opponentTeamName : playerTeamName;
+  const homePos  = isHome ? myPosition      : opponentPosition;
+  const awayPos  = isHome ? opponentPosition : myPosition;
+  const homeForm = isHome ? myForm           : opponentForm;
+  const awayForm = isHome ? opponentForm      : myForm;
+
+  return (
+    <div className="fixed inset-0 bg-bg-deep flex flex-col z-50 overflow-hidden">
+
+      {/* Header */}
+      <div className="shrink-0 flex items-center justify-between px-4 py-2.5 border-b border-bg-raised">
+        <span className="text-xs font-semibold text-txt-muted uppercase tracking-widest">
+          Match Day
+        </span>
+        <span className="text-xs font-mono text-txt-muted">
+          Week {week}
+        </span>
+      </div>
+
+      {/* Main content */}
+      <div className="flex-1 flex flex-col items-center justify-center px-4 gap-8">
+
+        {/* VS badge */}
+        <div className="text-center">
+          <p className="text-xs2 uppercase tracking-widest text-txt-muted font-semibold mb-1">
+            Kick-off
+          </p>
+          <div className="w-12 h-12 rounded-full bg-bg-raised border border-bg-raised/60 flex items-center justify-center">
+            <span className="text-xs font-bold text-txt-muted">VS</span>
+          </div>
+        </div>
+
+        {/* Team cards */}
+        <div className="w-full max-w-sm flex gap-3">
+          <TeamCard
+            name={homeTeam}
+            position={homePos}
+            form={homeForm}
+            isPlayerTeam={isHome}
+            side="home"
+          />
+          <TeamCard
+            name={awayTeam}
+            position={awayPos}
+            form={awayForm}
+            isPlayerTeam={!isHome}
+            side="away"
+          />
+        </div>
+
+        {/* Form legend */}
+        <div className="flex items-center gap-4 text-xs2 text-txt-muted">
+          <span>Last 5 results</span>
+          <FormStrip form={['W', 'D', 'L']} />
+        </div>
+      </div>
+
+      {/* Kick off button */}
+      <div className="shrink-0 px-4 py-6 border-t border-bg-raised">
+        <button
+          onClick={onKickOff}
+          className="w-full py-4 rounded-card bg-data-blue text-white font-bold text-base
+                     hover:bg-data-blue/80 active:scale-95 transition-all duration-150 tracking-wide"
+        >
+          Kick Off
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **PreMatchScreen**: full-screen overlay between "Advance to Week" and the Owner's Box — shows home/away team cards with league position and last-5 form strip, "Kick Off" CTA
- **PostMatchScreen**: result banner (Victory / Draw / Defeat) with colour treatment, final score, morale milestone if one fired that week, and a brief NPC reaction (Val on wins+losses, Marcus on draws)
- **App.tsx**: `OwnerBoxData` replaced with `MatchdayState` tracking phase through `pre-match → live → post-match`; Owner's Box `onComplete` now transitions to post-match instead of dismissing directly

## Test plan

- [ ] Advance to Week — pre-match screen appears with correct home/away teams, positions, and form
- [ ] Kick Off — Owner's Box fires as before with Kev commentary
- [ ] After Owner's Box completes — post-match screen appears with correct result and score
- [ ] Win shows Victory in green with Val reaction
- [ ] Draw shows Draw in amber with Marcus reaction
- [ ] Loss shows Defeat in red with Val reaction
- [ ] Morale event (W3/W5/L3/L5) shown on post-match screen when present, absent when not
- [ ] "Back to Command Centre" dismisses and returns to normal game state

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)