### PR TITLE
Polish batch 3: club identity, transfer drama, NPC depth, construction visuals, poaching (#28 #36 #82 #83 #84 #85 #86)

### DIFF
--- a/.build/NEXT.md
+++ b/.build/NEXT.md
@@ -1,7 +1,7 @@
 ---
 project: "Calculating Glory"
 type: "build"
-lastUpdated: "2026-03-31"
+lastUpdated: "2026-04-03"
 ---
 
 # Calculating Glory — Next Steps
@@ -59,33 +59,61 @@ lastUpdated: "2026-03-31"
 
 ---
 
+## Recently Completed (PRs #95–100, merged 2026-04-03)
+
+### ✅ NPC Message System
+- **Issue:** #95
+- **Status:** MERGED (PR #96)
+- Kev, Val, Marcus messages wired into Command Centre inbox
+- Message routing by sender with NPC avatar chips
+
+### ✅ Inbox Overflow Partial Fix
+- **Issue:** #92 (partial)
+- **Status:** MERGED (PR #97)
+- Pending decisions capped at 2 in InboxCard preview
+- PREVIEW_LIMIT = 4 controls total items shown
+
+### ✅ Post-Match Report Screen
+- **Issue:** #81
+- **Status:** MERGED (PR #98)
+- Full post-match summary after Owner's Box concludes
+
+### ✅ Owner's Box Phone-Screen UI
+- **Issue:** #91 (partial)
+- **Status:** MERGED (PR #99)
+- Mobile/phone-screen UI polish for Owner's Box
+
+### ✅ Commercial Facilities Panel
+- **Issue:** #87 (partial)
+- **Status:** MERGED (PR #100)
+- Commercial facility types open Val's ClubCommercialSlideOver
+- Groups CLUB_COMMERCIAL, FOOD_AND_BEVERAGE, FAN_ZONE, GROUNDS_SECURITY
+
+---
+
 ## Current Priority Queue
 
-### 1. 🔜 Season-End Experience
-- **Issue:** #91
-- **Priority:** HIGH — season loop completeness
-- Final table reveal, awards, promotion/relegation moment
-- "Next season" teaser
-
-### 2. 🔜 Inbox Overflow Fix
-- **Issue:** #92
-- **Priority:** HIGH — UX bug
-- Multiple events stacking on same week overflows inbox
-
-### 3. 🔜 Stadium View — Isometric Facility View
-- **Issue:** #87
-- **Priority:** MEDIUM — Phase 7 foundation
-- Facility info panels and upgrade actions from isometric view
-
-### 4. 🔜 Math Challenge Difficulty Scaling
+### 1. 🔄 Math Challenge Difficulty Scaling
 - **Issue:** #86
-- **Priority:** MEDIUM — educational quality
-- Early challenges too easy, late ones don't stretch
+- **Priority:** HIGH — educational quality
+- Progressive session difficulty: start D1, unlock D2 after 3 correct D1, unlock D3 after 3 correct D2
+- Brief unlock message in chat ("tougher challenges incoming")
+- Cap by MAX_DIFFICULTY_BY_LEVEL per curriculum level
 
-### 5. 🔜 Sponsor Negotiation
+### 2. 🔜 Sponsor Negotiation
 - **Issue:** #80
 - **Priority:** MEDIUM — decision density
 - Val presents deals, negotiate terms via maths challenge
+
+### 3. 🔜 Inbox Overflow — Full Fix
+- **Issue:** #92
+- **Priority:** MEDIUM — remaining stacking edge cases
+- Check NPC messages + pending events + news all showing correctly within PREVIEW_LIMIT
+
+### 4. 🔜 Stadium View — Remaining Facility Panels
+- **Issue:** #87 (remaining)
+- **Priority:** MEDIUM
+- Training, Medical, Scout, Youth Academy panels from isometric view
 
 ---
 

--- a/.build/STATUS.md
+++ b/.build/STATUS.md
@@ -3,16 +3,16 @@ project: "Calculating Glory"
 type: "build"
 priority: 2
 phase: "Phase 8 — Polish"
-progress: 98
-lastUpdated: "2026-03-31"
-lastTouched: "2026-03-31"
+progress: 99
+lastUpdated: "2026-04-03"
+lastTouched: "2026-04-03"
 status: "in-progress"
 ---
 
 # Calculating Glory - Current Status
 
-**Phase:** Phase 8 — Polish (98% complete)
-**Last Updated:** 2026-03-31
+**Phase:** Phase 8 — Polish (99% complete)
+**Last Updated:** 2026-04-03
 
 ## What's Done
 
@@ -71,18 +71,23 @@ status: "in-progress"
 - Goal celebration: radial pulse + blip convergence + scoreboard bounce
 - Crowd atmosphere glow, prefers-reduced-motion support
 
+*PRs #95–100 (merged 2026-04–03):*
+- NPC message system: Kev/Val/Marcus messages wired into Command Centre inbox (PR #96)
+- Inbox overflow partial fix: pending decisions capped at 2 in InboxCard preview (PR #97)
+- Post-match report screen after Owner's Box (PR #98)
+- Phone-screen UI polish for Owner's Box (PR #99)
+- Commercial facilities open Val's operations panel from Stadium View (PR #100)
+
 ## What's In Progress
 
-- #65 match pitch on branch `claude/plan-next-priorities-VHNXw`, ready to PR
+- #86 Math challenge difficulty scaling — progressive session difficulty gating
 - Balance pass — passive, during play-testing
 
 ## What's Next
 
-- #91 Season-end experience (final table, awards, promotion/relegation)
-- #92 Inbox overflow fix (multiple events stacking)
-- #87 Stadium view — isometric facility panels
-- #86 Math challenge difficulty scaling
-- #80 Sponsor negotiation
+- #80 Sponsor negotiation — Val presents deals, negotiate via math challenge
+- #92 Inbox overflow — fully resolve multi-event stacking (partial fix in PR #97)
+- #87 Stadium view — remaining isometric facility panels (commercial done in PR #100)
 
 ## Blockers
 

--- a/packages/domain/src/data/npc-templates.ts
+++ b/packages/domain/src/data/npc-templates.ts
@@ -251,3 +251,69 @@ export const DANI_RESULT_LOSS = [
   'More to navigate after that result. Nothing unmanageable, but I\'d rather have better news.',
   'Loss means the questions sharpen. I\'ll handle the comms side — you focus on the next result.',
 ];
+
+// ── Kev: extended streaks ──────────────────────────────────────────────────
+//
+// Fires on a 5-game winning/losing run. Distinct from the 3-game pools —
+// Kev is more emphatic when the streak has gone on this long.
+// Placeholders: [STREAK]
+
+/** Kev: 5+ game winning run. Quietly thrilled but still grounded. */
+export const KEV_STREAK_WIN_5 = [
+  'Five wins on the bounce. I keep waiting for us to slip up and it\'s not happening. The squad\'s in a brilliant place.',
+  '[STREAK] straight wins. I\'ve been doing this long enough to know — don\'t change a thing. Keep the rhythm going.',
+  'This is a proper run now. [STREAK] wins. The lads are competing like a team that believes it can go all the way.',
+  '[STREAK]-game winning streak. I don\'t want to jinx it but I\'m going to say it — this squad is something special right now.',
+  'That\'s [STREAK] in a row. At some point this stops being form and starts being standard. I like it.',
+];
+
+/** Kev: 5+ game losing run. Frank, not panicking, but serious. */
+export const KEV_STREAK_LOSS_5 = [
+  '[STREAK] straight defeats. I\'m not going to lie to you — that\'s a crisis. We need to figure this out before it gets worse.',
+  'Five losses. Morale in the dressing room is the lowest I\'ve seen it. The lads need a result, not just a pep talk.',
+  '[STREAK] games. That\'s not bad form, that\'s a serious problem. Something has to change — tactics, squad, something.',
+  'The run is [STREAK] now. Every manager goes through a bad patch. But this one needs to end this week.',
+  '[STREAK] defeats on the bounce. I\'ll be honest — I\'m worried. Not about my job, about the club. What\'s the plan?',
+];
+
+// ── Kev: table position reactions ──────────────────────────────────────────
+//
+// Fires when the club enters or holds a notable table position.
+// Kev picks this up because it directly affects the squad\'s mentality.
+// Placeholders: [POSITION]
+
+/** Kev: automatic promotion zone (top 3). Quietly excited, eyes on the prize. */
+export const KEV_PROMOTION_ZONE = [
+  'We\'re in the top three. I keep saying it to the lads — this is real. Don\'t throw it away.',
+  '[POSITION]th. The lads can see the promotion places. It\'s not a dream anymore. Don\'t let them think it is.',
+  'Top three. Every session this week I\'ve had to keep their feet on the ground. The focus has to stay sharp.',
+  'The table doesn\'t lie. [POSITION]th — we\'re in the hunt. Stay disciplined, don\'t get giddy.',
+  'Promotion places. We\'re there. Protect what we\'ve built — one game at a time.',
+];
+
+/** Kev: automatic relegation zone (bottom 4). Grim, practical, no drama. */
+export const KEV_RELEGATION_ZONE = [
+  'The table\'s honest. [POSITION]th — we\'re in the drop zone. I\'d rather say that clearly than dress it up.',
+  'Bottom four. Kev\'s not going to pretend otherwise. The lads know it. We need points, not excuses.',
+  '[POSITION]th. Relegation zone. Every point from here is massive. Simple.',
+  'We\'re in the places you don\'t want to be in. [POSITION]th. The squad\'s been told — no hiding, no pointing fingers.',
+  'Down in [POSITION]th. I\'ve kept squads up from worse. But it takes honesty and hard work from everyone.',
+];
+
+// ── Marcus: commercial observations ───────────────────────────────────────
+//
+// Fires roughly every 6 weeks. Marcus steps outside his scouting brief
+// to share an observation about the commercial side of the club — fan zone,
+// attendance, income trends. Warm, football-obsessed, slightly over-enthusiastic.
+// Placeholders: [POSITION], [INCOME], [BUDGET], [SQUAD]
+
+export const MARCUS_COMMERCIAL_OBS = [
+  'Not really my area, but I walked past the fan zone yesterday and it was buzzing. That atmosphere carries into the stadium — I genuinely believe it helps the lads.',
+  'Had a look at the matchday attendance numbers. When we\'re playing well, the ground fills up. The connection between results and revenue is real. Win more, earn more — simple.',
+  'Saw some of the hospitality figures. There\'s real money in making the matchday experience good. The commercial side matters more than people think.',
+  'The stadium\'s generating [INCOME]/week. That\'s the engine. Every facility upgrade is an investment in what we can build next. Worth knowing.',
+  'I know this is Val\'s territory, but I pay attention: the clubs that invest in the commercial side early are the ones who can afford better players later. Just saying.',
+  'Bit of unsolicited analysis: we\'re [POSITION]th in the league and our fanbase feels it. Winning brings people in, people in means income, income means better players. It\'s all connected.',
+  'Word from the youth players — they want to play for a club with a buzz about it. Commercial investment creates that. It\'s not just about money.',
+  'The food and beverage revenue on matchday is underrated. I know it sounds unglamorous but a well-run concession adds up over a season. Val\'s probably already told you this.',
+];

--- a/packages/domain/src/data/npc-templates.ts
+++ b/packages/domain/src/data/npc-templates.ts
@@ -14,6 +14,9 @@
  *   [SCORE]    — match scoreline e.g. "2–1"
  *   [FORM]     — last 5 results string e.g. "W W D L W"
  *   [SQUAD]    — current squad count
+ *   [STREAK]   — current streak length (wins or losses)
+ *   [CLUB]     — club name (e.g. "Hartfield FC")
+ *   [STADIUM]  — stadium name (e.g. "Calder Park")
  */
 
 // ── Val Okoro — Finance Director ───────────────────────────────────────────
@@ -21,22 +24,22 @@
 /** Net positive (income exceeds wages). Val is dry, never effusive. */
 export const VAL_SUMMARY_SURPLUS = [
   'Weekly position: income [INCOME], wages [WAGES]. Net [NET]/wk. Nothing requiring your attention.',
-  'Finances in order. [NET]/wk net surplus. Budget [BUDGET]. Keep it steady.',
+  '[CLUB] finances in order. [NET]/wk net surplus. Budget [BUDGET]. Keep it steady.',
   'Weekly summary: [INCOME] in, [WAGES] out. Net [NET]. Comfortable position.',
   'Wage bill covered, revenue ahead of it. Net [NET]/wk. Runway healthy.',
   '[NET] net per week at current rates. Budget [BUDGET]. No flags from me.',
   'Income [INCOME], outgoings [WAGES]. Surplus of [NET]/wk. Fine.',
-  'Clean week financially. [NET]/wk net. Nothing to worry about — yet.',
-  'Summary: we made money this week. [NET] net. Budget [BUDGET]. Good.',
+  'Clean week financially at [CLUB]. [NET]/wk net. Nothing to worry about — yet.',
+  'Summary: [CLUB] made money this week. [NET] net. Budget [BUDGET]. Good.',
 ];
 
 /** Burning slowly (runway 20+ weeks). Val is calm but watching. */
 export const VAL_SUMMARY_GREEN = [
   'Weekly position: wages [WAGES], income [INCOME]. Burn [NET]/wk. Runway [RUNWAY] weeks — comfortable.',
   'Wages [WAGES], revenue [INCOME]. Net [NET]/wk. Runway [RUNWAY] weeks. Fine for now.',
-  'Burning [NET]/wk at current rates. Budget [BUDGET], [RUNWAY] weeks of runway. Not a concern.',
+  '[CLUB] burning [NET]/wk at current rates. Budget [BUDGET], [RUNWAY] weeks of runway. Not a concern.',
   'Weekly summary: [INCOME] in, [WAGES] out. Net [NET]. [RUNWAY] weeks runway. Watching it.',
-  'Finances stable. [RUNWAY] weeks of runway at this burn rate. Keep an eye on wages.',
+  '[CLUB] finances stable. [RUNWAY] weeks of runway at this burn rate. Keep an eye on wages.',
   'Budget [BUDGET]. Burning [NET]/wk. [RUNWAY] weeks. Nothing urgent — but worth tracking.',
   'Wage bill [WAGES], income [INCOME]. Net [NET]/wk. Runway [RUNWAY] weeks. As expected.',
   'Weekly outgoings [WAGES], weekly revenue [INCOME]. Net [NET]. [RUNWAY] weeks. Steady.',
@@ -44,11 +47,11 @@ export const VAL_SUMMARY_GREEN = [
 
 /** Runway amber (10–20 weeks). Val is measured but pointed. */
 export const VAL_SUMMARY_AMBER = [
-  'Weekly burn [NET]/wk. Budget [BUDGET], runway [RUNWAY] weeks. Getting tighter. Worth watching.',
+  '[CLUB] weekly burn [NET]/wk. Budget [BUDGET], runway [RUNWAY] weeks. Getting tighter. Worth watching.',
   'Wages [WAGES] against income [INCOME]. Net [NET]/wk. Runway down to [RUNWAY] weeks. I\'d start thinking about this.',
   'Summary: burning [NET]/wk. [RUNWAY] weeks of runway left. Not critical, but not comfortable either.',
   'Budget [BUDGET]. Burn rate [NET]/wk. Runway [RUNWAY] weeks. You should have a plan if this doesn\'t improve.',
-  '[RUNWAY] weeks of runway at current burn. That\'s not a lot of buffer if something unexpected comes up.',
+  '[RUNWAY] weeks of runway at current burn. That\'s not a lot of buffer if something unexpected comes up at [CLUB].',
   'Wage bill [WAGES]. Revenue [INCOME]. Net [NET]/wk. [RUNWAY] weeks. I\'d flag this as a concern.',
   'Burning [NET]/wk. [RUNWAY] weeks until the budget\'s gone. This needs attention.',
   'Net [NET]/wk outgoing. [RUNWAY] weeks runway. I\'ll keep saying it until the number improves.',
@@ -56,9 +59,9 @@ export const VAL_SUMMARY_AMBER = [
 
 /** Runway red/critical (<10 weeks). Val is direct. */
 export const VAL_SUMMARY_RED = [
-  'Budget [BUDGET]. Burning [NET]/wk. Runway [RUNWAY] weeks. This is serious. We need to cut costs or find revenue.',
+  '[CLUB] budget [BUDGET]. Burning [NET]/wk. Runway [RUNWAY] weeks. This is serious. We need to cut costs or find revenue.',
   '[RUNWAY] weeks of runway. At this burn rate, that\'s not enough. Something has to change.',
-  'Wage bill [WAGES] exceeds income [INCOME] by [NET]/wk. Budget [BUDGET]. I\'m not going to dress this up — we\'re in trouble.',
+  'Wage bill [WAGES] exceeds income [INCOME] by [NET]/wk. Budget [BUDGET]. I\'m not going to dress this up — [CLUB] is in trouble.',
   'Net [NET]/wk outgoing. [RUNWAY] weeks left. This is the situation I\'ve been warning you about.',
   'Summary: [RUNWAY] weeks of runway. Wages [WAGES], revenue [INCOME]. We cannot sustain this.',
   '[RUNWAY] weeks. That\'s all. Something needs to change this week, not next week.',
@@ -88,15 +91,15 @@ export const VAL_ALERT_RED = [
 /** Post-match: win */
 export const KEV_POST_MATCH_WIN = [
   'That\'s three points. The lads gave everything today — [OPPONENT] didn\'t like it. [SCORE].',
-  'Get in. [SCORE] against [OPPONENT]. Exactly what we needed.',
+  'Get in. [SCORE] against [OPPONENT]. Exactly what [CLUB] needed.',
   '[SCORE]. [OPPONENT] was a tough ask today but the lads delivered. Happy.',
-  'Three points in the bag. [SCORE] vs [OPPONENT]. Massive for the table.',
+  'Three points in the bag. [SCORE] vs [OPPONENT]. Massive for [CLUB]\'s table.',
   'Job done. [SCORE] — [OPPONENT] didn\'t have an answer for us today.',
-  'The lads were brilliant. [SCORE] against [OPPONENT]. That\'s a statement result.',
-  '[SCORE]. Big win that. [OPPONENT] are no pushovers. The squad should be proud.',
-  'Three points. The way we played against [OPPONENT] today — that\'s the standard I want.',
+  'The lads were brilliant. [SCORE] against [OPPONENT]. That\'s a [CLUB] statement result.',
+  '[SCORE]. Big win that. [OPPONENT] are no pushovers. [CLUB] should be proud.',
+  'Three points. The way we played against [OPPONENT] today — that\'s the standard I want from [CLUB].',
   '[SCORE] vs [OPPONENT]. Couldn\'t ask for more from the lads. Brilliant.',
-  'That\'s the result we needed. [SCORE]. [OPPONENT] made it hard but we found a way.',
+  'That\'s the result [CLUB] needed. [SCORE]. [OPPONENT] made it hard but we found a way.',
 ];
 
 /** Post-match: draw */
@@ -115,44 +118,44 @@ export const KEV_POST_MATCH_DRAW = [
 
 /** Post-match: loss */
 export const KEV_POST_MATCH_LOSS = [
-  '[SCORE] against [OPPONENT]. Not good enough. The lads know it.',
+  '[SCORE] against [OPPONENT]. Not good enough. The [CLUB] lads know it.',
   'That one hurts. [SCORE] vs [OPPONENT]. We were second best today.',
-  'Loss. [SCORE]. [OPPONENT] were sharper, more clinical. We have to be better.',
+  'Loss. [SCORE]. [OPPONENT] were sharper, more clinical. [CLUB] has to be better.',
   '[SCORE] — [OPPONENT] deserved that. We didn\'t turn up in the key moments.',
-  'Not a good day. [SCORE] vs [OPPONENT]. A few things to sort in the week.',
+  'Not a good day for [CLUB]. [SCORE] vs [OPPONENT]. A few things to sort in the week.',
   '[SCORE]. We gave [OPPONENT] too much respect. We played scared.',
   'Beaten [SCORE] by [OPPONENT]. Disappointing. The response next week is what matters now.',
-  '[SCORE] against [OPPONENT]. Hard to take. But we don\'t have time to dwell.',
+  '[SCORE] against [OPPONENT]. Hard to take. But [CLUB] don\'t have time to dwell.',
   'The lads are quiet. [SCORE] vs [OPPONENT]. That one\'s on all of us.',
-  '[SCORE]. [OPPONENT] were better. Simple as that. We need to respond.',
+  '[SCORE]. [OPPONENT] were better. Simple as that. [CLUB] need to respond.',
 ];
 
 /** Kev: squad concern (squad < 14) */
 export const KEV_SQUAD_CONCERN = [
-  'Boss, we\'ve got [SQUAD] players. That\'s thin. One injury and we\'re in trouble.',
+  'Boss, [CLUB] has got [SQUAD] players. That\'s thin. One injury and we\'re in trouble.',
   'I need to flag the squad depth — [SQUAD] players is not enough. We need bodies.',
-  '[SQUAD] in the squad. I\'m not going to panic, but I am going to flag this every week until it changes.',
+  '[SQUAD] in the [CLUB] squad. I\'m not going to panic, but I am going to flag this every week until it changes.',
   'Squad\'s at [SQUAD]. One or two knocks and we\'re struggling to fill positions. Worth addressing.',
   'Just to put it on record: [SQUAD] players. We need more cover. I\'d rather say it now than after someone gets injured.',
-  'Boss, [SQUAD] is light. I know the budget\'s tight but we need to address squad depth.',
+  'Boss, [SQUAD] is light. I know the budget\'s tight but [CLUB] needs to address squad depth.',
   '[SQUAD] players. Any manager would tell you that\'s not enough. The free agent list has options.',
-  'We\'re running lean at [SQUAD]. Might be worth a look at the transfer market.',
+  '[CLUB]\'s running lean at [SQUAD]. Might be worth a look at the transfer market.',
 ];
 
 /** Kev: good run of form (win streak 3+) */
 export const KEV_FORM_GOOD = [
-  'The lads are flying right now. Don\'t change what\'s working.',
+  'The [CLUB] lads are flying right now. Don\'t change what\'s working.',
   'Three wins on the bounce — the squad\'s in a great place. Momentum is real.',
   'Brilliant run of form. The training ground investment is paying off.',
-  'The lads are believing right now. Keep giving them reasons to.',
-  'Form\'s exceptional. This is a squad that knows how to win.',
+  'The lads are believing right now. Keep giving [CLUB] reasons to.',
+  'Form\'s exceptional. This is a [CLUB] squad that knows how to win.',
 ];
 
 /** Kev: poor run of form (loss streak 3+) */
 export const KEV_FORM_POOR = [
-  'Three losses in a row. I\'m not going to sugar-coat it — we need to turn this around fast.',
+  'Three losses in a row. I\'m not going to sugar-coat it — [CLUB] need to turn this around fast.',
   'The lads need a result. Morale is taking a hit from this run.',
-  'Poor form. Three straight defeats. Something has to change.',
+  'Poor form. Three straight defeats. Something has to change at [CLUB].',
   'We\'re in a bad run. The table doesn\'t lie. We need to respond this week.',
   'Three losses. The dressing room is quiet. We need a win — not a draw, a win.',
 ];
@@ -165,9 +168,9 @@ export const KEV_FORM_POOR = [
 
 /** Squad depth: strong (≥17 players). Marcus is measured, competent. */
 export const MARCUS_SQUAD_STRONG = [
-  'Squad at [SQUAD]. Good depth — we can handle rotation without worrying about injuries.',
+  '[CLUB] squad at [SQUAD]. Good depth — we can handle rotation without worrying about injuries.',
   '[SQUAD] registered. Comfortable with the numbers. [AGENTS] agents on the market if you want to upgrade anyone.',
-  'Scouting summary: [SQUAD] in the building, [AGENTS] free agents available. Good position to be in.',
+  'Scouting summary: [SQUAD] in the building at [CLUB], [AGENTS] free agents available. Good position to be in.',
   '[SQUAD] players — solid. Keep an eye on the free agent list though; it moves quickly.',
   'Squad depth looking healthy at [SQUAD]. The market has [AGENTS] options if anything comes up.',
 ];
@@ -183,10 +186,10 @@ export const MARCUS_SQUAD_OK = [
 
 /** Squad depth: thin (<14 players). Marcus is pointed. */
 export const MARCUS_SQUAD_THIN = [
-  '[SQUAD] players. That\'s the kind of squad where one hamstring pull becomes a selection problem. [AGENTS] agents are available now.',
+  '[CLUB] have [SQUAD] players. That\'s the kind of squad where one hamstring pull becomes a selection problem. [AGENTS] agents are available now.',
   'Flagging again: [SQUAD] is too thin for a full season. [AGENTS] free agents out there — some decent options.',
   'Squad at [SQUAD]. I know Kev\'s said it too, but I\'ll add: the free agent list has [AGENTS] names on it right now.',
-  '[SQUAD]. We\'re a small injury away from real trouble. [AGENTS] agents available — some of them won\'t be there next week.',
+  '[SQUAD]. [CLUB] are a small injury away from real trouble. [AGENTS] agents available — some of them won\'t be there next week.',
   'I keep saying [SQUAD] isn\'t enough. [AGENTS] free agents available. Some of them are better than you\'d expect.',
 ];
 
@@ -213,8 +216,8 @@ export const MARCUS_MARKET_QUIET = [
 
 /** League position: strong (top 8). Dani is smooth, managing from a good place. */
 export const DANI_PRESS_POSITIVE = [
-  '[POSITION]th in the division. That\'s the kind of number that keeps the board quiet. Long may it continue.',
-  'Good week from a narrative standpoint. [POSITION]th place — people are talking positively.',
+  '[CLUB] are [POSITION]th in the division. That\'s the kind of number that keeps the board quiet. Long may it continue.',
+  'Good week from a narrative standpoint. [POSITION]th place — people are talking positively about [CLUB].',
   'Position [POSITION]: fans engaged, board comfortable, press asking the right questions. Keep it going.',
   'Board confidence is at [BOARD]%. That\'s a healthy margin to work with. Nothing urgent from my side.',
   '[POSITION]th. Honest answer: this is the easy part to manage. Let\'s not waste it.',
@@ -222,18 +225,18 @@ export const DANI_PRESS_POSITIVE = [
 
 /** League position: mid-table (9–18). Dani is measured, cautiously optimistic. */
 export const DANI_PRESS_NEUTRAL = [
-  '[POSITION]th. Solid mid-table. Not the story for the wrong reasons, which is fine by me.',
+  '[CLUB] are [POSITION]th. Solid mid-table. Not the story for the wrong reasons, which is fine by me.',
   'Position [POSITION] — board\'s watching, not panicking. That\'s the goal for now.',
   '[POSITION]th in the table. Board confidence at [BOARD]%. Manageable.',
-  'Narrative\'s quiet this week — [POSITION]th, nothing inflammatory. That\'s a result in itself.',
+  'Narrative\'s quiet this week — [CLUB] at [POSITION]th, nothing inflammatory. That\'s a result in itself.',
   '[POSITION]th. Nothing to shout about, nothing to manage down. Mid-table is its own kind of peace.',
 ];
 
 /** League position: danger zone (19+). Dani is frank, managing expectations. */
 export const DANI_PRESS_NEGATIVE = [
-  '[POSITION]th. We\'re in the part of the table where questions start. I\'m managing it — but they\'re coming.',
+  '[CLUB] are [POSITION]th. We\'re in the part of the table where questions start. I\'m managing it — but they\'re coming.',
   'Board confidence at [BOARD]%. At [POSITION]th, every result carries weight. I can shape the narrative, but results are the only real fix.',
-  'Position [POSITION] — local press has noticed. Nothing hostile yet, but I\'d rather we weren\'t here.',
+  'Position [POSITION] — local press has noticed [CLUB]. Nothing hostile yet, but I\'d rather we weren\'t here.',
   '[POSITION]th and the tone is shifting. I\'ll hold the line on comms, but I need results to work with.',
   'At [POSITION]th I can only do so much. [BOARD]% board confidence. Results move the dial, not press releases.',
 ];
@@ -260,20 +263,20 @@ export const DANI_RESULT_LOSS = [
 
 /** Kev: 5+ game winning run. Quietly thrilled but still grounded. */
 export const KEV_STREAK_WIN_5 = [
-  'Five wins on the bounce. I keep waiting for us to slip up and it\'s not happening. The squad\'s in a brilliant place.',
+  'Five wins on the bounce. I keep waiting for [CLUB] to slip up and it\'s not happening. The squad\'s in a brilliant place.',
   '[STREAK] straight wins. I\'ve been doing this long enough to know — don\'t change a thing. Keep the rhythm going.',
-  'This is a proper run now. [STREAK] wins. The lads are competing like a team that believes it can go all the way.',
-  '[STREAK]-game winning streak. I don\'t want to jinx it but I\'m going to say it — this squad is something special right now.',
+  'This is a proper run now. [STREAK] wins. The [CLUB] lads are competing like a team that believes it can go all the way.',
+  '[STREAK]-game winning streak. I don\'t want to jinx it but I\'m going to say it — this [CLUB] squad is something special right now.',
   'That\'s [STREAK] in a row. At some point this stops being form and starts being standard. I like it.',
 ];
 
 /** Kev: 5+ game losing run. Frank, not panicking, but serious. */
 export const KEV_STREAK_LOSS_5 = [
-  '[STREAK] straight defeats. I\'m not going to lie to you — that\'s a crisis. We need to figure this out before it gets worse.',
+  '[STREAK] straight defeats. I\'m not going to lie to you — that\'s a crisis for [CLUB]. We need to figure this out before it gets worse.',
   'Five losses. Morale in the dressing room is the lowest I\'ve seen it. The lads need a result, not just a pep talk.',
-  '[STREAK] games. That\'s not bad form, that\'s a serious problem. Something has to change — tactics, squad, something.',
+  '[STREAK] games. That\'s not bad form, that\'s a serious problem. Something has to change at [CLUB] — tactics, squad, something.',
   'The run is [STREAK] now. Every manager goes through a bad patch. But this one needs to end this week.',
-  '[STREAK] defeats on the bounce. I\'ll be honest — I\'m worried. Not about my job, about the club. What\'s the plan?',
+  '[STREAK] defeats on the bounce. I\'ll be honest — I\'m worried. Not about my job, about [CLUB]. What\'s the plan?',
 ];
 
 // ── Kev: table position reactions ──────────────────────────────────────────
@@ -284,20 +287,20 @@ export const KEV_STREAK_LOSS_5 = [
 
 /** Kev: automatic promotion zone (top 3). Quietly excited, eyes on the prize. */
 export const KEV_PROMOTION_ZONE = [
-  'We\'re in the top three. I keep saying it to the lads — this is real. Don\'t throw it away.',
+  '[CLUB] are in the top three. I keep saying it to the lads — this is real. Don\'t throw it away.',
   '[POSITION]th. The lads can see the promotion places. It\'s not a dream anymore. Don\'t let them think it is.',
   'Top three. Every session this week I\'ve had to keep their feet on the ground. The focus has to stay sharp.',
-  'The table doesn\'t lie. [POSITION]th — we\'re in the hunt. Stay disciplined, don\'t get giddy.',
-  'Promotion places. We\'re there. Protect what we\'ve built — one game at a time.',
+  'The table doesn\'t lie. [CLUB] are [POSITION]th — we\'re in the hunt. Stay disciplined, don\'t get giddy.',
+  'Promotion places. [CLUB] are there. Protect what we\'ve built — one game at a time.',
 ];
 
 /** Kev: automatic relegation zone (bottom 4). Grim, practical, no drama. */
 export const KEV_RELEGATION_ZONE = [
-  'The table\'s honest. [POSITION]th — we\'re in the drop zone. I\'d rather say that clearly than dress it up.',
-  'Bottom four. Kev\'s not going to pretend otherwise. The lads know it. We need points, not excuses.',
+  'The table\'s honest. [CLUB] are [POSITION]th — we\'re in the drop zone. I\'d rather say that clearly than dress it up.',
+  'Bottom four. I\'m not going to pretend otherwise. The lads know it. [CLUB] need points, not excuses.',
   '[POSITION]th. Relegation zone. Every point from here is massive. Simple.',
-  'We\'re in the places you don\'t want to be in. [POSITION]th. The squad\'s been told — no hiding, no pointing fingers.',
-  'Down in [POSITION]th. I\'ve kept squads up from worse. But it takes honesty and hard work from everyone.',
+  '[CLUB] are in the places you don\'t want to be. [POSITION]th. The squad\'s been told — no hiding, no pointing fingers.',
+  'Down in [POSITION]th. I\'ve kept squads up from worse. But [CLUB] need honesty and hard work from everyone.',
 ];
 
 // ── Marcus: commercial observations ───────────────────────────────────────
@@ -308,12 +311,12 @@ export const KEV_RELEGATION_ZONE = [
 // Placeholders: [POSITION], [INCOME], [BUDGET], [SQUAD]
 
 export const MARCUS_COMMERCIAL_OBS = [
-  'Not really my area, but I walked past the fan zone yesterday and it was buzzing. That atmosphere carries into the stadium — I genuinely believe it helps the lads.',
-  'Had a look at the matchday attendance numbers. When we\'re playing well, the ground fills up. The connection between results and revenue is real. Win more, earn more — simple.',
-  'Saw some of the hospitality figures. There\'s real money in making the matchday experience good. The commercial side matters more than people think.',
-  'The stadium\'s generating [INCOME]/week. That\'s the engine. Every facility upgrade is an investment in what we can build next. Worth knowing.',
+  'Not really my area, but I walked past the fan zone at [STADIUM] yesterday and it was buzzing. That atmosphere carries into the ground — I genuinely believe it helps the lads.',
+  'Had a look at the matchday attendance numbers. When [CLUB] are playing well, the ground fills up. The connection between results and revenue is real. Win more, earn more — simple.',
+  'Saw some of the hospitality figures. There\'s real money in making the matchday experience at [STADIUM] good. The commercial side matters more than people think.',
+  '[STADIUM]\'s generating [INCOME]/week. That\'s the engine. Every facility upgrade is an investment in what [CLUB] can build next. Worth knowing.',
   'I know this is Val\'s territory, but I pay attention: the clubs that invest in the commercial side early are the ones who can afford better players later. Just saying.',
-  'Bit of unsolicited analysis: we\'re [POSITION]th in the league and our fanbase feels it. Winning brings people in, people in means income, income means better players. It\'s all connected.',
-  'Word from the youth players — they want to play for a club with a buzz about it. Commercial investment creates that. It\'s not just about money.',
-  'The food and beverage revenue on matchday is underrated. I know it sounds unglamorous but a well-run concession adds up over a season. Val\'s probably already told you this.',
+  'Bit of unsolicited analysis: [CLUB] are [POSITION]th in the league and the fanbase feels it. Winning brings people in, people in means income, income means better players. It\'s all connected.',
+  'Word from the youth players — they want to play for a club with a buzz about it. Commercial investment creates that at [CLUB]. It\'s not just about money.',
+  'The food and beverage revenue on matchday at [STADIUM] is underrated. I know it sounds unglamorous but a well-run concession adds up over a season. Val\'s probably already told you this.',
 ];

--- a/packages/domain/src/simulation/events.ts
+++ b/packages/domain/src/simulation/events.ts
@@ -341,6 +341,10 @@ export function generatePoachAttempts(
       npcClubId: npcClub.id,
       npcClubName: npcClub.name,
       offeredFee: fee,
+      playerName: target.name,
+      playerPosition: target.position,
+      playerOverall: computeOverallRating(target),
+      playerWage: target.wage,
     },
     choices: [
       {

--- a/packages/domain/src/simulation/npc-messages.ts
+++ b/packages/domain/src/simulation/npc-messages.ts
@@ -127,6 +127,8 @@ export function generateNpcMessages(
     POSITION: playerPosition > 0 ? String(playerPosition) : '?',
     TOTAL:    String(state.league.entries.length),
     BOARD:    String(state.boardConfidence),
+    CLUB:     state.club.name,
+    STADIUM:  state.club.stadium.name,
   };
 
   // ── Val weekly summary ─────────────────────────────────────────────────

--- a/packages/domain/src/simulation/npc-messages.ts
+++ b/packages/domain/src/simulation/npc-messages.ts
@@ -24,11 +24,16 @@ import {
   KEV_SQUAD_CONCERN,
   KEV_FORM_GOOD,
   KEV_FORM_POOR,
+  KEV_STREAK_WIN_5,
+  KEV_STREAK_LOSS_5,
+  KEV_PROMOTION_ZONE,
+  KEV_RELEGATION_ZONE,
   MARCUS_SQUAD_STRONG,
   MARCUS_SQUAD_OK,
   MARCUS_SQUAD_THIN,
   MARCUS_MARKET_BUSY,
   MARCUS_MARKET_QUIET,
+  MARCUS_COMMERCIAL_OBS,
   DANI_PRESS_POSITIVE,
   DANI_PRESS_NEUTRAL,
   DANI_PRESS_NEGATIVE,
@@ -45,7 +50,10 @@ export type NpcMessageCategory =
   | 'POST_MATCH'
   | 'FINANCIAL_ALERT'
   | 'SQUAD_CONCERN'
-  | 'FORM_UPDATE';
+  | 'FORM_UPDATE'
+  | 'STREAK_UPDATE'
+  | 'TABLE_UPDATE'
+  | 'COMMERCIAL_UPDATE';
 
 export interface NpcMessage {
   /** Stable ID for React keys: `${sender}-${category}-w${week}-s${season}` */
@@ -205,13 +213,38 @@ export function generateNpcMessages(
       category: 'POST_MATCH',
     });
 
-    // Kev form update — only after a 3+ streak, once per run
+    // Kev streak messages — differentiate 3-game and 5-game runs
     const form = state.club.form;
     if (form.length >= 3) {
+      const last5 = form.slice(-5);
       const last3 = form.slice(-3);
-      const allWin = last3.every(r => r === 'W');
-      const allLoss = last3.every(r => r === 'L');
-      if (allWin) {
+      const win5  = last5.length >= 5 && last5.every(r => r === 'W');
+      const loss5 = last5.length >= 5 && last5.every(r => r === 'L');
+      const win3  = last3.every(r => r === 'W');
+      const loss3 = last3.every(r => r === 'L');
+
+      if (win5) {
+        // 5-game win streak — emphatic
+        messages.push({
+          id: `KEV-STREAK_UPDATE-w${week}-s${season}`,
+          sender: 'KEV',
+          text: fillPlaceholders(pick(KEV_STREAK_WIN_5, rng), { ...fillVars, STREAK: String(last5.filter(r => r === 'W').length) }),
+          week,
+          season,
+          category: 'STREAK_UPDATE',
+        });
+      } else if (loss5) {
+        // 5-game loss streak — serious
+        messages.push({
+          id: `KEV-STREAK_UPDATE-w${week}-s${season}`,
+          sender: 'KEV',
+          text: fillPlaceholders(pick(KEV_STREAK_LOSS_5, rng), { ...fillVars, STREAK: String(last5.filter(r => r === 'L').length) }),
+          week,
+          season,
+          category: 'STREAK_UPDATE',
+        });
+      } else if (win3) {
+        // 3-game win streak (not yet 5)
         messages.push({
           id: `KEV-FORM_UPDATE-w${week}-s${season}`,
           sender: 'KEV',
@@ -220,7 +253,8 @@ export function generateNpcMessages(
           season,
           category: 'FORM_UPDATE',
         });
-      } else if (allLoss) {
+      } else if (loss3) {
+        // 3-game loss streak (not yet 5)
         messages.push({
           id: `KEV-FORM_UPDATE-w${week}-s${season}`,
           sender: 'KEV',
@@ -231,6 +265,34 @@ export function generateNpcMessages(
         });
       }
     }
+  }
+
+  // ── Kev table position reaction ────────────────────────────────────────
+  // Fire once when entering promo/relegation zone — seeded so it doesn't fire every week.
+  // Use week % 3 === 0 as a simple throttle (not every week, not too rare).
+
+  const relegationStart = state.league.entries.length - (state.league.relegation?.length ?? 4) + 1;
+  const inPromoAuto     = playerPosition >= 1 && playerPosition <= state.league.automaticPromotion;
+  const inRelegation    = playerPosition >= relegationStart;
+
+  if (inPromoAuto && week % 3 === 1) {
+    messages.push({
+      id: `KEV-TABLE_UPDATE-promo-w${week}-s${season}`,
+      sender: 'KEV',
+      text: fillPlaceholders(pick(KEV_PROMOTION_ZONE, rng), fillVars),
+      week,
+      season,
+      category: 'TABLE_UPDATE',
+    });
+  } else if (inRelegation && week % 3 === 1) {
+    messages.push({
+      id: `KEV-TABLE_UPDATE-rele-w${week}-s${season}`,
+      sender: 'KEV',
+      text: fillPlaceholders(pick(KEV_RELEGATION_ZONE, rng), fillVars),
+      week,
+      season,
+      category: 'TABLE_UPDATE',
+    });
   }
 
   // ── Kev squad concern ──────────────────────────────────────────────────
@@ -282,6 +344,21 @@ export function generateNpcMessages(
       week,
       season,
       category: 'FINANCIAL_ALERT',
+    });
+  }
+
+  // ── Marcus commercial observation (~every 6 weeks) ─────────────────────
+  // Marcus steps outside his scouting brief to share a commercial observation.
+  // Seeded to week 2, 8, 14, 20, 26, 32, 38, 44 (week % 6 === 2).
+
+  if (week % 6 === 2) {
+    messages.push({
+      id: `MARCUS-COMMERCIAL_UPDATE-w${week}-s${season}`,
+      sender: 'MARCUS',
+      text: fillPlaceholders(pick(MARCUS_COMMERCIAL_OBS, rng), fillVars),
+      week,
+      season,
+      category: 'COMMERCIAL_UPDATE',
     });
   }
 

--- a/packages/domain/src/types/game-state-updated.ts
+++ b/packages/domain/src/types/game-state-updated.ts
@@ -79,6 +79,11 @@ export interface PendingClubEvent {
     npcClubId?: string;
     npcClubName?: string;
     offeredFee?: number;
+    /** Snapshot of target player's details at time of bid (avoids squad lookup in UI) */
+    playerName?: string;
+    playerPosition?: string;
+    playerOverall?: number;
+    playerWage?: number;
   };
 }
 

--- a/packages/domain/tsconfig.json
+++ b/packages/domain/tsconfig.json
@@ -13,6 +13,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "allowSyntheticDefaultImports": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/packages/frontend/src/components/command-centre/CommandCentre.tsx
+++ b/packages/frontend/src/components/command-centre/CommandCentre.tsx
@@ -101,6 +101,7 @@ export function CommandCentre({ state, events, dispatch, isLoading, onNavigateTo
           stadiumName={state.club.stadium.name}
           leagueEntries={state.league.entries}
           squad={state.club.squad}
+          freeAgents={state.freeAgentPool ?? []}
           currentWeek={state.currentWeek}
         />
         {dim('news-ticker')}

--- a/packages/frontend/src/components/command-centre/CommandCentre.tsx
+++ b/packages/frontend/src/components/command-centre/CommandCentre.tsx
@@ -102,6 +102,7 @@ export function CommandCentre({ state, events, dispatch, isLoading, onNavigateTo
           leagueEntries={state.league.entries}
           squad={state.club.squad}
           freeAgents={state.freeAgentPool ?? []}
+          pendingEvents={state.pendingEvents}
           currentWeek={state.currentWeek}
         />
         {dim('news-ticker')}

--- a/packages/frontend/src/components/command-centre/DataTiles.tsx
+++ b/packages/frontend/src/components/command-centre/DataTiles.tsx
@@ -30,7 +30,7 @@ function DataTile({ label, value, sub, trend, color, animateClass, onClick }: Ti
   return (
     <div
       className={[
-        'card flex flex-col gap-1 min-w-[120px]',
+        'card flex flex-col gap-1 min-w-0',
         animateClass ?? '',
         onClick ? 'cursor-pointer hover:border hover:border-data-blue/40 transition-colors' : '',
       ].join(' ')}
@@ -146,7 +146,7 @@ export function DataTiles({ state, gridMode, onBackroomClick, onAcumenClick }: D
   ];
 
   return (
-    <div className={gridMode ? 'grid grid-cols-4 gap-2' : 'flex flex-wrap gap-3'}>
+    <div className={gridMode ? 'grid grid-cols-2 sm:grid-cols-4 gap-2' : 'flex flex-wrap gap-3'}>
       {tiles.map(tile => (
         <DataTile key={tile.label} {...tile} />
       ))}

--- a/packages/frontend/src/components/command-centre/NewsTicker.tsx
+++ b/packages/frontend/src/components/command-centre/NewsTicker.tsx
@@ -1,6 +1,14 @@
 import { GameEvent, MatchSimulatedEvent, MoraleTickerEvent, Player, avgSquadMorale, isUnsettled } from '@calculating-glory/domain';
 import { LeagueTableEntry } from '@calculating-glory/domain';
 
+// ── Ordinal helper ──────────────────────────────────────────────────────────
+
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] ?? s[v] ?? s[0]);
+}
+
 interface NewsTickerProps {
   events: GameEvent[];
   clubId: string;
@@ -9,6 +17,119 @@ interface NewsTickerProps {
   leagueEntries: LeagueTableEntry[];
   squad: Player[];
   currentWeek?: number;
+}
+
+// ── Season arc headlines ────────────────────────────────────────────────────
+//
+// Narrative headlines derived from the current state of the season.
+// Fire on streak milestones, zone entries, and new best-result records.
+// Added to the tail of the ticker so they appear alongside match scores.
+
+function buildSeasonArcHeadlines(
+  events: GameEvent[],
+  clubId: string,
+  clubName: string,
+  leagueEntries: LeagueTableEntry[],
+  currentWeek?: number,
+): string[] {
+  if (!currentWeek || currentWeek < 3) return [];
+
+  const headlines: string[] = [];
+  const nameMap = new Map(leagueEntries.map(e => [e.clubId, e.clubName]));
+
+  // ── Compute form from events ─────────────────────────────────────────────
+  const playerMatches = (events.filter(e =>
+    e.type === 'MATCH_SIMULATED' &&
+    (e as MatchSimulatedEvent).homeTeamId === clubId ||
+    (e.type === 'MATCH_SIMULATED' && (e as MatchSimulatedEvent).awayTeamId === clubId)
+  ) as MatchSimulatedEvent[]);
+
+  if (playerMatches.length < 3) return headlines;
+
+  type Result = 'W' | 'D' | 'L';
+  const results: Result[] = playerMatches.map(m => {
+    const isHome = m.homeTeamId === clubId;
+    const p = isHome ? m.homeGoals : m.awayGoals;
+    const o = isHome ? m.awayGoals : m.homeGoals;
+    return p > o ? 'W' : p < o ? 'L' : 'D';
+  });
+
+  // Current streak
+  const latest = results[results.length - 1];
+  let streak = 0;
+  for (let i = results.length - 1; i >= 0; i--) {
+    if (results[i] === latest) streak++;
+    else break;
+  }
+
+  // ── Win streak milestones (3 / 5 / 7+) ──────────────────────────────────
+  if (latest === 'W') {
+    if (streak === 3) headlines.push(`🔥 ${clubName} on a 3-game winning run — momentum building`);
+    else if (streak === 5) headlines.push(`🔥 Five straight wins — ${clubName} are flying`);
+    else if (streak === 7) headlines.push(`🔥 Seven in a row — one of the best runs in the division`);
+    else if (streak >= 9) headlines.push(`🔥 ${streak}-game winning run — extraordinary form from ${clubName}`);
+  }
+
+  // ── Loss streak milestones ───────────────────────────────────────────────
+  if (latest === 'L') {
+    if (streak === 3) headlines.push(`⚠ 3 straight defeats — the run has to end`);
+    else if (streak === 5) headlines.push(`⚠ Five straight defeats — crisis point for ${clubName}`);
+    else if (streak >= 7) headlines.push(`⚠ ${streak} games without a win — alarm bells ringing at ${clubName}`);
+  }
+
+  // ── Unbeaten run (mix of W/D, no L for 5+) ──────────────────────────────
+  if (latest !== 'L') {
+    let unbeaten = 0;
+    for (let i = results.length - 1; i >= 0; i--) {
+      if (results[i] !== 'L') unbeaten++;
+      else break;
+    }
+    if (unbeaten >= 5 && streak < 3) {
+      // Only show if not already covered by a win-streak headline
+      headlines.push(`${clubName} unbeaten in ${unbeaten} — solid and hard to beat`);
+    }
+  }
+
+  // ── New season-best win (fires on the week it happens) ──────────────────
+  const lastMatch = playerMatches[playerMatches.length - 1];
+  const lastIsHome = lastMatch.homeTeamId === clubId;
+  const lastP = lastIsHome ? lastMatch.homeGoals : lastMatch.awayGoals;
+  const lastO = lastIsHome ? lastMatch.awayGoals : lastMatch.homeGoals;
+  const lastDiff = lastP - lastO;
+
+  if (lastDiff >= 3) {
+    // Check if this is the biggest margin of the season
+    const margins = playerMatches.slice(0, -1).map(m => {
+      const ih = m.homeTeamId === clubId;
+      return (ih ? m.homeGoals : m.awayGoals) - (ih ? m.awayGoals : m.homeGoals);
+    });
+    const prevBest = margins.length > 0 ? Math.max(...margins) : 0;
+    if (lastDiff > prevBest) {
+      const opponentId = lastIsHome ? lastMatch.awayTeamId : lastMatch.homeTeamId;
+      const opponentName = nameMap.get(opponentId) ?? 'opposition';
+      headlines.push(`★ SEASON BEST — ${lastP}–${lastO} vs ${opponentName} — ${clubName}'s biggest win this season`);
+    }
+  }
+
+  // ── Zone banners (fires on weeks divisible by 5 to avoid every-week spam) ─
+  const playerEntry = leagueEntries.find(e => e.clubId === clubId);
+  if (playerEntry && currentWeek % 5 === 0) {
+    const pos   = playerEntry.position;
+    const total = leagueEntries.length;
+    const autoPromo   = 3;
+    const playoffEdge = 7;
+    const dropZone    = total - 1; // bottom 2 start here
+
+    if (pos <= autoPromo) {
+      headlines.push(`🏆 ${clubName} in the automatic promotion places — ${ordinal(pos)} in League Two`);
+    } else if (pos <= playoffEdge) {
+      headlines.push(`⚔️ Playoff contenders — ${clubName} sit ${ordinal(pos)} in the table`);
+    } else if (pos >= dropZone) {
+      headlines.push(`⚠ ${clubName} in the drop zone — ${ordinal(pos)} — every point is crucial`);
+    }
+  }
+
+  return headlines;
 }
 
 function buildMoraleHeadlines(squad: Player[]): string[] {
@@ -100,7 +221,8 @@ function buildHeadlines(
     }
   }
 
-  return [...headlines.slice(-30).reverse(), ...buildMoraleHeadlines(squad), ...milestoneHeadlines];
+  const arcHeadlines = buildSeasonArcHeadlines(events, clubId, clubName, leagueEntries, currentWeek);
+  return [...headlines.slice(-30).reverse(), ...buildMoraleHeadlines(squad), ...milestoneHeadlines, ...arcHeadlines];
 }
 
 export function NewsTicker({ events, clubId, clubName, stadiumName, leagueEntries, squad, currentWeek }: NewsTickerProps) {

--- a/packages/frontend/src/components/command-centre/NewsTicker.tsx
+++ b/packages/frontend/src/components/command-centre/NewsTicker.tsx
@@ -16,6 +16,7 @@ interface NewsTickerProps {
   stadiumName: string;
   leagueEntries: LeagueTableEntry[];
   squad: Player[];
+  freeAgents?: Player[];
   currentWeek?: number;
 }
 
@@ -159,6 +160,36 @@ function buildMoraleHeadlines(squad: Player[]): string[] {
   return headlines;
 }
 
+// ── Transfer rumours ────────────────────────────────────────────────────────
+//
+// Free agents with high NPC interest appear as rumours before any deal is done.
+// Uses the same deterministic hash as getNpcInterestCount in TransferMarketSlideOver.
+
+function getNpcInterestForTicker(playerId: string): number {
+  let h = 0;
+  for (let i = 0; i < playerId.length; i++) {
+    h = (Math.imul(31, h) + playerId.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h) % 4;
+}
+
+function buildRumourHeadlines(freeAgents: Player[], clubName: string): string[] {
+  // Only surface the top 3 most-wanted agents (npcInterest >= 2), max 3 rumours
+  const hotAgents = freeAgents
+    .map(p => ({ p, interest: getNpcInterestForTicker(p.id) }))
+    .filter(x => x.interest >= 2)
+    .sort((a, b) => b.interest - a.interest)
+    .slice(0, 3);
+
+  return hotAgents.map(({ p, interest }) => {
+    const clubs = interest === 3 ? 'three clubs' : 'two clubs';
+    const posLabel = p.position === 'GK' ? 'goalkeeper' :
+                     p.position === 'DEF' ? 'defender' :
+                     p.position === 'MID' ? 'midfielder' : 'forward';
+    return `📰 RUMOUR · ${p.name} attracting interest — ${clubs} tracking the ${posLabel}, including ${clubName}`;
+  });
+}
+
 function buildHeadlines(
   events: GameEvent[],
   clubId: string,
@@ -166,6 +197,7 @@ function buildHeadlines(
   stadiumName: string,
   nameMap: Map<string, string>,
   squad: Player[],
+  leagueEntries: LeagueTableEntry[],
   currentWeek?: number
 ): string[] {
   const headlines: string[] = [];
@@ -225,9 +257,11 @@ function buildHeadlines(
   return [...headlines.slice(-30).reverse(), ...buildMoraleHeadlines(squad), ...milestoneHeadlines, ...arcHeadlines];
 }
 
-export function NewsTicker({ events, clubId, clubName, stadiumName, leagueEntries, squad, currentWeek }: NewsTickerProps) {
+export function NewsTicker({ events, clubId, clubName, stadiumName, leagueEntries, squad, freeAgents, currentWeek }: NewsTickerProps) {
   const nameMap = new Map<string, string>(leagueEntries.map(e => [e.clubId, e.clubName]));
-  const headlines = buildHeadlines(events, clubId, clubName, stadiumName, nameMap, squad, currentWeek);
+  const eventHeadlines = buildHeadlines(events, clubId, clubName, stadiumName, nameMap, squad, leagueEntries, currentWeek);
+  const rumourHeadlines = freeAgents && freeAgents.length > 0 ? buildRumourHeadlines(freeAgents, clubName) : [];
+  const headlines = [...eventHeadlines, ...rumourHeadlines];
 
   if (headlines.length === 0) return null;
 

--- a/packages/frontend/src/components/command-centre/NewsTicker.tsx
+++ b/packages/frontend/src/components/command-centre/NewsTicker.tsx
@@ -241,6 +241,12 @@ function buildHeadlines(
       }
     } else if (e.type === 'FACILITY_UPGRADED') {
       headlines.push(`${clubName} invest at ${stadiumName}: ${e.facilityType} upgraded to Level ${e.level}`);
+    } else if (e.type === 'FACILITY_UPGRADE_STARTED') {
+      const label = e.facilityType.replace(/_/g, ' ').toLowerCase().replace(/\b\w/g, (c: string) => c.toUpperCase());
+      headlines.push(`🏗 Construction started: ${label} upgrade underway at ${stadiumName} — Level ${e.targetLevel} in ${e.weeksToComplete} week${e.weeksToComplete === 1 ? '' : 's'}`);
+    } else if (e.type === 'FACILITY_CONSTRUCTION_COMPLETED') {
+      const label = e.facilityType.replace(/_/g, ' ').toLowerCase().replace(/\b\w/g, (c: string) => c.toUpperCase());
+      headlines.push(`✅ Construction complete: ${label} now Level ${e.newLevel} at ${stadiumName}`);
     } else if (e.type === 'SEASON_ENDED') {
       const status = e.promoted ? '🏆 PROMOTED!' : e.relegated ? '⚠ RELEGATED' : 'Season complete';
       headlines.push(`${clubName}: ${status} — Final position: ${e.finalPosition}`);

--- a/packages/frontend/src/components/command-centre/NewsTicker.tsx
+++ b/packages/frontend/src/components/command-centre/NewsTicker.tsx
@@ -1,4 +1,4 @@
-import { GameEvent, MatchSimulatedEvent, MoraleTickerEvent, Player, avgSquadMorale, isUnsettled } from '@calculating-glory/domain';
+import { GameEvent, MatchSimulatedEvent, MoraleTickerEvent, Player, PendingClubEvent, avgSquadMorale, isUnsettled } from '@calculating-glory/domain';
 import { LeagueTableEntry } from '@calculating-glory/domain';
 
 // ── Ordinal helper ──────────────────────────────────────────────────────────
@@ -17,6 +17,7 @@ interface NewsTickerProps {
   leagueEntries: LeagueTableEntry[];
   squad: Player[];
   freeAgents?: Player[];
+  pendingEvents?: PendingClubEvent[];
   currentWeek?: number;
 }
 
@@ -173,6 +174,12 @@ function getNpcInterestForTicker(playerId: string): number {
   return Math.abs(h) % 4;
 }
 
+function buildPoachHeadlines(pendingEvents: PendingClubEvent[]): string[] {
+  return pendingEvents
+    .filter(e => e.templateId === 'npc-poach' && !e.resolved && e.metadata?.playerName)
+    .map(e => `🚨 BREAKING · ${e.metadata!.npcClubName} submit formal bid for ${e.metadata!.playerName} — decision pending`);
+}
+
 function buildRumourHeadlines(freeAgents: Player[], clubName: string): string[] {
   // Only surface the top 3 most-wanted agents (npcInterest >= 2), max 3 rumours
   const hotAgents = freeAgents
@@ -257,11 +264,12 @@ function buildHeadlines(
   return [...headlines.slice(-30).reverse(), ...buildMoraleHeadlines(squad), ...milestoneHeadlines, ...arcHeadlines];
 }
 
-export function NewsTicker({ events, clubId, clubName, stadiumName, leagueEntries, squad, freeAgents, currentWeek }: NewsTickerProps) {
+export function NewsTicker({ events, clubId, clubName, stadiumName, leagueEntries, squad, freeAgents, pendingEvents, currentWeek }: NewsTickerProps) {
   const nameMap = new Map<string, string>(leagueEntries.map(e => [e.clubId, e.clubName]));
   const eventHeadlines = buildHeadlines(events, clubId, clubName, stadiumName, nameMap, squad, leagueEntries, currentWeek);
   const rumourHeadlines = freeAgents && freeAgents.length > 0 ? buildRumourHeadlines(freeAgents, clubName) : [];
-  const headlines = [...eventHeadlines, ...rumourHeadlines];
+  const poachHeadlines = pendingEvents ? buildPoachHeadlines(pendingEvents) : [];
+  const headlines = [...poachHeadlines, ...eventHeadlines, ...rumourHeadlines];
 
   if (headlines.length === 0) return null;
 

--- a/packages/frontend/src/components/command-centre/PendingEventCard.tsx
+++ b/packages/frontend/src/components/command-centre/PendingEventCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { PendingClubEvent, GameCommand } from '@calculating-glory/domain';
+import { PendingClubEvent, GameCommand, formatMoney } from '@calculating-glory/domain';
 
 interface PendingEventCardProps {
   event: PendingClubEvent;
@@ -29,10 +29,12 @@ function EffectPills({
   budgetEffect,
   reputationEffect,
   performanceEffect,
+  moraleEffect,
 }: {
   budgetEffect?: number;
   reputationEffect?: number;
   performanceEffect?: number;
+  moraleEffect?: number;
 }) {
   const pills: { label: string; cls: string }[] = [];
 
@@ -63,6 +65,15 @@ function EffectPills({
     });
   }
 
+  if (moraleEffect !== undefined && moraleEffect !== 0) {
+    pills.push({
+      label: `Morale ${moraleEffect > 0 ? '+' : ''}${moraleEffect}`,
+      cls: moraleEffect > 0
+        ? 'bg-pitch-green/15 text-pitch-green border border-pitch-green/30'
+        : 'bg-warn-amber/15 text-warn-amber border border-warn-amber/30',
+    });
+  }
+
   if (pills.length === 0) {
     pills.push({ label: 'No financial impact', cls: 'bg-bg-raised text-txt-muted' });
   }
@@ -87,7 +98,8 @@ function isRiskyChoice(choice: PendingClubEvent['choices'][number]): boolean {
   const hasNegative =
     (choice.budgetEffect !== undefined && choice.budgetEffect < 0) ||
     (choice.reputationEffect !== undefined && choice.reputationEffect < 0) ||
-    (choice.performanceEffect !== undefined && choice.performanceEffect < 0);
+    (choice.performanceEffect !== undefined && choice.performanceEffect < 0) ||
+    (choice.moraleEffect !== undefined && choice.moraleEffect < 0);
   return !hasPositive && hasNegative;
 }
 
@@ -282,6 +294,24 @@ export function PendingEventCard({ event, dispatch, onError, onMathChallenge }: 
 
       <p className="text-xs text-txt-muted mb-3 leading-relaxed">{event.description}</p>
 
+      {/* Poach: player snapshot strip */}
+      {event.templateId === 'npc-poach' && event.metadata?.playerName && (
+        <div className="mb-3 flex items-center gap-3 bg-bg-raised rounded-card border border-white/5 px-3 py-2">
+          <div className="flex flex-col gap-0.5 flex-1 min-w-0">
+            <span className="text-xs font-semibold text-txt-primary truncate">{event.metadata.playerName}</span>
+            <span className="text-[10px] text-txt-muted">
+              {event.metadata.playerPosition} · {event.metadata.playerWage ? formatMoney(event.metadata.playerWage) + '/wk' : ''}
+            </span>
+          </div>
+          {event.metadata.playerOverall !== undefined && (
+            <div className="text-right shrink-0">
+              <span className="text-data-blue font-bold text-sm">{event.metadata.playerOverall}</span>
+              <div className="text-[10px] text-txt-muted">OVR</div>
+            </div>
+          )}
+        </div>
+      )}
+
       {/* Inline maths challenge for chain events */}
       {event.mathsChallenge && mathsResult === null && (
         <MathsChallengeWidget
@@ -331,6 +361,7 @@ export function PendingEventCard({ event, dispatch, onError, onMathChallenge }: 
                   budgetEffect={choice.budgetEffect}
                   reputationEffect={choice.reputationEffect}
                   performanceEffect={choice.performanceEffect}
+                  moraleEffect={choice.moraleEffect}
                 />
               </button>
             );

--- a/packages/frontend/src/components/intro/MathsChallenge.tsx
+++ b/packages/frontend/src/components/intro/MathsChallenge.tsx
@@ -67,6 +67,7 @@ export function MathsChallenge({ onResult }: Props) {
             <span className="absolute left-3 top-1/2 -translate-y-1/2 text-txt-muted text-sm">£</span>
             <input
               type="number"
+              inputMode="numeric"
               value={input}
               onChange={e => setInput(e.target.value)}
               onKeyDown={handleKeyDown}

--- a/packages/frontend/src/components/isometric/CoreUnit.tsx
+++ b/packages/frontend/src/components/isometric/CoreUnit.tsx
@@ -25,6 +25,7 @@ import {
   groundCenter,
 } from './isometric-utils';
 import { CoreUnitDef } from './stadium-layout';
+import { constructionDuration } from '@calculating-glory/domain';
 
 interface CoreUnitProps {
   def:       CoreUnitDef;
@@ -41,7 +42,19 @@ interface CoreUnitProps {
 
 export function CoreUnit({ def, level, constructionWeeksRemaining, isHovered, isHighlighted, onClick, onHover }: CoreUnitProps) {
   const isBuilding = (constructionWeeksRemaining ?? 0) > 0;
-  const bh   = def.blockHeights[Math.min(level, 5)];
+
+  // During construction interpolate block height between current and target level.
+  // Starts at old-level height, grows toward new-level height as weeks tick down.
+  const bhCurrent = def.blockHeights[Math.min(level, 5)];
+  const bhTarget  = def.blockHeights[Math.min(level + 1, 5)];
+  const bh = isBuilding
+    ? Math.round(
+        bhCurrent +
+        (bhTarget - bhCurrent) *
+          (1 - (constructionWeeksRemaining! / constructionDuration(level + 1)))
+      )
+    : bhCurrent;
+
   const fv   = footprintVertices(def.gc, def.gr, def.cols, def.rows);
   const gnd  = footprintPath(fv);
 
@@ -175,8 +188,25 @@ export function CoreUnit({ def, level, constructionWeeksRemaining, isHovered, is
         {isBuilding ? '🏗' : def.icon}
       </text>
 
+      {/* ── Construction progress bar (replaces pips while building) */}
+      {isBuilding && bh > 0 && (() => {
+        const totalWeeks = constructionDuration(level + 1);
+        const weeksLeft  = constructionWeeksRemaining!;
+        const progress   = 1 - weeksLeft / totalWeeks; // 0 → 1
+        const barW = 28;
+        const barH = 4;
+        const bx   = iconPos.x - barW / 2;
+        const by   = iconPos.y - bh * 0.45 - 8;
+        return (
+          <g transform={`translate(${bx}, ${by})`} style={{ pointerEvents: 'none' }}>
+            <rect x={0} y={0} width={barW} height={barH} rx={2} fill="rgba(0,0,0,0.40)" />
+            <rect x={0} y={0} width={barW * progress} height={barH} rx={2} fill="#FFB400" />
+          </g>
+        );
+      })()}
+
       {/* ── Level pip row (level > 0, small dots above icon) ─────── */}
-      {level > 0 && bh > 0 && (
+      {level > 0 && bh > 0 && !isBuilding && (
         <g
           transform={`translate(${iconPos.x - (level * 7) / 2}, ${iconPos.y - (bh > 0 ? bh * 0.45 : 0) - 6})`}
           style={{ pointerEvents: 'none' }}

--- a/packages/frontend/src/components/shared/FacilityCard.tsx
+++ b/packages/frontend/src/components/shared/FacilityCard.tsx
@@ -1,4 +1,4 @@
-import { Facility, FacilityType, FACILITY_CONFIG, formatMoney } from '@calculating-glory/domain';
+import { Facility, FacilityType, FACILITY_CONFIG, formatMoney, constructionDuration } from '@calculating-glory/domain';
 
 const LEVEL_LABELS = ['Derelict', 'Basic', 'Decent', 'Good', 'Excellent', 'World-Class'];
 
@@ -76,17 +76,32 @@ export function FacilityCard({
       </div>
 
       {/* Construction in progress */}
-      {isBuilding && (
-        <div className="flex items-center gap-2 pt-1 border-t border-bg-raised">
-          <span className="text-base">🏗</span>
-          <div>
-            <span className="text-xs font-semibold text-warn-amber">Under Construction</span>
-            <span className="text-xs2 text-txt-muted ml-1.5">
-              — {facility.constructionWeeksRemaining} week{facility.constructionWeeksRemaining === 1 ? '' : 's'} remaining
-            </span>
+      {isBuilding && (() => {
+        const targetLevel = facility.level + 1;
+        const totalWeeks  = constructionDuration(targetLevel);
+        const weeksLeft   = facility.constructionWeeksRemaining!;
+        const progress    = Math.round(((totalWeeks - weeksLeft) / totalWeeks) * 100);
+        return (
+          <div className="flex flex-col gap-1.5 pt-1 border-t border-bg-raised">
+            <div className="flex items-center gap-2">
+              <span className="text-base">🏗</span>
+              <div className="flex-1 min-w-0">
+                <span className="text-xs font-semibold text-warn-amber">Under Construction</span>
+                <span className="text-xs2 text-txt-muted ml-1.5">
+                  — {weeksLeft} week{weeksLeft === 1 ? '' : 's'} remaining
+                </span>
+              </div>
+              <span className="text-xs2 text-warn-amber font-semibold data-font shrink-0">{progress}%</span>
+            </div>
+            <div className="h-1.5 bg-bg-deep rounded-full overflow-hidden">
+              <div
+                className="h-full bg-warn-amber rounded-full transition-all duration-500"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
           </div>
-        </div>
-      )}
+        );
+      })()}
 
       {/* Upgrade section */}
       {!isMaxLevel && !isBuilding && (

--- a/packages/frontend/src/components/shared/ViewToggle.tsx
+++ b/packages/frontend/src/components/shared/ViewToggle.tsx
@@ -61,41 +61,43 @@ export function ViewToggle({
     <>
       <div className="flex items-center justify-between px-4 py-2 border-b border-bg-raised bg-bg-surface">
         {/* Left: Club info */}
-        <div className="flex items-center gap-4">
-          <div>
-            <h1 className="text-lg font-bold text-txt-primary tracking-tight">
+        <div className="flex items-center gap-4 min-w-0 shrink">
+          <div className="min-w-0">
+            <h1 className="text-base sm:text-lg font-bold text-txt-primary tracking-tight truncate max-w-[120px] sm:max-w-none">
               {state.club.name}
             </h1>
             <p className="text-xs text-txt-muted">
-              Season {state.season} · Week {state.currentWeek} ·{' '}
-              <span className="capitalize">{state.phase.replace('_', ' ').toLowerCase()}</span>
+              S{state.season} · W{state.currentWeek}
+              <span className="hidden sm:inline"> · <span className="capitalize">{state.phase.replace('_', ' ').toLowerCase()}</span></span>
             </p>
           </div>
         </div>
 
         {/* Centre: View toggle */}
-        <div className="flex items-center gap-1 bg-bg-raised rounded-card p-1">
+        <div className="flex items-center gap-1 bg-bg-raised rounded-card p-1 shrink-0">
           <button
             onClick={() => onViewChange('command')}
             className={[
-              'px-3 py-1.5 rounded-tag text-xs font-semibold transition-all duration-150',
+              'px-2 sm:px-3 py-1.5 rounded-tag text-xs font-semibold transition-all duration-150',
               activeView === 'command'
                 ? 'bg-bg-surface text-txt-primary shadow-sm'
                 : 'text-txt-muted hover:text-txt-primary',
             ].join(' ')}
           >
-            Command Centre
+            <span className="hidden sm:inline">Command Centre</span>
+            <span className="sm:hidden">CMD</span>
           </button>
           <button
             onClick={() => onViewChange('stadium')}
             className={[
-              'px-3 py-1.5 rounded-tag text-xs font-semibold transition-all duration-150',
+              'px-2 sm:px-3 py-1.5 rounded-tag text-xs font-semibold transition-all duration-150',
               activeView === 'stadium'
                 ? 'bg-bg-surface text-txt-primary shadow-sm'
                 : 'text-txt-muted hover:text-txt-primary',
             ].join(' ')}
           >
-            Stadium View
+            <span className="hidden sm:inline">Stadium View</span>
+            <span className="sm:hidden">Stadium</span>
           </button>
         </div>
 

--- a/packages/frontend/src/components/social-feed/MathChallengeCard.tsx
+++ b/packages/frontend/src/components/social-feed/MathChallengeCard.tsx
@@ -24,7 +24,8 @@ export function MathChallengeCard({ challenge, hintIndex }: MathChallengeCardPro
         <span className="badge bg-data-blue/20 text-data-blue text-xs2">
           {TOPIC_LABELS[challenge.topic] ?? challenge.topic}
         </span>
-        <span className="text-warn-amber text-xs2 data-font">
+        <span className="text-warn-amber text-xs2 data-font flex items-center gap-1">
+          <span className="text-txt-muted text-[10px]">D{challenge.difficulty}</span>
           {DIFFICULTY_STARS[challenge.difficulty]}
         </span>
       </div>

--- a/packages/frontend/src/components/social-feed/SocialFeed.tsx
+++ b/packages/frontend/src/components/social-feed/SocialFeed.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { GameState, GameCommand, GameEvent, PendingClubEvent, CurriculumLevel, checkMastery, curriculumDisplayName, CURRICULUM_LEVELS } from '@calculating-glory/domain';
+import { GameState, GameCommand, GameEvent, PendingClubEvent, CurriculumLevel, checkMastery, curriculumDisplayName, CURRICULUM_LEVELS, MAX_DIFFICULTY_BY_LEVEL } from '@calculating-glory/domain';
 import { ChatBubble } from './ChatBubble';
 import { NegotiationKeyboard } from './NegotiationKeyboard';
 import { MathChallengeCard } from './MathChallengeCard';
@@ -76,6 +76,12 @@ const PRACTICE_CONSEQUENCE = [
   "Solid work. That kind of preparation makes a difference in the boardroom.",
 ];
 
+const DIFFICULTY_UNLOCK = [
+  "The board are impressed — tougher challenges incoming.",
+  "You're ready for harder problems. Let's step it up.",
+  "Sharp thinking. Time to raise the stakes.",
+];
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function uid() {
@@ -116,8 +122,13 @@ export function SocialFeed({ state, events, dispatch, linkedEvent, practiceMode,
   const [practiceTopicOverride, setPracticeTopic]   = useState<ChallengeTopic | null>(null);
   const [wasNegotiation, setWasNegotiation]         = useState(false);
   const [masteryNudge, setMasteryNudge]             = useState<CurriculumLevel | null>(null);
+  // Progressive session difficulty: starts at D1, unlocks D2/D3 as player demonstrates mastery
+  const [sessionDifficulty, setSessionDifficulty]   = useState<1 | 2 | 3>(1);
+  const [correctAtDiff, setCorrectAtDiff]           = useState(0);
   const bottomRef   = useRef<HTMLDivElement>(null);
   const seededRef   = useRef(false);
+
+  const curriculumMax = MAX_DIFFICULTY_BY_LEVEL[state.curriculum?.level ?? 'YEAR_7'];
 
   function addMsg(msg: Omit<Message, 'id'>) {
     setMessages(prev => [...prev, { ...msg, id: uid() }]);
@@ -158,7 +169,7 @@ export function SocialFeed({ state, events, dispatch, linkedEvent, practiceMode,
 
   // ── Seed a practice thread ────────────────────────────────────────────────
   function seedPractice(topic: ChallengeTopic) {
-    const challenge = generateChallenge(state, 0, getPerformance(state), topic);
+    const challenge = generateChallenge(state, 0, getPerformance(state), topic, undefined, sessionDifficulty);
 
     setActiveLinkedEvent(null);
     setPracticeTopic(topic);
@@ -246,6 +257,25 @@ export function SocialFeed({ state, events, dispatch, linkedEvent, practiceMode,
     if (correct) {
       setAwaitingAnswer(false);
       setSolved(true);
+
+      // ── Progressive difficulty tracking ─────────────────────────────────────
+      // Only count practice-session answers (not event negotiations) toward unlock
+      if (!activeLinkedEvent) {
+        const diffMatches = currentChallenge.difficulty === sessionDifficulty;
+        const newCount = diffMatches ? correctAtDiff + 1 : correctAtDiff;
+        const canUnlock = sessionDifficulty < curriculumMax && newCount >= 3;
+        if (canUnlock) {
+          const next = (sessionDifficulty + 1) as 1 | 2 | 3;
+          setSessionDifficulty(next);
+          setCorrectAtDiff(0);
+          setTimeout(() => addMsg({
+            kind: 'system',
+            text: `⬆ D${next} unlocked — ${pick(DIFFICULTY_UNLOCK)}`,
+          }), 1200);
+        } else {
+          setCorrectAtDiff(diffMatches ? newCount : 0);
+        }
+      }
 
       if (activeLinkedEvent) {
         const result = dispatch({
@@ -370,6 +400,7 @@ export function SocialFeed({ state, events, dispatch, linkedEvent, practiceMode,
       getPerformance(state),
       practiceTopicOverride ?? undefined,
       excludeSlug,
+      sessionDifficulty,
     );
 
     setChallengeIndex(nextIdx);

--- a/packages/frontend/src/components/social-feed/generateChallenge.ts
+++ b/packages/frontend/src/components/social-feed/generateChallenge.ts
@@ -101,6 +101,7 @@ export const MATH_TOPIC_TO_CHALLENGE: Partial<Record<MathTopic, ChallengeTopic>>
  * Selection logic:
  * - Filters bank by student's curriculum level (minCurriculumLevel ≤ studentLevel)
  * - Caps difficulty by MAX_DIFFICULTY_BY_LEVEL[curriculumLevel]
+ * - Optionally further capped by sessionMaxDifficulty (progressive in-session unlock)
  * - Optionally filters to a single topic (topicOverride)
  * - Excludes the previous template to avoid back-to-back duplicates
  * - With performance data: applies adaptive difficulty weighting (struggling → easier, mastered → harder)
@@ -112,11 +113,17 @@ export function generateChallenge(
   performance?: TopicPerformance,
   topicOverride?: ChallengeTopic,
   excludeTemplateSlug?: string,
+  /** Optional per-session difficulty cap (1–3). When provided, overrides the curriculum max downward. */
+  sessionMaxDifficulty?: 1 | 2 | 3,
 ): MathChallenge {
   const vars          = extractVariables(state);
   const curriculumLevel = state.curriculum?.level ?? 'YEAR_7';
   const studentIdx    = CURRICULUM_LEVEL_ORDER.indexOf(curriculumLevel);
-  const maxDifficulty = MAX_DIFFICULTY_BY_LEVEL[curriculumLevel];
+  const curriculumMax = MAX_DIFFICULTY_BY_LEVEL[curriculumLevel];
+  // Session difficulty cap: take the tighter of curriculum max and session unlock level
+  const maxDifficulty: 1 | 2 | 3 = sessionMaxDifficulty !== undefined
+    ? (Math.min(sessionMaxDifficulty, curriculumMax) as 1 | 2 | 3)
+    : curriculumMax;
 
   // ── Build pool: level- and difficulty-filtered ───────────────────────────────
   let pool: QuestionTemplate[] = QUESTION_BANK.filter(q => {

--- a/packages/frontend/src/components/stadium-view/ScoutNetworkSlideOver.tsx
+++ b/packages/frontend/src/components/stadium-view/ScoutNetworkSlideOver.tsx
@@ -219,6 +219,7 @@ export function ScoutNetworkSlideOver({
               </p>
               <input
                 type="number"
+                inputMode="numeric"
                 min={0}
                 step={1000}
                 value={Math.round(budgetCeil / 100)}
@@ -418,6 +419,7 @@ export function ScoutNetworkSlideOver({
                 </p>
                 <input
                   type="number"
+                  inputMode="numeric"
                   min={0}
                   step={100}
                   value={wageOfferedPounds}
@@ -441,6 +443,7 @@ export function ScoutNetworkSlideOver({
                 <div className="flex gap-2">
                   <input
                     type="number"
+                    inputMode="decimal"
                     placeholder="Your answer"
                     value={userAnswer}
                     onChange={e => setUserAnswer(e.target.value)}

--- a/packages/frontend/src/components/transfer-market/TransferMarketSlideOver.tsx
+++ b/packages/frontend/src/components/transfer-market/TransferMarketSlideOver.tsx
@@ -40,6 +40,23 @@ function getNpcInterestCount(playerId: string): number {
 }
 
 /**
+ * Whether a reluctant player rejects a "hold firm" approach.
+ * 0 NPC clubs → never rejects (reluctance was wage-only).
+ * 1 NPC club  → 50/50 (deterministic from id).
+ * 2+ NPC clubs → always rejects (they had better options).
+ */
+function willRejectHoldFirm(playerId: string, npcInterest: number): boolean {
+  if (npcInterest === 0) return false;
+  if (npcInterest >= 2) return true;
+  // 1 rival club: coin-flip seeded on player id
+  let h = 0;
+  for (let i = 0; i < playerId.length; i++) {
+    h = (Math.imul(17, h) + playerId.charCodeAt(i)) | 0;
+  }
+  return (Math.abs(h) % 2) === 0;
+}
+
+/**
  * How keen a free agent is to join, based on your league position and the wage
  * you're offering relative to their asking wage.
  */
@@ -288,7 +305,7 @@ interface FreeAgentCardProps {
   onSign: (wage: number) => void;
 }
 
-type SignStep = 'idle' | 'countering' | 'confirming' | 'done';
+type SignStep = 'idle' | 'countering' | 'confirming' | 'done' | 'rejected';
 
 const NPC_INTEREST_LABELS: Record<number, string> = {
   1: '1 other club watching',
@@ -331,6 +348,15 @@ function FreeAgentCard({
   function handleAcceptOriginal() {
     onSign(player.wage);
     setStep('done');
+  }
+
+  function handleHoldFirm() {
+    if (willRejectHoldFirm(player.id, npcInterest)) {
+      setStep('rejected');
+    } else {
+      onSign(player.wage);
+      setStep('done');
+    }
   }
 
   function handleCancel() {
@@ -381,6 +407,13 @@ function FreeAgentCard({
       {/* Action row */}
       {step === 'done' ? (
         <div className="text-xs text-pitch-green font-semibold">Signed! {npcInterest > 0 ? 'You beat the competition.' : ''}</div>
+      ) : step === 'rejected' ? (
+        <div className="text-xs text-alert-red bg-alert-red/5 border border-alert-red/20 rounded px-2 py-1.5">
+          <span className="font-semibold">Gone.</span>{' '}
+          {npcInterest >= 2
+            ? `${npcInterest} clubs were waiting — ${player.name} chose elsewhere.`
+            : `${player.name} walked away. A rival club made their move.`}
+        </div>
       ) : step === 'countering' ? (
         /* Reluctant player counter-offer */
         <div className="flex flex-col gap-2 text-xs">
@@ -400,7 +433,7 @@ function FreeAgentCard({
               Accept {counterLabel}/wk
             </button>
             <button
-              onClick={handleAcceptOriginal}
+              onClick={handleHoldFirm}
               className="px-2 py-1 bg-pitch-green/10 text-pitch-green border border-pitch-green/30 rounded hover:bg-pitch-green/20 transition-colors"
             >
               Hold firm at {formatMoney(player.wage)}/wk

--- a/packages/frontend/src/components/transfer-market/TransferMarketSlideOver.tsx
+++ b/packages/frontend/src/components/transfer-market/TransferMarketSlideOver.tsx
@@ -172,7 +172,7 @@ function SquadFormationView({
                 const ovr = computeOverallRating(player);
                 const isExpanded = expandedId === player.id;
                 return (
-                  <div key={player.id} className="flex flex-col gap-1" style={{ minWidth: '140px', maxWidth: '200px' }}>
+                  <div key={player.id} className="flex flex-col gap-1 min-w-[140px] max-w-[200px]">
                     <button
                       onClick={() => setExpandedId(isExpanded ? null : player.id)}
                       className={`bg-bg-raised border rounded-card px-3 py-2 text-left w-full transition-colors hover:border-white/20 ${ovrBorderClass(ovr)} ${isExpanded ? 'border-opacity-80' : ''}`}
@@ -205,8 +205,7 @@ function SquadFormationView({
                 <button
                   key={`vacant-${i}`}
                   onClick={() => onFillPosition(pos)}
-                  className="bg-bg-raised border border-dashed border-white/20 rounded-card px-3 py-2 text-left hover:border-white/40 transition-colors"
-                  style={{ minWidth: '140px' }}
+                  className="bg-bg-raised border border-dashed border-white/20 rounded-card px-3 py-2 text-left hover:border-white/40 transition-colors min-w-[140px]"
                 >
                   <div className="text-xs text-txt-muted font-semibold">+ VACANT</div>
                   <div className="text-[10px] text-data-blue mt-0.5">Find a {pos} →</div>

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -15,6 +15,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Eight issues implemented across two sessions — all domain logic was already in place, this batch focused on completing the frontend experience and adding depth to existing systems.

### #86 — Progressive session difficulty
- Session starts at D1; unlock D2 after 3 correct, D3 after 3 correct at D2
- Capped by `MAX_DIFFICULTY_BY_LEVEL` (curriculum level ceiling)
- D{n} label visible on each challenge card
- Brief unlock toast in chat feed

### #85 — NPC cast depth
- 5 new template pools: `KEV_STREAK_WIN_5`, `KEV_STREAK_LOSS_5`, `KEV_PROMOTION_ZONE`, `KEV_RELEGATION_ZONE`, `MARCUS_COMMERCIAL_OBS`
- W5/L5 streak detection with W3/L3 cascade (no double-firing)
- Kev table position reaction (promo/relegation zone, fires every 3 weeks)
- Marcus commercial observation (fires every 6 weeks)

### #84 — Club identity
- `[CLUB]` and `[STADIUM]` fill vars added to `generateNpcMessages`
- ~40% of template entries across all NPC pools personalised naturally
- Fixed 3rd-person slip in `KEV_RELEGATION_ZONE`
- Fixed TS6 deprecation errors (`ignoreDeprecations: "6.0"`) in both tsconfigs

### #83 — Season arc headlines in ticker
- Win streaks (3/5/7/9+), loss streaks (3/5/7+), unbeaten runs (5+)
- New season-best win detection (margin ≥ 3 and > previous best)
- Zone banners every 5 weeks when in promo/relegation zone
- Fixed latent bug: `leagueEntries` used inside `buildHeadlines()` without being a parameter

### #82 — Transfer market friction
- "Hold firm" now has real consequences: 0 rival clubs = always accepts; 1 club = 50/50; 2+ clubs = always rejects
- New `rejected` step state: "Gone. X clubs were waiting — [name] chose elsewhere."
- Free agents with NPC interest ≥ 2 appear as `📰 RUMOUR` headlines in ticker before any deal lands

### #36 — NPC poaching (frontend)
- Domain was fully implemented; this wires the UI
- Poach cards now show player snapshot (name, position, OVR, wage) embedded in event metadata at generation time
- `moraleEffect` now visible in `EffectPills` — reject (−15) and ignore (−25) morale penalties were previously hidden
- `isRiskyChoice` updated to consider morale — reject renders amber/warning
- Active poach bids appear as `🚨 BREAKING` at the front of the ticker

### #28 — Construction lag visuals
- Domain was already fully implemented; this wires the visual experience
- Block height interpolates between old and new level during construction
- Level pips replaced with amber progress bar (dark track, 0→100% as weeks tick down)
- FacilityCard shows construction progress bar with percentage
- Ticker: `FACILITY_UPGRADE_STARTED` → "🏗 Construction started…", `FACILITY_CONSTRUCTION_COMPLETED` → "✅ Construction complete…"

## Test plan
- [ ] Start a game, simulate weeks — NPC messages reference club and stadium names
- [ ] Practice mode: answer 3 correct at D1, confirm D2 unlocks; repeat for D3
- [ ] Sign a reluctant free agent with 2+ NPC interest — hold firm, confirm they reject
- [ ] Sign a reluctant free agent with 0 NPC interest — hold firm, confirm they sign
- [ ] Upgrade a facility — confirm building grows visually over construction weeks
- [ ] FacilityCard slide-over shows progress bar during construction
- [ ] Ticker shows BREAKING on active poach bid, RUMOUR for hot free agents
- [ ] Ticker shows construction started/completed headlines

https://claude.ai/code/session_01MVQNqNmm4LS5Eb4ScABaDk
EOF
)