### PR TITLE
fix: remove invalid ignoreDeprecations from tsconfigs

### DIFF
--- a/packages/domain/tsconfig.json
+++ b/packages/domain/tsconfig.json
@@ -13,7 +13,6 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "moduleResolution": "node",
-    "ignoreDeprecations": "6.0",
     "allowSyntheticDefaultImports": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -15,7 +15,6 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
-    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
## Summary
- Removes `"ignoreDeprecations": "6.0"` from both `packages/frontend/tsconfig.json` and `packages/domain/tsconfig.json`
- TS 5.9 rejects `"6.0"` as an invalid value for this option, breaking `tsc --noEmit`
- Neither config actually needs it: frontend uses `moduleResolution: "bundler"` (no baseUrl deprecation), domain uses `moduleResolution: "node"` (no deprecation triggered)

## Test plan
- [ ] `npx tsc --noEmit -p packages/frontend/tsconfig.json` passes clean
- [ ] `npx tsc --noEmit -p packages/domain/tsconfig.json` passes clean

https://claude.ai/code/session_01MVQNqNmm4LS5Eb4ScABaDk