### PR TITLE
Polish: NPC cast depth, mobile fixes, real name removal (#85 #86)

### DIFF
--- a/.build/BACKLOG.md
+++ b/.build/BACKLOG.md
@@ -136,6 +136,10 @@ Performance notes for Chromebooks:
 - Blip engine renders only during match context (`isMatchDay`) — zero overhead outside match
 - 22 blips as `<rect>` elements inside one `<g>` is cheap; avoid mounting as individual React components with their own state/intervals
 
+## Multiplayer Readiness
+
+- [ ] Expand free agent name bank from 60 → 150–200 names to avoid repetition across concurrent sessions (single-player pool is seeded so 60 is fine; multiplayer draws from different seeds and will surface duplicates quickly)
+
 ## Balance / Tuning
 
 - [ ] Balance pass — observe growth/decline rates, retirement frequency (~1–2/season), and whether promotion to L1 feels meaningfully harder; run passively during normal play-throughs rather than as a dedicated task

--- a/.build/NEXT.md
+++ b/.build/NEXT.md
@@ -1,14 +1,14 @@
 ---
 project: "Calculating Glory"
 type: "build"
-lastUpdated: "2026-03-30"
+lastUpdated: "2026-03-31"
 ---
 
 # Calculating Glory - Next Steps
 
 ## Immediate (Next Session)
 
-1. **Open PR for nifty-ride branch** — morale ticker milestones + Groundskeeper's Drill; both browser-verified.
+1. **Merge PR #89** — Owner's Box polish + Dani observations; browser-verified, ready.
 2. **Balance pass** — full L2 → L1 play-through; observe growth/retirement rates, budget scaling, question difficulty progression; compare Year 7 vs Year 9 starting experience.
 
 ## Short Term (Next 2–4 Weeks)

--- a/.build/NEXT.md
+++ b/.build/NEXT.md
@@ -8,8 +8,9 @@ lastUpdated: "2026-03-31"
 
 ## Immediate (Next Session)
 
-1. **Merge PR #89** — Owner's Box polish + Dani observations; browser-verified, ready.
-2. **Balance pass** — full L2 → L1 play-through; observe growth/retirement rates, budget scaling, question difficulty progression; compare Year 7 vs Year 9 starting experience.
+1. **#85 — NPC cast** — Val/Marcus/Kev voice distinctiveness, contextual reappearance, first 10 minutes pacing.
+2. **#86 — Mobile/touch** — tap targets, no horizontal scroll, slide-overs on small screens, isometric on touch.
+3. **Balance pass** — full L2 → L1 play-through; observe growth/retirement rates, budget scaling, question difficulty progression; compare Year 7 vs Year 9 starting experience.
 
 ## Short Term (Next 2–4 Weeks)
 

--- a/.build/SESSION_START.md
+++ b/.build/SESSION_START.md
@@ -1,39 +1,46 @@
-# Session Progress - 2026-03-30
+# Session Progress - 2026-03-31
 
 ## Session Goals
-- Morale news ticker milestone messages (domain event, fires once per streak crossing)
-- Geometry challenges in Stadium View (Groundskeeper's Drill panel)
+- Verify Dani facility observation cards fire correctly in browser
+- Remove green styling from Owner's Box messages; replace with physics bump animations
+- Fix duplicate consecutive commentary lines in Owner's Box
 
 ## Completed Work
 
-### 1. Morale news ticker milestone messages ✅
-- New domain event `MORALE_TICKER_EVENT` fires exactly once per form-streak milestone crossing (W3, W5, L3, L5)
-- `detectFormMilestone()` + `FORM_MILESTONE_HEADLINES` added to `simulation/morale.ts`
-- `lastFormMilestone` field on `GameState` tracks last known milestone so re-fires don't happen
-- `handleSimulateWeek` in `handlers.ts` detects crossing by comparing prospective form to `state.lastFormMilestone`
-- `WEEK_ADVANCED` reducer resets `lastFormMilestone` to current form state (naturally returns `null` when no streak)
-- `NewsTicker.tsx` now reads `MORALE_TICKER_EVENT` from `state.events[]` instead of computing from live form — eliminates the "always showing" bug
+### 1. Dani facility observations — verified ✅
+- `generateDaniFacilityObservationEvents()` wired into `handleSimulateWeek` in `handlers.ts`
+- Fires roughly every 6–8 weeks with an inbox card observing a rival club's facility investment
+- Verified at Week 6: card appeared with correct amber "Dani Lopes · Operations" badge, proper Dani voice, "Noted. I'll keep an eye on it" single choice, "No financial impact" label
 
-### 2. Geometry challenges — Groundskeeper's Drill ✅
-- New `angles.ts` question bank: 8 questions (5 × D1 Year 8, 3 × D2 Year 9) — angles on a line, vertically opposite, triangle rules, polygon interior/exterior, parallel lines
-- Registered in `bank.ts` (`...anglesBank`)
-- `GeometryDrillCard` gains `onAttempt` callback; first submission dispatches `RECORD_MATH_ATTEMPT`
-- `StadiumView` below-fold: "📐 Groundskeeper's Drill" panel renders when `stadiumLevel >= 1`
-- `generateChallenge` called with topic override `'geometry'` (maps to AREA_AND_PERIMETER + ANGLES + SCALE_AND_PROPORTION + PROPERTIES_OF_SHAPES)
-- Verified in browser: panel appears after upgrading Stadium to Level 1; question + hints + submit all working
+### 2. Owner's Box physics animations ✅
+- Removed goal-green styling (`bg-pitch-green/10`, `text-pitch-green`, border, avatar ring)
+- Three-tier animation system using both `beatType` and `mood`:
+  - Normal messages → `animate-fade-in`
+  - CHANCE / NEAR_MISS beats → `animate-msg-bump origin-left` (springy single bump)
+  - Player GOAL reaction (`mood: 'elated'`) → `animate-msg-goal-bump origin-left` (quadruple flash, 1.4s)
+  - Player GOAL buildup (`mood: 'excited'`) → `animate-msg-bump origin-left` (single bump)
+  - Opposition GOAL reaction (`mood: 'frustrated'`) → `animate-msg-goal-bump-oppo origin-left` (double bump, 0.9s)
+- Three new tailwind keyframes added: `msgBump`, `msgGoalBump`, `msgGoalBumpOppo`
+- `origin-left` keeps scale anchored to the bubble's left edge
+
+### 3. No-duplicate commentary ✅
+- `pick()` in `commentary.ts` now tracks `lastPicked`; re-rolls once if same value would appear back-to-back
+- Preserves seeded determinism (at most one extra RNG draw, not a loop)
+- Verified: no consecutive identical messages across full Week 13 match
+
+### 4. Text polish (em-dash → period/comma) ✅
+- Replaced em-dashes throughout NPC dialogue: intro screen, events, club-events, social feed, facility card, commentary templates
 
 ## Architecture Notes
 
-- Domain events pattern: both features follow the `FINANCIAL_THRESHOLD_EVENT` precedent — fire once on crossing, store "last known" band in state
-- Worktree dist sync: domain changes always need `npm run build` in worktree dist then `cp -r dist/ /main/packages/domain/dist/`
-- `stadiumLevel >= 1` gate: Groundskeeper only appears once the stadium has been built (level 0 = derelict = no Kev on site)
+- Animation discriminant: `mood` field on `PhoneMessage` is used to distinguish player vs opposition goals; player buildup is `'excited'`, player reaction is `'elated'`, opposition is `'frustrated'`
+- `lastPicked` is closure-scoped inside `generateMatchTimeline()` — resets per match; no cross-match state leakage
 
 ## Current Status
 
 ### ✅ Working
-- Both features shipped and browser-verified
-- Domain dist synced
-- TypeScript clean
+- All features browser-verified across Week 12 + Week 13 matches
+- PR #89 open: https://github.com/Oaks3000/calculating-glory/pull/89
 
 ### 🟡 In Progress
 - Nothing
@@ -53,21 +60,18 @@ npm run dev --workspace=@calculating-glory/frontend
 ```
 
 Key files:
-- `packages/domain/src/events/types.ts` — MoraleTickerEvent
-- `packages/domain/src/simulation/morale.ts` — detectFormMilestone, FORM_MILESTONE_HEADLINES
-- `packages/domain/src/commands/handlers.ts` — morale event emission
-- `packages/domain/src/reducers/index.ts` — MORALE_TICKER_EVENT case + lastFormMilestone reset
-- `packages/domain/src/content/questions/angles.ts` — new angles bank
-- `packages/domain/src/content/questions/bank.ts` — anglesBank registration
-- `packages/frontend/src/components/stadium-view/GeometryDrillCard.tsx` — onAttempt callback
-- `packages/frontend/src/components/stadium-view/StadiumView.tsx` — Kev's Drill panel
+- `packages/domain/src/simulation/commentary.ts` — pick() duplicate fix + Dani event integration
+- `packages/domain/src/simulation/events.ts` — generateDaniFacilityObservationEvents()
+- `packages/domain/src/commands/handlers.ts` — Dani events wired into handleSimulateWeek
+- `packages/frontend/src/components/owner-box/OwnerBox.tsx` — KevBubble animation tiers
+- `packages/frontend/tailwind.config.js` — msgBump, msgGoalBump, msgGoalBumpOppo keyframes
 
 ## Next Session Goals
 
-1. **Commit this branch** and open PR against main
-2. **Balance pass** — full L2 → L1 play-through; observe growth/retirement, question difficulty progression
-3. **Multiple leagues** — League One NPC team data, division-aware match sim, promotion/relegation
+1. Merge PR #89
+2. Balance pass — full L2 → L1 play-through
+3. Pick next polish issue from #81/#82/#83/#85/#86
 
 ---
 
-**Status**: Morale ticker milestones + Groundskeeper's Drill both shipped. Browser verified. Ready to commit.
+**Status**: Owner's Box polish + Dani observations shipped. PR #89 open and browser-verified. Ready to merge.

--- a/.build/STATUS.md
+++ b/.build/STATUS.md
@@ -3,16 +3,16 @@ project: "Calculating Glory"
 type: "build"
 priority: 2
 phase: "Phase 8 — Polish"
-progress: 94
-lastUpdated: "2026-03-30"
-lastTouched: "2026-03-30"
+progress: 97
+lastUpdated: "2026-03-31"
+lastTouched: "2026-03-31"
 status: "in-progress"
 ---
 
 # Calculating Glory - Current Status
 
-**Phase:** Phase 8 — Polish (94% complete)
-**Last Updated:** 2026-03-30
+**Phase:** Phase 8 — Polish (97% complete)
+**Last Updated:** 2026-03-31
 
 ## What's Done
 
@@ -43,7 +43,7 @@ status: "in-progress"
 - Owner's Box: real-time Kev commentary over ~75 real seconds, 8 crowd states, 60+ templates
 - Val financial threshold inbox messages: amber/red/critical/recovery bands
 
-**Phase 8 — Polish (PR #80 + nifty-ride worktree)**
+**Phase 8 — Polish (PRs #80, #89 + open issues)**
 
 *PR #80 — Morale & Groundskeeper (merged):*
 - Morale news ticker milestone messages: W3, W5, L3, L5 streaks + morale high/low thresholds
@@ -53,16 +53,17 @@ status: "in-progress"
 - Architecture futureproofing for CIRCLES + VOLUME_AND_SURFACE_AREA (GCSE Higher)
 - `DiagramLibrary` + `diagram?` field threaded through QuestionTemplate → MathChallenge
 
-*nifty-ride worktree (open, not yet PR'd):*
-- **Intro spotlight**: each NPC beat reveals its corresponding CC section at full brightness; all others dimmed via per-section overlay divs (CSS opacity transition, not global filter)
-- **Single-message intro**: one card at a time, bottom-anchored — never covers the spotlighted section
-- **Club identity**: `[TEAM]` placeholder in Kev commentary (kickoff, goal reaction/aftermath, full-time win)
-- **Stadium name**: derived from club name at game start; `GameStartedEvent.stadiumName?` optional for backward compat
-- **Club + stadium naming flow**: "Name your club" step in new game setup; stadium auto-suggests, fully editable; names thread through to all NPCs and commentary
+*Also merged in #80: Intro spotlight, single-message intro, club identity ([TEAM] in commentary), club + stadium naming flow*
+
+*PR #89 — Owner's Box polish + Dani observations (open):*
+- **Owner's Box animations**: removed goal-green styling; physics bump system (fade-in / single bump / quadruple flash for player goals / double bump for opposition goals); tailwind keyframes `msg-bump`, `msg-goal-bump`, `msg-goal-bump-oppo`
+- **No-duplicate commentary**: `pick()` tracks `lastPicked`, re-rolls once to prevent identical back-to-back lines
+- **Dani facility observations**: wired into weekly sim — rival club observation inbox card every ~6–8 weeks
+- **Text polish**: em-dashes → periods/commas throughout NPC dialogue
 
 ## What's In Progress
 
-- nifty-ride worktree — polish batch 1, ready to PR
+- PR #89 — Owner's Box polish (open, ready to merge)
 - Open polish issues: #81 (match day), #82 (transfers), #83 (season arc), #85 (NPC cast), #86 (mobile)
 - Balance pass — passive, during play-testing
 

--- a/.build/STATUS.md
+++ b/.build/STATUS.md
@@ -43,7 +43,7 @@ status: "in-progress"
 - Owner's Box: real-time Kev commentary over ~75 real seconds, 8 crowd states, 60+ templates
 - Val financial threshold inbox messages: amber/red/critical/recovery bands
 
-**Phase 8 — Polish (PRs #80, #89 + open issues)**
+**Phase 8 — Polish (PRs #80, #88, #89 — all merged)**
 
 *PR #80 — Morale & Groundskeeper (merged):*
 - Morale news ticker milestone messages: W3, W5, L3, L5 streaks + morale high/low thresholds
@@ -55,7 +55,7 @@ status: "in-progress"
 
 *Also merged in #80: Intro spotlight, single-message intro, club identity ([TEAM] in commentary), club + stadium naming flow*
 
-*PR #89 — Owner's Box polish + Dani observations (open):*
+*PR #89 — Owner's Box polish + Dani observations (merged 2026-03-31):*
 - **Owner's Box animations**: removed goal-green styling; physics bump system (fade-in / single bump / quadruple flash for player goals / double bump for opposition goals); tailwind keyframes `msg-bump`, `msg-goal-bump`, `msg-goal-bump-oppo`
 - **No-duplicate commentary**: `pick()` tracks `lastPicked`, re-rolls once to prevent identical back-to-back lines
 - **Dani facility observations**: wired into weekly sim — rival club observation inbox card every ~6–8 weeks
@@ -63,8 +63,8 @@ status: "in-progress"
 
 ## What's In Progress
 
-- PR #89 — Owner's Box polish (open, ready to merge)
-- Open polish issues: #81 (match day), #82 (transfers), #83 (season arc), #85 (NPC cast), #86 (mobile)
+- #85 — NPC cast (Val/Marcus/Kev feel like a real cast)
+- #86 — mobile/touch feel
 - Balance pass — passive, during play-testing
 
 ## Blockers

--- a/packages/domain/src/commands/handlers.ts
+++ b/packages/domain/src/commands/handlers.ts
@@ -11,7 +11,7 @@ import { validateTransfer, validateFacilityUpgrade, validateStaffHire } from '..
 import { simulateMatch, clubToTeam, generateAITeam, Team } from '../simulation/match';
 import { generateSeasonFixtures, getWeekFixtures, matchSeed } from '../simulation/season';
 import { createRng } from '../simulation/rng';
-import { generateWeekEvents, generatePoachAttempts, generateMoraleThresholdEvents, generateFinancialThresholdEvents, generateDaniFacilityObservationEvents } from '../simulation/events';
+import { generateWeekEvents, generatePoachAttempts, generateMoraleThresholdEvents, generateFinancialThresholdEvents, generateDaniFacilityObservationEvents, generateKevFormMilestoneEvent, generateMarcusCommercialEvents } from '../simulation/events';
 import { computeWeeklyFinancials, computeRunwayBand } from '../simulation/revenue';
 import { detectFormMilestone, FORM_MILESTONE_HEADLINES } from '../simulation/morale';
 import { getTeamsForDivision } from '../data/division-teams';
@@ -342,6 +342,16 @@ function handleSimulateWeek(command: any, state: GameState): CommandResult {
         headline: FORM_MILESTONE_HEADLINES[currentMilestone],
         milestoneKey: currentMilestone,
       });
+      const kevMilestoneEvent = generateKevFormMilestoneEvent(currentMilestone, week, season);
+      events.push({
+        type: 'CLUB_EVENT_OCCURRED',
+        timestamp: now,
+        eventId: kevMilestoneEvent.id,
+        templateId: kevMilestoneEvent.templateId,
+        week,
+        clubId: state.club.id,
+        pendingEvent: kevMilestoneEvent,
+      });
     }
   }
 
@@ -433,6 +443,25 @@ function handleSimulateWeek(command: any, state: GameState): CommandResult {
   {
     const daniEvents = generateDaniFacilityObservationEvents(state, week, season, baseSeed);
     for (const pendingEvent of daniEvents) {
+      events.push({
+        type: 'CLUB_EVENT_OCCURRED',
+        timestamp: now,
+        eventId: pendingEvent.id,
+        templateId: pendingEvent.templateId,
+        week,
+        clubId: state.club.id,
+        pendingEvent,
+      });
+    }
+  }
+
+  // ── Marcus commercial observations ──────────────────────────────────────────
+
+  // Occasionally (roughly once every 5–6 weeks) Marcus sends a commercial
+  // observation inbox card — revenue opportunities, fan engagement, sponsorship.
+  {
+    const marcusEvents = generateMarcusCommercialEvents(state, week, season, baseSeed);
+    for (const pendingEvent of marcusEvents) {
       events.push({
         type: 'CLUB_EVENT_OCCURRED',
         timestamp: now,

--- a/packages/domain/src/data/free-agent-generator.ts
+++ b/packages/domain/src/data/free-agent-generator.ts
@@ -5,7 +5,7 @@
  * Deterministic — same seed always produces the same pool.
  *
  * Narrative context: these are journeymen and near-misses rattling around
- * the lower leagues. A few recognisable faces (sort of) among the journeymen.
+ * the lower leagues. All names are fictional.
  */
 
 import { Player, Position, PlayerAttributes } from '../types/player';
@@ -25,22 +25,17 @@ const DIVISION_QUALITY_BOOST: Record<Division, number> = {
   PREMIER_LEAGUE: 30,
 };
 
-// ─── Famous-ish parody names (8) ──────────────────────────────────────────────
-
-const PARODY_NAMES: string[] = [
-  'Lional Messy',
-  'Crystiano Ronoldo',
-  'Neymur Jr',
-  'Killian Mboppe',
-  'Errling Haland',
-  'Kevin De Bruyne',
-  'Virgil van Dijck',
-  'Mohammid Salah',
-];
-
-// ─── Plausible lower-league journeymen (52) ────────────────────────────────────
+// ─── Plausible lower-league journeymen (60) ────────────────────────────────────
 
 const JOURNEYMEN_NAMES: string[] = [
+  'Luca Fiorelli',
+  'Andres Cienfuegos',
+  'Tomasz Wierzbicki',
+  'Declan Murtagh',
+  'Oumar Sy',
+  'Nils Bergqvist',
+  'Davide Caruso',
+  'Thibault Renaudin',
   'Dale Hutchins',
   'Connor Farrell',
   'Matty Swann',
@@ -161,9 +156,7 @@ export function generateFreeAgentPool(seed: string, division: Division = 'LEAGUE
   const qualityBoost = DIVISION_QUALITY_BOOST[division];
   const rng = createRng(`${seed}-free-agents`);
 
-  // Build full name list: parody names first, then journeymen
-  // Shuffle both lists separately using rng for variety
-  const allNames = [...PARODY_NAMES, ...JOURNEYMEN_NAMES];
+  const allNames = [...JOURNEYMEN_NAMES];
 
   // Shuffle the name list deterministically
   const shuffledNames = [...allNames];

--- a/packages/domain/src/simulation/events.ts
+++ b/packages/domain/src/simulation/events.ts
@@ -807,3 +807,138 @@ export function generateDaniFacilityObservationEvents(
     resolved: false,
   }];
 }
+
+// ── Kev form milestone inbox cards ────────────────────────────────────────────
+
+export const KEV_FORM_MILESTONE_TEMPLATE_IDS = new Set([
+  'kev-form-milestone',
+]);
+
+const KEV_FORM_MILESTONE_MESSAGES: Record<'W3' | 'W5' | 'L3' | 'L5', { title: string; description: string }> = {
+  W3: {
+    title: 'Three wins on the bounce',
+    description: `Three on the bounce. Don't let it go to their heads — I won't — but the lads are in good nick. Shape has been solid, everyone's working hard. This is what it looks like when things click. Long way to go yet but I'll take it.`,
+  },
+  W5: {
+    title: 'Five straight wins',
+    description: `Five. I've been doing this a long time and five on the bounce still means something. The squad's confident, training has been sharp, and honestly we've deserved every point. Keep the heads down. Don't start believing the noise. But yeah. Five.`,
+  },
+  L3: {
+    title: 'Three defeats in a row',
+    description: `Three losses. Not going to dress it up. We've been off it and the results show it. I've had a word with the lads — it's not finger-pointing, it's about getting back to basics. We've done it before. We'll do it again. But we need to be honest about where we're at.`,
+  },
+  L5: {
+    title: 'Five defeats. We need to talk.',
+    description: `Five straight defeats. That's a bad run and I'm not going to pretend otherwise. The mood in the changing room isn't great. We need to look at everything, training, selection, the lot. I'm not panicking, but I need you to know it's serious. We have to turn this around.`,
+  },
+};
+
+/**
+ * Generate a Kev Mulligan inbox card when a form-streak milestone fires.
+ * Called from the handler alongside the MORALE_TICKER_EVENT.
+ */
+export function generateKevFormMilestoneEvent(
+  milestoneKey: 'W3' | 'W5' | 'L3' | 'L5',
+  week: number,
+  season: number,
+): PendingClubEvent {
+  const { title, description } = KEV_FORM_MILESTONE_MESSAGES[milestoneKey];
+  return {
+    id: `evt-S${season}-W${week}-kev-form-${milestoneKey}`,
+    templateId: 'kev-form-milestone',
+    week,
+    title,
+    description,
+    severity: 'minor',
+    npc: 'kev',
+    choices: [
+      {
+        id: 'noted',
+        label: 'Understood. Keep them focused.',
+        description: 'Acknowledge the run and move on.',
+      },
+    ],
+    resolved: false,
+  };
+}
+
+// ── Marcus commercial observations ────────────────────────────────────────────
+
+export const MARCUS_COMMERCIAL_TEMPLATE_IDS = new Set([
+  'marcus-commercial-observation',
+]);
+
+const COMMERCIAL_OBSERVATIONS = [
+  {
+    title: 'Season ticket push — worth a look',
+    observation: `Been running the numbers on season ticket holders vs walk-ups. The regulars spend more per head on matchday, they tell their mates, and we know exactly what revenue's coming in. I think there's a window here to run a push. Even picking up another twenty or thirty would make a difference to the budget.`,
+  },
+  {
+    title: 'Matchday revenue — there\'s more in this',
+    observation: `I keep looking at what we bring in on a matchday and thinking we're leaving money on the table. Programme sales, food, merchandise — none of it's bad but none of it's great either. Some clubs our size are pulling in noticeably more per head. Worth a conversation about what we can do differently.`,
+  },
+  {
+    title: 'Local sponsor interest',
+    observation: `Had a conversation with a local business this week. They're not ready to commit but they're interested. Kit sponsorship, pitch-side boards, that kind of thing. I'm not counting it until it's signed but I wanted you to know there's something to develop there. Sponsorship at our level is all about relationships.`,
+  },
+  {
+    title: 'Fan engagement is up',
+    observation: `Don't have hard numbers but the noise around the club feels different lately. More people talking about us, more faces I don't recognise at games. That kind of organic buzz doesn't happen by accident — the results have helped, obviously, but it's also the atmosphere we're building. Keep it going and it starts to show up in the revenue.`,
+  },
+  {
+    title: 'Away support — don\'t ignore it',
+    observation: `Noticed we're picking up a few more away fans at games. Small numbers but they're there. That's the kind of support that grows if you nurture it. Travel packages, early ticket access, that sort of thing. It's a long way off being significant but I always say: find the thing early and grow it properly.`,
+  },
+  {
+    title: 'Kit sales — a quick win',
+    observation: `Kit sales are ticking along but I think we can do better. People want to wear the badge when the team's doing well. We're in a decent window for a push. Online store, a post on the socials, maybe a signing session. Low cost, decent return. I can handle it if you're happy for me to.`,
+  },
+  {
+    title: 'Community ties — worth investing',
+    observation: `We've had a few local schools reach out about visits and coaching sessions. I know it's not directly commercial but hear me out — community work builds goodwill, goodwill builds fans, fans build revenue. It's a long loop but it's a real one. Worth putting some time in even if it doesn't pay off immediately.`,
+  },
+];
+
+/**
+ * Generate 0–1 Marcus Webb inbox commercial observation.
+ * Fires roughly once every 5–6 weeks in season, seeded and deterministic.
+ * One unresolved observation at a time.
+ */
+export function generateMarcusCommercialEvents(
+  state: GameState,
+  week: number,
+  season: number,
+  seed: string
+): PendingClubEvent[] {
+  if (state.phase === 'PRE_SEASON' || state.phase === 'SEASON_END') return [];
+  if (week === 0) return [];
+
+  // Don't stack — skip if an unresolved Marcus observation is already in the inbox
+  if (state.pendingEvents.some(
+    e => MARCUS_COMMERCIAL_TEMPLATE_IDS.has(e.templateId) && !e.resolved
+  )) return [];
+
+  // Seeded gate: roughly 1-in-6 chance per week
+  const rng = createRng(`${seed}-S${season}-W${week}-marcus-obs`);
+  if (rng.next() > 1 / 6) return [];
+
+  const obs = COMMERCIAL_OBSERVATIONS[Math.floor(rng.next() * COMMERCIAL_OBSERVATIONS.length)];
+
+  return [{
+    id: `evt-S${season}-W${week}-marcus-obs`,
+    templateId: 'marcus-commercial-observation',
+    week,
+    title: obs.title,
+    description: obs.observation,
+    severity: 'minor',
+    npc: 'marcus',
+    choices: [
+      {
+        id: 'noted',
+        label: 'Good thinking. Keep me posted.',
+        description: 'Acknowledge and move on.',
+      },
+    ],
+    resolved: false,
+  }];
+}

--- a/packages/frontend/src/components/command-centre/DataTiles.tsx
+++ b/packages/frontend/src/components/command-centre/DataTiles.tsx
@@ -30,7 +30,7 @@ function DataTile({ label, value, sub, trend, color, animateClass, onClick }: Ti
   return (
     <div
       className={[
-        'card flex flex-col gap-1 min-w-[120px]',
+        'card flex flex-col gap-1',
         animateClass ?? '',
         onClick ? 'cursor-pointer hover:border hover:border-data-blue/40 transition-colors' : '',
       ].join(' ')}
@@ -146,7 +146,7 @@ export function DataTiles({ state, gridMode, onBackroomClick, onAcumenClick }: D
   ];
 
   return (
-    <div className={gridMode ? 'grid grid-cols-4 gap-2' : 'flex flex-wrap gap-3'}>
+    <div className={gridMode ? 'grid grid-cols-2 sm:grid-cols-4 gap-2' : 'flex flex-wrap gap-3'}>
       {tiles.map(tile => (
         <DataTile key={tile.label} {...tile} />
       ))}

--- a/packages/frontend/src/components/intro/MathsChallenge.tsx
+++ b/packages/frontend/src/components/intro/MathsChallenge.tsx
@@ -67,6 +67,7 @@ export function MathsChallenge({ onResult }: Props) {
             <span className="absolute left-3 top-1/2 -translate-y-1/2 text-txt-muted text-sm">£</span>
             <input
               type="number"
+              inputMode="numeric"
               value={input}
               onChange={e => setInput(e.target.value)}
               onKeyDown={handleKeyDown}

--- a/packages/frontend/src/components/shared/ViewToggle.tsx
+++ b/packages/frontend/src/components/shared/ViewToggle.tsx
@@ -61,12 +61,12 @@ export function ViewToggle({
     <>
       <div className="flex items-center justify-between px-4 py-2 border-b border-bg-raised bg-bg-surface">
         {/* Left: Club info */}
-        <div className="flex items-center gap-4">
-          <div>
-            <h1 className="text-lg font-bold text-txt-primary tracking-tight">
+        <div className="flex items-center gap-4 min-w-0">
+          <div className="min-w-0">
+            <h1 className="text-lg font-bold text-txt-primary tracking-tight truncate max-w-[120px] sm:max-w-none">
               {state.club.name}
             </h1>
-            <p className="text-xs text-txt-muted">
+            <p className="text-xs text-txt-muted hidden sm:block">
               Season {state.season} · Week {state.currentWeek} ·{' '}
               <span className="capitalize">{state.phase.replace('_', ' ').toLowerCase()}</span>
             </p>

--- a/packages/frontend/src/components/transfer-market/TransferMarketSlideOver.tsx
+++ b/packages/frontend/src/components/transfer-market/TransferMarketSlideOver.tsx
@@ -172,7 +172,7 @@ function SquadFormationView({
                 const ovr = computeOverallRating(player);
                 const isExpanded = expandedId === player.id;
                 return (
-                  <div key={player.id} className="flex flex-col gap-1" style={{ minWidth: '140px', maxWidth: '200px' }}>
+                  <div key={player.id} className="flex flex-col gap-1 min-w-[120px] flex-1">
                     <button
                       onClick={() => setExpandedId(isExpanded ? null : player.id)}
                       className={`bg-bg-raised border rounded-card px-3 py-2 text-left w-full transition-colors hover:border-white/20 ${ovrBorderClass(ovr)} ${isExpanded ? 'border-opacity-80' : ''}`}
@@ -205,8 +205,7 @@ function SquadFormationView({
                 <button
                   key={`vacant-${i}`}
                   onClick={() => onFillPosition(pos)}
-                  className="bg-bg-raised border border-dashed border-white/20 rounded-card px-3 py-2 text-left hover:border-white/40 transition-colors"
-                  style={{ minWidth: '140px' }}
+                  className="bg-bg-raised border border-dashed border-white/20 rounded-card px-3 py-2 text-left hover:border-white/40 transition-colors min-w-[120px] flex-1"
                 >
                   <div className="text-xs text-txt-muted font-semibold">+ VACANT</div>
                   <div className="text-[10px] text-data-blue mt-0.5">Find a {pos} →</div>


### PR DESCRIPTION
## Summary

- **#85 — NPC cast depth**: Kev Mulligan now sends inbox cards on W3/W5/L3/L5 form streaks (dry, grounded voice). Marcus Webb sends periodic commercial observations every ~6 weeks (warm, revenue-focused), following the same pattern as Dani's facility observations.
- **#86 — Mobile layout**: DataTiles fixed to 2-col grid on mobile (was forcing overflow at 375px); ViewToggle club name truncates on mobile; transfer market inline `minWidth` styles replaced with Tailwind; MathsChallenge gets `inputMode="numeric"` for proper phone keyboard. Browser-verified at 375×812.
- **IP fix**: Removed all real-player-derived names from the free agent pool (including an unchanged "Kevin De Bruyne"). Replaced with 8 additional fictional journeymen. All 60 names are now fully invented.
- **Backlog/issues**: Logged free agent name expansion for multiplayer; issues #90 and #91 created on GitHub.

## Test plan

- [ ] Advance 3+ consecutive losses — Kev inbox card should appear alongside the morale ticker headline
- [ ] Advance ~6 weeks in season — Marcus commercial observation inbox card should appear
- [ ] Open Transfers slide-over — confirm no real player names in free agent pool
- [ ] Resize browser to 375px — Command Centre DataTiles should render 2-column with no horizontal scroll
- [ ] Open a maths challenge on mobile — numeric keyboard should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)