### PR TITLE
feat: NPC messages in Command Centre inbox (#95)

### DIFF
--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -29,6 +29,7 @@ export * from './simulation/match';
 export * from './simulation/season';
 export * from './simulation/events';
 export * from './simulation/commentary';
+export * from './simulation/npc-messages';
 
 // Validation
 export * from './validation/rules';

--- a/packages/frontend/src/components/command-centre/CommandCentre.tsx
+++ b/packages/frontend/src/components/command-centre/CommandCentre.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { GameState, GameEvent, GameCommand, PendingClubEvent } from '@calculating-glory/domain';
+import { GameState, GameEvent, GameCommand, PendingClubEvent, generateNpcMessages } from '@calculating-glory/domain';
 import { DataTiles } from './DataTiles';
 import { LeagueTable } from './LeagueTable';
 import { SquadAuditTable } from './SquadAuditTable';
@@ -59,6 +59,7 @@ export function CommandCentre({ state, events, dispatch, isLoading, onNavigateTo
   }
 
   const unresolvedEvents = state.pendingEvents.filter(e => !e.resolved);
+  const npcMessages = generateNpcMessages(state, events);
   const maxFacilityLevel = state.club.facilities.length > 0
     ? Math.max(...state.club.facilities.map(f => f.level))
     : 0;
@@ -149,6 +150,7 @@ export function CommandCentre({ state, events, dispatch, isLoading, onNavigateTo
               onError={setError}
               onMathChallenge={handleMathChallenge}
               onViewAll={() => setInboxOpen(true)}
+              npcMessages={npcMessages}
             />
             {dim('inbox')}
           </div>

--- a/packages/frontend/src/components/command-centre/InboxCard.tsx
+++ b/packages/frontend/src/components/command-centre/InboxCard.tsx
@@ -1,4 +1,4 @@
-import { GameEvent, GameCommand, PendingClubEvent, LeagueTableEntry } from '@calculating-glory/domain';
+import { GameEvent, GameCommand, PendingClubEvent, LeagueTableEntry, NpcMessage, NpcSender } from '@calculating-glory/domain';
 import { PendingEventCard } from './PendingEventCard';
 import {
   buildNotableMatches,
@@ -6,6 +6,15 @@ import {
   OUTCOME_STYLES,
   REASON_ORDER,
 } from './inboxUtils';
+
+// ── NPC sender display config ─────────────────────────────────────────────────
+
+const NPC_CONFIG: Record<NpcSender, { initial: string; name: string; avatarClass: string; nameClass: string }> = {
+  VAL:    { initial: 'V', name: 'Val Chen',       avatarClass: 'bg-warn-amber/20 text-warn-amber',   nameClass: 'text-warn-amber'   },
+  KEV:    { initial: 'K', name: 'Kev Mulligan',   avatarClass: 'bg-data-blue/20 text-data-blue',     nameClass: 'text-data-blue'    },
+  MARCUS: { initial: 'M', name: 'Marcus Webb',    avatarClass: 'bg-pitch-green/20 text-pitch-green', nameClass: 'text-pitch-green'  },
+  DANI:   { initial: 'D', name: 'Dani Osei',      avatarClass: 'bg-alert-red/20 text-alert-red',     nameClass: 'text-alert-red'    },
+};
 
 interface InboxCardProps {
   pendingEvents: PendingClubEvent[];
@@ -21,6 +30,7 @@ interface InboxCardProps {
   onError: (msg: string) => void;
   onMathChallenge: (event: PendingClubEvent) => void;
   onViewAll: () => void;
+  npcMessages?: NpcMessage[];
 }
 
 const PREVIEW_LIMIT = 4;
@@ -39,6 +49,7 @@ export function InboxCard({
   onError,
   onMathChallenge,
   onViewAll,
+  npcMessages = [],
 }: InboxCardProps) {
   const unresolvedDecisions = pendingEvents.filter(e => !e.resolved);
 
@@ -66,7 +77,7 @@ export function InboxCard({
   const displayNews    = newsItems.slice(0, previewNewsCount);
   const hiddenCount    = (totalMatches - previewMatchCount) + (totalNews - previewNewsCount);
 
-  const isEmpty = unresolvedDecisions.length === 0 && totalMatches === 0 && totalNews === 0;
+  const isEmpty = unresolvedDecisions.length === 0 && totalMatches === 0 && totalNews === 0 && npcMessages.length === 0;
 
   return (
     <div className="absolute inset-0 bg-bg-raised rounded-card p-4 overflow-hidden flex flex-col">
@@ -156,6 +167,35 @@ export function InboxCard({
                 </div>
               </div>
             ))}
+          </>
+        )}
+
+        {/* NPC character messages */}
+        {npcMessages.length > 0 && (
+          <>
+            {(unresolvedDecisions.length > 0 || displayMatches.length > 0) && (
+              <div className="border-t border-bg-deep/60 mt-0.5 mb-0.5" />
+            )}
+            <p className="text-xs2 text-txt-muted uppercase tracking-wider px-1">
+              From the Team
+            </p>
+            {npcMessages.map((msg) => {
+              const cfg = NPC_CONFIG[msg.sender];
+              return (
+                <div
+                  key={msg.id}
+                  className="flex items-start gap-2 px-3 py-2 rounded-card bg-bg-surface/80 border border-bg-deep/30"
+                >
+                  <div className={`shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold ${cfg.avatarClass}`}>
+                    {cfg.initial}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className={`text-xs2 font-semibold mb-0.5 ${cfg.nameClass}`}>{cfg.name}</p>
+                    <p className="text-xs leading-relaxed text-txt-primary">{msg.text}</p>
+                  </div>
+                </div>
+              );
+            })}
           </>
         )}
 


### PR DESCRIPTION
## Summary
- Exports `generateNpcMessages` from domain `index.ts`
- Calls it in `CommandCentre` (has access to full `GameState` + events)
- Adds a **"From the Team"** section to `InboxCard` with colour-coded NPC bubbles:
  - Val Chen — amber
  - Kev Mulligan — blue  
  - Marcus Webb — green
  - Dani Osei — red
- Section is hidden during `PRE_SEASON` (domain returns `[]`)

## Test plan
- [ ] Start a new game, advance to week 1 — "From the Team" section appears in inbox with Val weekly summary + Marcus squad report + Dani press update
- [ ] Win/lose a match — Kev post-match reaction appears
- [ ] Squad below 14 — Kev squad concern message appears
- [ ] Runway < 10 weeks — Val financial alert appears as second Val message
- [ ] No messages during PRE_SEASON

🤖 Generated with [Claude Code](https://claude.com/claude-code)