### PR TITLE
feat(#91): Phone-screen UI for Owner's Box

### DIFF
--- a/packages/frontend/src/components/owner-box/OwnerBox.tsx
+++ b/packages/frontend/src/components/owner-box/OwnerBox.tsx
@@ -25,28 +25,29 @@ interface VisibleMessage {
   beatType: BeatType;
 }
 
-// ── Crowd display config ───────────────────────────────────────────────────────
+// ── Crowd config ───────────────────────────────────────────────────────────────
 
-const CROWD_LABEL: Record<CrowdState, string> = {
-  MURMUR:      'Crowd murmuring',
+const CROWD_STATUS: Record<CrowdState, string> = {
+  MURMUR:      'Crowd murmuring…',
   BUILDING:    'Atmosphere building',
   TENSE:       'Tension in the stands',
-  ROAR:        'The crowd erupts',
+  ROAR:        'The crowd erupts! 🔥',
   GROAN:       'Collective groan',
-  CELEBRATION: 'Celebrating',
+  CELEBRATION: 'They\'re celebrating! 🎉',
   HOSTILE:     'Hostile reception',
   SILENT:      'Eerie silence',
 };
 
-const CROWD_COLOR: Record<CrowdState, string> = {
-  MURMUR:      'text-txt-muted',
-  BUILDING:    'text-warn-amber',
-  TENSE:       'text-warn-amber',
-  ROAR:        'text-data-blue',
-  GROAN:       'text-alert-red',
-  CELEBRATION: 'text-pitch-green',
-  HOSTILE:     'text-alert-red',
-  SILENT:      'text-txt-muted',
+// Subtle background tint per crowd state — CSS colour string
+const CROWD_TINT: Record<CrowdState, string> = {
+  MURMUR:      'rgba(30,40,55,0)',
+  BUILDING:    'rgba(251,191,36,0.04)',
+  TENSE:       'rgba(251,191,36,0.06)',
+  ROAR:        'rgba(59,130,246,0.08)',
+  GROAN:       'rgba(239,68,68,0.06)',
+  CELEBRATION: 'rgba(34,197,94,0.10)',
+  HOSTILE:     'rgba(239,68,68,0.08)',
+  SILENT:      'rgba(30,40,55,0)',
 };
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -77,39 +78,32 @@ export function OwnerBox({ timeline, playerTeamName, opponentTeamName, onComplet
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [visibleMessages]);
 
-  // Run the timeline — set up all timeouts on mount, clean up on unmount
+  // Run the timeline
   useEffect(() => {
     const timeouts: ReturnType<typeof setTimeout>[] = [];
 
     timeline.beats.forEach(beat => {
       const beatDelay = beat.realTimeOffset * 1000;
 
-      // Update scoreboard / minute / crowd / blip state at beat start
       timeouts.push(setTimeout(() => {
         setCurrentMinute(beat.matchMinute);
         setCurrentCrowd(beat.crowdState);
 
         if (beat.scoreboardUpdate) {
           setCurrentScore(prev => {
-            // Detect which side scored for the bounce animation
             if (beat.scoreboardUpdate!.home > prev.home) setScoreBounce('home');
             else if (beat.scoreboardUpdate!.away > prev.away) setScoreBounce('away');
             return beat.scoreboardUpdate!;
           });
-          // Reset bounce after animation completes
           timeouts.push(setTimeout(() => setScoreBounce(null), 600));
         }
 
-        // Drive blip state machine from beat type
         if (beat.type === 'GOAL') {
           const isPlayerGoal = beat.content.some(m => m.mood === 'elated');
           const homeScored = timeline.isHome ? isPlayerGoal : !isPlayerGoal;
           setBlipState(homeScored ? 'CELEBRATE_HOME' : 'CELEBRATE_AWAY');
-
           if (isPlayerGoal) setPlayerGoalFlash(true);
           else setOpponentGoalFlash(true);
-
-          // Reset flash and blip state after celebration
           timeouts.push(setTimeout(() => {
             setBlipState('RESET');
             setPlayerGoalFlash(false);
@@ -128,7 +122,6 @@ export function OwnerBox({ timeline, playerTeamName, opponentTeamName, onComplet
         }
       }, beatDelay));
 
-      // Reveal each message with stagger within the beat
       beat.content.forEach((msg, idx) => {
         timeouts.push(setTimeout(() => {
           setVisibleMessages(prev => [...prev, {
@@ -141,7 +134,6 @@ export function OwnerBox({ timeline, playerTeamName, opponentTeamName, onComplet
         }, beatDelay + (idx + 1) * 800));
       });
 
-      // After FULL_TIME messages reveal, show the continue button
       if (beat.type === 'FULL_TIME') {
         timeouts.push(setTimeout(() => {
           setCompleted(true);
@@ -154,49 +146,15 @@ export function OwnerBox({ timeline, playerTeamName, opponentTeamName, onComplet
   }, []);
 
   return (
-    <div className="fixed inset-0 bg-bg-deep flex flex-col z-50 overflow-hidden">
-
-      {/* ── Top bar ──────────────────────────────────────────────────────────── */}
-      <div className="shrink-0 flex items-center justify-between px-4 py-2.5 border-b border-bg-raised">
-        <span className="text-xs font-semibold text-txt-muted uppercase tracking-widest">
-          Owner's Box
-        </span>
-        <span className="text-xs font-mono text-txt-muted tabular-nums">
-          {currentMinute}'
-        </span>
-      </div>
-
-      {/* ── Scoreboard ───────────────────────────────────────────────────────── */}
-      <div className="shrink-0 flex items-center justify-center gap-6 py-3 bg-bg-surface border-b border-bg-raised">
-        <span
-          className={[
-            'text-sm font-semibold truncate max-w-[120px] text-right',
-            timeline.isHome ? 'text-txt-primary' : 'text-txt-muted',
-          ].join(' ')}
-        >
-          {homeTeam}
-        </span>
-        <div className="flex items-center gap-3 shrink-0">
-          <span className={`text-4xl font-bold text-txt-primary tabular-nums w-8 text-center ${scoreBounce === 'home' ? 'animate-score-bounce' : ''}`}>
-            {currentScore.home}
-          </span>
-          <span className="text-xl text-txt-muted">—</span>
-          <span className={`text-4xl font-bold text-txt-primary tabular-nums w-8 text-center ${scoreBounce === 'away' ? 'animate-score-bounce' : ''}`}>
-            {currentScore.away}
-          </span>
-        </div>
-        <span
-          className={[
-            'text-sm font-semibold truncate max-w-[120px]',
-            !timeline.isHome ? 'text-txt-primary' : 'text-txt-muted',
-          ].join(' ')}
-        >
-          {awayTeam}
-        </span>
-      </div>
-
-      {/* ── Pitch visualisation ──────────────────────────────────────────────── */}
-      <div className="shrink-0 py-2 px-4 bg-bg-deep border-b border-bg-raised/40">
+    <div
+      className="fixed inset-0 z-50 overflow-hidden transition-colors duration-1000"
+      style={{ backgroundColor: '#09090f' }}
+    >
+      {/* ── Background: blurred pitch ───────────────────────────────────────── */}
+      <div
+        className="absolute inset-0 flex items-center justify-center pointer-events-none
+                   scale-125 blur-sm opacity-[0.18] transition-opacity duration-700"
+      >
         <MatchPitch
           blipState={blipState}
           crowdState={currentCrowd}
@@ -205,66 +163,177 @@ export function OwnerBox({ timeline, playerTeamName, opponentTeamName, onComplet
           playerGoalFlash={playerGoalFlash}
           opponentGoalFlash={opponentGoalFlash}
         />
-        {/* Crowd state label below pitch */}
-        <div className="flex items-center justify-center pt-1">
-          <span className={`text-xs2 uppercase tracking-widest font-medium transition-colors duration-500 ${CROWD_COLOR[currentCrowd]}`}>
-            {CROWD_LABEL[currentCrowd]}
-          </span>
-        </div>
       </div>
 
-      {/* ── Message thread ───────────────────────────────────────────────────── */}
-      <div className="flex-1 overflow-y-auto px-4 py-4 flex flex-col gap-3">
-        {visibleMessages.map(msg => (
-          <KevBubble key={msg.id} text={msg.text} beatType={msg.beatType} mood={msg.mood} />
-        ))}
+      {/* ── Crowd tint overlay ──────────────────────────────────────────────── */}
+      <div
+        className="absolute inset-0 pointer-events-none transition-colors duration-1000"
+        style={{ backgroundColor: CROWD_TINT[currentCrowd] }}
+      />
 
-        {/* Typing indicator — shown when not complete and at least one message visible */}
-        {!completed && visibleMessages.length > 0 && (
-          <TypingIndicator />
-        )}
-
-        <div ref={bottomRef} />
+      {/* ── Ambient score ghost ─────────────────────────────────────────────── */}
+      <div className="absolute inset-x-0 top-[18%] flex justify-center pointer-events-none select-none">
+        <span className="text-[96px] font-black tabular-nums text-white/[0.04] leading-none tracking-tight">
+          {currentScore.home}–{currentScore.away}
+        </span>
       </div>
 
-      {/* ── Post-match result card (appears after FULL_TIME) ───────────────── */}
-      {completed && (
-        <div className="shrink-0 px-4 py-4 border-t border-bg-raised flex flex-col gap-3">
-          <PostMatchResult
-            finalScore={timeline.finalScore}
-            isHome={timeline.isHome}
-            playerTeamName={playerTeamName}
-            opponentTeamName={opponentTeamName}
-          />
-          <button
-            onClick={onComplete}
-            className="w-full py-3 rounded-card bg-data-blue text-white text-sm font-semibold
-                       hover:bg-data-blue/80 active:scale-95 transition-all duration-150"
-          >
-            Back to Command Centre
-          </button>
+      {/* ── Phone frame ─────────────────────────────────────────────────────── */}
+      <div className="absolute inset-0 flex items-center justify-center py-4 px-3">
+        <div
+          className="w-full max-w-[380px] h-full max-h-[720px]
+                     flex flex-col overflow-hidden
+                     rounded-[36px] border border-white/[0.12]
+                     shadow-[0_32px_80px_rgba(0,0,0,0.7),0_0_0_1px_rgba(255,255,255,0.04)]"
+          style={{ background: 'rgba(13,13,22,0.92)', backdropFilter: 'blur(24px)' }}
+        >
+          {/* ── Phone status bar ──────────────────────────────────────────── */}
+          <div className="shrink-0 flex items-center justify-between px-6 pt-3.5 pb-1">
+            <span className="text-[11px] font-semibold text-white/40 tabular-nums">9:41</span>
+            <div className="flex items-center gap-1.5">
+              {/* Signal bars */}
+              <svg width="17" height="12" viewBox="0 0 17 12" fill="none" className="opacity-40">
+                <rect x="0" y="8" width="3" height="4" rx="0.5" fill="white"/>
+                <rect x="4.5" y="5" width="3" height="7" rx="0.5" fill="white"/>
+                <rect x="9" y="2" width="3" height="10" rx="0.5" fill="white"/>
+                <rect x="13.5" y="0" width="3" height="12" rx="0.5" fill="white" opacity="0.35"/>
+              </svg>
+              {/* Battery */}
+              <svg width="22" height="12" viewBox="0 0 22 12" fill="none" className="opacity-40">
+                <rect x="0.5" y="0.5" width="18" height="11" rx="2.5" stroke="white"/>
+                <rect x="19.5" y="3.5" width="2" height="5" rx="1" fill="white"/>
+                <rect x="2" y="2" width="12" height="8" rx="1.5" fill="white"/>
+              </svg>
+            </div>
+          </div>
+
+          {/* ── Contact header ────────────────────────────────────────────── */}
+          <div className="shrink-0 px-4 pb-3 flex items-center gap-3">
+            {/* Avatar */}
+            <div className="shrink-0 w-10 h-10 rounded-full
+                            bg-data-blue/25 border border-data-blue/30
+                            flex items-center justify-center
+                            text-sm font-bold text-data-blue">
+              K
+            </div>
+
+            {/* Name + status */}
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-semibold text-txt-primary leading-tight">Kev Mulligan</p>
+              <p className="text-[10px] text-txt-muted leading-tight truncate transition-all duration-500">
+                {CROWD_STATUS[currentCrowd]}
+              </p>
+            </div>
+
+            {/* Score chip */}
+            <div
+              className="shrink-0 flex items-center gap-1.5
+                         bg-white/[0.06] border border-white/[0.08]
+                         rounded-full px-3 py-1.5"
+            >
+              <span className={`text-xs font-bold text-txt-primary tabular-nums transition-transform ${scoreBounce === 'home' ? 'animate-score-bounce' : ''}`}>
+                {currentScore.home}
+              </span>
+              <span className="text-[10px] text-txt-muted">–</span>
+              <span className={`text-xs font-bold text-txt-primary tabular-nums transition-transform ${scoreBounce === 'away' ? 'animate-score-bounce' : ''}`}>
+                {currentScore.away}
+              </span>
+              <span className="text-[10px] text-txt-muted/70 ml-0.5 tabular-nums">
+                {currentMinute}'
+              </span>
+            </div>
+          </div>
+
+          {/* Separator */}
+          <div className="shrink-0 mx-4 h-px bg-white/[0.06]" />
+
+          {/* ── Team names strip ──────────────────────────────────────────── */}
+          <div className="shrink-0 flex items-center justify-center gap-2 px-4 py-2">
+            <span className={`text-[11px] font-medium truncate max-w-[120px] text-right ${timeline.isHome ? 'text-txt-primary' : 'text-txt-muted/60'}`}>
+              {homeTeam}
+            </span>
+            <span className="text-[10px] text-txt-muted/40 shrink-0">vs</span>
+            <span className={`text-[11px] font-medium truncate max-w-[120px] ${!timeline.isHome ? 'text-txt-primary' : 'text-txt-muted/60'}`}>
+              {awayTeam}
+            </span>
+          </div>
+
+          {/* ── Message thread ────────────────────────────────────────────── */}
+          <div className="flex-1 overflow-y-auto px-4 py-3 flex flex-col gap-2.5">
+            {visibleMessages.map(msg => (
+              <PhoneBubble
+                key={msg.id}
+                text={msg.text}
+                beatType={msg.beatType}
+                mood={msg.mood}
+              />
+            ))}
+
+            {!completed && visibleMessages.length > 0 && <TypingIndicator />}
+
+            <div ref={bottomRef} />
+          </div>
+
+          {/* ── Full-time footer ──────────────────────────────────────────── */}
+          {completed ? (
+            <div className="shrink-0 px-4 pb-6 pt-3 flex flex-col gap-3">
+              <div className="h-px bg-white/[0.06] mx-0 mb-1" />
+              <PostMatchResult
+                finalScore={timeline.finalScore}
+                isHome={timeline.isHome}
+                playerTeamName={playerTeamName}
+                opponentTeamName={opponentTeamName}
+              />
+              <button
+                onClick={onComplete}
+                className="w-full py-3 rounded-[18px] bg-data-blue text-white text-sm font-semibold
+                           hover:bg-data-blue/80 active:scale-95 transition-all duration-150"
+              >
+                Back to Command Centre
+              </button>
+              {/* Home indicator */}
+              <div className="flex justify-center pt-1">
+                <div className="w-24 h-1 rounded-full bg-white/20" />
+              </div>
+            </div>
+          ) : (
+            <div className="shrink-0 pb-3 flex justify-center">
+              <div className="w-24 h-1 rounded-full bg-white/10" />
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </div>
   );
 }
 
-// ── Sub-components ────────────────────────────────────────────────────────────
+// ── Phone-style chat bubble ────────────────────────────────────────────────────
 
-function KevBubble({ text, beatType, mood }: { text: string; beatType: BeatType; mood: PhoneMessage['mood'] }) {
+function PhoneBubble({ text, beatType, mood }: { text: string; beatType: BeatType; mood: PhoneMessage['mood'] }) {
   const animClass =
-    beatType === 'GOAL' && mood === 'elated'      ? 'animate-msg-goal-bump origin-left'
-    : beatType === 'GOAL' && mood === 'frustrated' ? 'animate-msg-goal-bump-oppo origin-left'
-    : beatType === 'CHANCE' || beatType === 'NEAR_MISS' || (beatType === 'GOAL' && mood === 'excited') ? 'animate-msg-bump origin-left'
+    beatType === 'GOAL' && mood === 'elated'       ? 'animate-msg-goal-bump origin-left'
+    : beatType === 'GOAL' && mood === 'frustrated'  ? 'animate-msg-goal-bump-oppo origin-left'
+    : beatType === 'CHANCE' || beatType === 'NEAR_MISS' || (beatType === 'GOAL' && mood === 'excited')
+      ? 'animate-msg-bump origin-left'
     : 'animate-fade-in';
+
+  // Bubble colour shifts slightly with mood
+  const bubbleBg =
+    mood === 'elated'      ? 'bg-pitch-green/20 border-pitch-green/20'
+    : mood === 'frustrated'  ? 'bg-alert-red/15 border-alert-red/15'
+    : mood === 'worried'     ? 'bg-warn-amber/15 border-warn-amber/15'
+    : 'bg-white/[0.07] border-white/[0.06]';
+
   return (
-    <div className={`flex items-start gap-2.5 max-w-sm ${animClass}`}>
-      <div className="shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold bg-data-blue/20 text-data-blue">
+    <div className={`flex items-end gap-2 max-w-[86%] ${animClass}`}>
+      {/* Avatar */}
+      <div className="shrink-0 w-6 h-6 rounded-full bg-data-blue/25 border border-data-blue/30
+                      flex items-center justify-center text-[10px] font-bold text-data-blue mb-0.5">
         K
       </div>
-      <div className="rounded-card px-3 py-2 bg-bg-raised">
-        <p className="text-xs2 font-semibold text-data-blue mb-0.5">Kev Mulligan</p>
-        <p className="text-xs leading-relaxed text-txt-primary">
+      {/* Bubble */}
+      <div className={`rounded-[18px] rounded-bl-[4px] px-3.5 py-2.5 border ${bubbleBg}`}>
+        <p className="text-[13px] leading-relaxed text-txt-primary">
           {text}
         </p>
       </div>
@@ -277,7 +346,7 @@ function KevBubble({ text, beatType, mood }: { text: string; beatType: BeatType;
 const RESULT_CONFIG = {
   W: {
     badge: 'WIN',
-    badgeClass: 'bg-pitch-green/20 text-pitch-green border border-pitch-green/40',
+    badgeClass: 'bg-pitch-green/20 text-pitch-green border border-pitch-green/30',
     headlines: [
       'Three points! Brilliant.',
       'Get in! What a result.',
@@ -286,16 +355,16 @@ const RESULT_CONFIG = {
   },
   D: {
     badge: 'DRAW',
-    badgeClass: 'bg-warn-amber/20 text-warn-amber border border-warn-amber/40',
+    badgeClass: 'bg-warn-amber/20 text-warn-amber border border-warn-amber/30',
     headlines: [
       'A point on the board.',
-      'We\'ll take it. Heads up.',
-      'Could have been worse. Move on.',
+      "We'll take it. Heads up.",
+      "Could've been worse. Move on.",
     ],
   },
   L: {
     badge: 'DEFEAT',
-    badgeClass: 'bg-alert-red/20 text-alert-red border border-alert-red/40',
+    badgeClass: 'bg-alert-red/20 text-alert-red border border-alert-red/30',
     headlines: [
       'Tough one. Back to the training ground.',
       'Not good enough today. We regroup.',
@@ -317,18 +386,15 @@ function PostMatchResult({ finalScore, isHome, playerTeamName, opponentTeamName 
   const result: 'W' | 'D' | 'L' =
     playerGoals > opponentGoals ? 'W' : playerGoals < opponentGoals ? 'L' : 'D';
   const cfg = RESULT_CONFIG[result];
-
-  // Pick a deterministic headline from the list based on goal diff
   const headlineIdx = Math.abs(playerGoals - opponentGoals) % cfg.headlines.length;
-  const headline = cfg.headlines[headlineIdx];
 
   return (
-    <div className="bg-bg-raised rounded-card border border-bg-raised/60 px-4 py-3 flex items-center gap-4">
-      <span className={`text-xs font-bold px-2 py-1 rounded shrink-0 ${cfg.badgeClass}`}>
+    <div className="bg-white/[0.05] rounded-[18px] border border-white/[0.07] px-4 py-3 flex items-center gap-3">
+      <span className={`text-xs font-bold px-2.5 py-1 rounded-full shrink-0 ${cfg.badgeClass}`}>
         {cfg.badge}
       </span>
       <div className="flex-1 min-w-0">
-        <p className="text-xs font-semibold text-txt-primary truncate">{headline}</p>
+        <p className="text-xs font-semibold text-txt-primary truncate">{cfg.headlines[headlineIdx]}</p>
         <p className="text-[10px] text-txt-muted mt-0.5">
           {playerTeamName} {playerGoals} – {opponentGoals} {opponentTeamName}
         </p>
@@ -337,13 +403,16 @@ function PostMatchResult({ finalScore, isHome, playerTeamName, opponentTeamName 
   );
 }
 
+// ── Typing indicator ──────────────────────────────────────────────────────────
+
 function TypingIndicator() {
   return (
-    <div className="flex items-start gap-2.5 max-w-sm">
-      <div className="shrink-0 w-7 h-7 rounded-full bg-data-blue/20 flex items-center justify-center text-xs font-bold text-data-blue">
+    <div className="flex items-end gap-2 max-w-[86%] animate-fade-in">
+      <div className="shrink-0 w-6 h-6 rounded-full bg-data-blue/25 border border-data-blue/30
+                      flex items-center justify-center text-[10px] font-bold text-data-blue mb-0.5">
         K
       </div>
-      <div className="bg-bg-raised rounded-card px-3 py-3">
+      <div className="bg-white/[0.07] border border-white/[0.06] rounded-[18px] rounded-bl-[4px] px-4 py-3">
         <div className="flex gap-1 items-center">
           <span className="w-1.5 h-1.5 rounded-full bg-txt-muted animate-bounce" style={{ animationDelay: '0ms' }} />
           <span className="w-1.5 h-1.5 rounded-full bg-txt-muted animate-bounce" style={{ animationDelay: '150ms' }} />


### PR DESCRIPTION
## Summary

- Redesigns the Owner's Box as a phone screen — rounded 36px bezel, frosted glass panel, blurred pitch behind the glass
- Status bar: iOS-style 9:41 clock, signal bars, battery
- Contact header replaces scoreboard strip: Kev avatar + live score chip + crowd status text
- Ambient ghost score watermark sits behind the chat bubbles
- Crowd tint overlay shifts the background colour with atmosphere (green for celebration, red for groan, amber for tense)
- Chat bubbles styled as native phone messages (rounded-[18px] with 4px tail, mood-tinted backgrounds)
- Full-time result card updated with rounded pill badge + iOS home indicator
- All existing animation hooks preserved (score-bounce, msg-bump, goal-bump)

## Test plan

- [ ] Start a new game, advance to Week 1, kick off
- [ ] Owner's Box opens as phone frame with status bar and contact header
- [ ] Score chip updates live and bounces on goal
- [ ] Crowd status text in contact subline updates with atmosphere
- [ ] Background tint shifts colour with crowd state
- [ ] Blurred pitch visible behind the frosted glass
- [ ] Chat bubbles tint green (elated), red (frustrated), amber (worried)
- [ ] Full time: WIN/DRAW/DEFEAT badge appears, "Back to Command Centre" CTA works

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)