### PR TITLE
feat(stadium): plot-based rendering, face textures, and painter's algorithm fixes

### DIFF
--- a/packages/frontend/src/components/isometric/CoreUnit.tsx
+++ b/packages/frontend/src/components/isometric/CoreUnit.tsx
@@ -85,17 +85,6 @@ export function CoreUnit({ def, level, constructionWeeksRemaining, isHovered, is
         />
       )}
 
-      {/* ── Plot border — only shown at level 1+ for definition ──── */}
-      {level > 0 && (
-        <path
-          d={gnd}
-          fill="none"
-          stroke="#0B1622"
-          strokeWidth="1"
-          style={{ pointerEvents: 'none' }}
-        />
-      )}
-
       {/* ── Hover tint ───────────────────────────────────────────── */}
       {isHovered && (
         <path

--- a/packages/frontend/src/components/isometric/CoreUnit.tsx
+++ b/packages/frontend/src/components/isometric/CoreUnit.tsx
@@ -1,31 +1,24 @@
 /**
- * CoreUnit — renders one isometric building on the stadium grid.
+ * CoreUnit — renders one facility plot on the stadium grid.
  *
- * Visual behaviour:
- *   level 0  → flat ground diamond with "empty plot" marker (icon + dashed border)
- *   level 1+ → isometric block whose height scales with level, icon on top face
- *
- * Shading model (Gemini visual spec — PR 6):
- *   Top face:  base colour (100% light)   + optional topPattern overlay
- *   SW face:   base colour + rgba(0,0,0,0.30) overlay + optional swPattern overlay
- *   SE face:   base colour + rgba(0,0,0,0.55) overlay
- *   Highlight: 1px rgba(255,255,255,0.20) on top front edge (T→R)
- *              1px rgba(255,255,255,0.10) on top back edge  (T→L)
+ * Visual model (plot-based — see FacilityPlotContents for per-facility detail):
+ *   level 0  → ground diamond with grass fill (url(#pat-ground)) + faint dashed
+ *              white outline — blends into the background, shows plot boundary
+ *   level 1+ → solid ground base (def.colors.ground) + FacilityPlotContents
+ *              sub-objects accumulate per level within the plot
  *
  * Interaction:
- *   - hover: block highlights with a blue outline + internal white tint
- *   - click: fires onCoreUnitClick (wired to navigation in PR 4)
+ *   - hover: blue outline + subtle white tint over the full plot
+ *   - click: fires onClick (wired to facility detail in parent)
  */
 
 import {
   footprintVertices,
   footprintPath,
-  blockPaths,
-  topFaceCenter,
   groundCenter,
 } from './isometric-utils';
 import { CoreUnitDef } from './stadium-layout';
-import { constructionDuration } from '@calculating-glory/domain';
+import { FacilityPlotContents } from './FacilityPlotContents';
 
 interface CoreUnitProps {
   def:       CoreUnitDef;
@@ -42,37 +35,14 @@ interface CoreUnitProps {
 
 export function CoreUnit({ def, level, constructionWeeksRemaining, isHovered, isHighlighted, onClick, onHover }: CoreUnitProps) {
   const isBuilding = (constructionWeeksRemaining ?? 0) > 0;
-
-  // During construction interpolate block height between current and target level.
-  // Starts at old-level height, grows toward new-level height as weeks tick down.
-  const bhCurrent = def.blockHeights[Math.min(level, 5)];
-  const bhTarget  = def.blockHeights[Math.min(level + 1, 5)];
-  const bh = isBuilding
-    ? Math.round(
-        bhCurrent +
-        (bhTarget - bhCurrent) *
-          (1 - (constructionWeeksRemaining! / constructionDuration(level + 1)))
-      )
-    : bhCurrent;
-
   const fv   = footprintVertices(def.gc, def.gr, def.cols, def.rows);
   const gnd  = footprintPath(fv);
 
-  // Block paths (only meaningful when bh > 0)
-  const bp = bh > 0 ? blockPaths(fv, bh) : null;
+  // Icon placement: always ground centre for plot-based rendering
+  const iconPos = groundCenter(fv);
 
-  // Icon placement
-  const iconPos = bh > 0
-    ? topFaceCenter(fv, bh)
-    : groundCenter(fv);
-
-  // Top-face raised vertex coords — used for highlight lines
-  const txTop   = fv.top.x,   tyTop   = fv.top.y - bh;
-  const txRight = fv.right.x, tyRight = fv.right.y - bh;
-  const txLeft  = fv.left.x,  tyLeft  = fv.left.y - bh;
-
-  // Hit region for click / hover — full block silhouette if built, ground diamond otherwise
-  const hitPath = bp ? bp.hitRegion : gnd;
+  // Hit region = ground diamond always (entire plot is clickable)
+  const hitPath = gnd;
 
   return (
     <g
@@ -83,25 +53,16 @@ export function CoreUnit({ def, level, constructionWeeksRemaining, isHovered, is
       onMouseEnter={() => onHover(def.id)}
       onMouseLeave={() => onHover(null)}
     >
-      {/* ── Ground base (always drawn) ───────────────────────────── */}
+      {/* ── Ground base ─────────────────────────────────────────────
+           Level 0: grass fill blending into background, faint outline.
+           Level 1+: soil / plot fill as distinct base. */}
       <path
         d={gnd}
-        fill={def.colors.ground}
-        stroke="#0B1622"
-        strokeWidth="1"
+        fill={level === 0 ? 'url(#pat-ground)' : def.colors.ground}
+        stroke={level === 0 ? 'rgba(255,255,255,0.18)' : '#0B1622'}
+        strokeWidth={level === 0 ? '1' : '1'}
+        strokeDasharray={level === 0 ? '5 3' : undefined}
       />
-
-      {/* ── Dashed "empty plot" border at level 0 ────────────────── */}
-      {level === 0 && !isBuilding && (
-        <path
-          d={gnd}
-          fill="none"
-          stroke={isHovered ? '#448AFF' : '#546E7A'}
-          strokeWidth="1.5"
-          strokeDasharray="4 3"
-          style={{ pointerEvents: 'none' }}
-        />
-      )}
 
       {/* ── Construction outline (amber dashes while building) ────── */}
       {isBuilding && (
@@ -115,50 +76,31 @@ export function CoreUnit({ def, level, constructionWeeksRemaining, isHovered, is
         />
       )}
 
-      {/* ── Building block (level > 0) ───────────────────────────── */}
-      {bp && (
-        <>
-          {/* SW face — base colour + 30% dark overlay */}
-          <path d={bp.left} fill={def.colors.base} />
-          <path d={bp.left} fill="rgba(0,0,0,0.30)" style={{ pointerEvents: 'none' }} />
-          {def.colors.swPattern && (
-            <path d={bp.left} fill={def.colors.swPattern} style={{ pointerEvents: 'none' }} />
-          )}
-
-          {/* SE face — base colour + 55% dark overlay */}
-          <path d={bp.right} fill={def.colors.base} />
-          <path d={bp.right} fill="rgba(0,0,0,0.55)" style={{ pointerEvents: 'none' }} />
-
-          {/* Top face — base colour (+ optional pattern) */}
-          <path d={bp.top} fill={def.colors.base} />
-          {def.colors.topPattern && (
-            <path d={bp.top} fill={def.colors.topPattern} style={{ pointerEvents: 'none' }} />
-          )}
-
-          {/* 1px highlight on top front edge (north → east) — 20% white */}
-          <line
-            x1={txTop}   y1={tyTop}
-            x2={txRight} y2={tyRight}
-            stroke="rgba(255,255,255,0.20)"
-            strokeWidth={1}
-            style={{ pointerEvents: 'none' }}
-          />
-          {/* Subtler highlight on top back edge (north → west) — 10% white */}
-          <line
-            x1={txTop}  y1={tyTop}
-            x2={txLeft} y2={tyLeft}
-            stroke="rgba(255,255,255,0.10)"
-            strokeWidth={1}
-            style={{ pointerEvents: 'none' }}
-          />
-        </>
+      {/* ── Plot contents (sub-objects per facility / level) ─────── */}
+      {level > 0 && !isBuilding && (
+        <FacilityPlotContents
+          facilityType={def.facilityType}
+          fv={fv}
+          level={level}
+        />
       )}
 
-      {/* ── Hover tint (sits above block faces, below icon) ──────── */}
+      {/* ── Plot border — only shown at level 1+ for definition ──── */}
+      {level > 0 && (
+        <path
+          d={gnd}
+          fill="none"
+          stroke="#0B1622"
+          strokeWidth="1"
+          style={{ pointerEvents: 'none' }}
+        />
+      )}
+
+      {/* ── Hover tint ───────────────────────────────────────────── */}
       {isHovered && (
         <path
           d={hitPath}
-          fill="rgba(255,255,255,0.10)"
+          fill="rgba(255,255,255,0.08)"
           stroke="#448AFF"
           strokeWidth="1.5"
           style={{ pointerEvents: 'none' }}
@@ -177,39 +119,52 @@ export function CoreUnit({ def, level, constructionWeeksRemaining, isHovered, is
         />
       )}
 
-      {/* ── Icon ─────────────────────────────────────────────────── */}
-      <text
-        x={iconPos.x}
-        y={iconPos.y + (bh > 0 ? 8 : 6)}
-        textAnchor="middle"
-        dominantBaseline="middle"
-        fontSize={def.cols >= 4 ? 22 : 16}
-        style={{ pointerEvents: 'none', userSelect: 'none' }}
-      >
-        {isBuilding ? '🏗' : def.icon}
-      </text>
+      {/* ── Facility icon ────────────────────────────────────────────
+           Level 0: centred in the plot so the player knows what's coming.
+           Construction: always show the crane.
+           Level 1+: small icon in the bottom corner so it doesn't fight
+                     the sub-objects but still provides quick identification. */}
+      {isBuilding ? (
+        <text
+          x={iconPos.x}
+          y={iconPos.y + 6}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize={22}
+          style={{ pointerEvents: 'none', userSelect: 'none' }}
+        >
+          🏗
+        </text>
+      ) : level === 0 ? (
+        <text
+          x={iconPos.x}
+          y={iconPos.y + 4}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize={def.cols >= 4 ? 20 : 16}
+          opacity={0.55}
+          style={{ pointerEvents: 'none', userSelect: 'none' }}
+        >
+          {def.icon}
+        </text>
+      ) : (
+        <text
+          x={fv.bottom.x - 6}
+          y={fv.bottom.y - 10}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize={12}
+          opacity={0.7}
+          style={{ pointerEvents: 'none', userSelect: 'none' }}
+        >
+          {def.icon}
+        </text>
+      )}
 
-      {/* ── Construction progress bar (replaces pips while building) */}
-      {isBuilding && bh > 0 && (() => {
-        const totalWeeks = constructionDuration(level + 1);
-        const weeksLeft  = constructionWeeksRemaining!;
-        const progress   = 1 - weeksLeft / totalWeeks; // 0 → 1
-        const barW = 28;
-        const barH = 4;
-        const bx   = iconPos.x - barW / 2;
-        const by   = iconPos.y - bh * 0.45 - 8;
-        return (
-          <g transform={`translate(${bx}, ${by})`} style={{ pointerEvents: 'none' }}>
-            <rect x={0} y={0} width={barW} height={barH} rx={2} fill="rgba(0,0,0,0.40)" />
-            <rect x={0} y={0} width={barW * progress} height={barH} rx={2} fill="#FFB400" />
-          </g>
-        );
-      })()}
-
-      {/* ── Level pip row (level > 0, small dots above icon) ─────── */}
-      {level > 0 && bh > 0 && !isBuilding && (
+      {/* ── Level pip row (level > 0) ─────────────────────────────── */}
+      {level > 0 && !isBuilding && (
         <g
-          transform={`translate(${iconPos.x - (level * 7) / 2}, ${iconPos.y - (bh > 0 ? bh * 0.45 : 0) - 6})`}
+          transform={`translate(${iconPos.x - (level * 7) / 2}, ${iconPos.y - 10})`}
           style={{ pointerEvents: 'none' }}
         >
           {Array.from({ length: level }).map((_, i) => (

--- a/packages/frontend/src/components/isometric/FacilityPlotContents.tsx
+++ b/packages/frontend/src/components/isometric/FacilityPlotContents.tsx
@@ -1,0 +1,454 @@
+/**
+ * FacilityPlotContents — renders the objects inside each facility plot.
+ *
+ * Each facility has a unique progression of sub-objects that accumulate
+ * across levels 1–5.  Level 0 is handled by CoreUnit (grass + faint outline).
+ *
+ * All geometry is built with subObjectFootprint() + blockPaths() so objects
+ * sit correctly in isometric space and are painted back-to-front via the
+ * order they appear in each facility's JSX.
+ *
+ * Coordinate convention:
+ *   u = left→right across plot (NW→NE edge)
+ *   v = back→front (NW→SW edge)
+ *   Heights are screen pixels, same unit as blockPaths bh param.
+ */
+
+import { FacilityType } from '@calculating-glory/domain';
+import { FootprintVertices, subObjectFootprint, blockPaths, footprintPath, shadeColor } from './isometric-utils';
+
+interface Props {
+  facilityType: FacilityType;
+  fv: FootprintVertices;
+  level: number;  // 1–5
+}
+
+// ---------------------------------------------------------------------------
+// Render helpers
+// ---------------------------------------------------------------------------
+
+/** Render a solid isometric box within the plot using normalised u/v coords. */
+function Box({
+  fv, u1, v1, u2, v2, h, base, shade = true,
+}: {
+  fv: FootprintVertices;
+  u1: number; v1: number; u2: number; v2: number;
+  h: number;
+  base: string;
+  shade?: boolean;
+}) {
+  const sfv = subObjectFootprint(fv, u1, v1, u2, v2);
+  if (h === 0) {
+    return <path d={footprintPath(sfv)} fill={base} style={{ pointerEvents: 'none' }} />;
+  }
+  const bp = blockPaths(sfv, h);
+  const lc = shade ? shadeColor(base, -15) : base;
+  const rc = shade ? shadeColor(base, -30) : base;
+  return (
+    <g style={{ pointerEvents: 'none' }}>
+      <path d={bp.left}  fill={lc} />
+      <path d={bp.right} fill={rc} />
+      <path d={bp.top}   fill={base} />
+    </g>
+  );
+}
+
+/** Flat ground patch within the plot. */
+function Patch({
+  fv, u1, v1, u2, v2, fill,
+}: {
+  fv: FootprintVertices;
+  u1: number; v1: number; u2: number; v2: number;
+  fill: string;
+}) {
+  const sfv = subObjectFootprint(fv, u1, v1, u2, v2);
+  return <path d={footprintPath(sfv)} fill={fill} style={{ pointerEvents: 'none' }} />;
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function FacilityPlotContents({ facilityType, fv, level }: Props) {
+  if (level === 0) return null;
+
+  const no = { pointerEvents: 'none' as const };
+
+  switch (facilityType) {
+
+    // ── Training Ground ────────────────────────────────────────────────────
+    case 'TRAINING_GROUND': {
+      // L1: small pitch marking on grass
+      // L2: + changing hut (back-left)
+      // L3: + equipment shed (back-right)
+      // L4: + small gym block (front-right)
+      // L5: + covered stand / pavilion (front)
+      return (
+        <g style={no}>
+          {/* Grass pitch surface */}
+          <Patch fv={fv} u1={0.08} v1={0.10} u2={0.92} v2={0.88} fill="#2D5A1B" />
+          {/* Pitch markings */}
+          <Patch fv={fv} u1={0.10} v1={0.12} u2={0.90} v2={0.86} fill="url(#pat-grass)" />
+
+          {/* Changing hut — L2+ */}
+          {level >= 2 && (
+            <Box fv={fv} u1={0.05} v1={0.05} u2={0.28} v2={0.35} h={18} base="#7A5C3A" />
+          )}
+
+          {/* Equipment shed — L3+ */}
+          {level >= 3 && (
+            <Box fv={fv} u1={0.72} v1={0.05} u2={0.95} v2={0.30} h={14} base="#6B4F30" />
+          )}
+
+          {/* Gym block — L4+ */}
+          {level >= 4 && (
+            <Box fv={fv} u1={0.65} v1={0.62} u2={0.95} v2={0.92} h={22} base="#7A5C3A" />
+          )}
+
+          {/* Covered pavilion / stand — L5 */}
+          {level >= 5 && (
+            <Box fv={fv} u1={0.05} v1={0.68} u2={0.55} v2={0.95} h={16} base="#8B6F52" />
+          )}
+        </g>
+      );
+    }
+
+    // ── Medical Centre ─────────────────────────────────────────────────────
+    case 'MEDICAL_CENTER': {
+      // L1: first-aid tent (small, white)
+      // L2: + ambulance bay (darker block)
+      // L3: clinic building
+      // L4: larger clinic + covered walkway
+      // L5: full medical centre complex
+      return (
+        <g style={no}>
+          {/* Base tarmac surface */}
+          <Patch fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} fill="#2A3540" />
+
+          {/* First-aid tent — L1 */}
+          <Box fv={fv} u1={0.30} v1={0.20} u2={0.70} v2={0.60} h={14} base="#C8D8DC" />
+          {/* Red cross marker on tent top */}
+
+          {/* Ambulance bay — L2+ */}
+          {level >= 2 && (
+            <Box fv={fv} u1={0.05} v1={0.60} u2={0.45} v2={0.95} h={10} base="#3D5060" />
+          )}
+
+          {/* Clinic building — L3+ */}
+          {level >= 3 && (
+            <>
+              <Box fv={fv} u1={0.10} v1={0.05} u2={0.90} v2={0.55} h={26} base="#8FA8B0" />
+              {/* Red cross on face */}
+              <Patch fv={fv} u1={0.42} v1={0.08} u2={0.58} v2={0.30} fill="#E53935" />
+            </>
+          )}
+
+          {/* Covered walkway — L4+ */}
+          {level >= 4 && (
+            <Box fv={fv} u1={0.05} v1={0.55} u2={0.95} v2={0.72} h={8} base="#6A8890" />
+          )}
+
+          {/* Full centre annex — L5 */}
+          {level >= 5 && (
+            <Box fv={fv} u1={0.05} v1={0.72} u2={0.55} v2={0.96} h={20} base="#8FA8B0" />
+          )}
+        </g>
+      );
+    }
+
+    // ── Scout Network ──────────────────────────────────────────────────────
+    case 'SCOUT_NETWORK': {
+      // L1: fold-out table + laptop (tiny flat box)
+      // L2: + caravan / mobile unit
+      // L3: small office + comms mast
+      // L4: + satellite dish (small cylinder on top)
+      // L5: full comms tower
+      return (
+        <g style={no}>
+          {/* Dark gravel base */}
+          <Patch fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} fill="#1A2530" />
+
+          {/* Table — L1 */}
+          <Box fv={fv} u1={0.35} v1={0.35} u2={0.65} v2={0.65} h={6} base="#4A5E6A" />
+
+          {/* Caravan — L2+ */}
+          {level >= 2 && (
+            <Box fv={fv} u1={0.55} v1={0.55} u2={0.92} v2={0.88} h={16} base="#3A5060" />
+          )}
+
+          {/* Office block — L3+ */}
+          {level >= 3 && (
+            <Box fv={fv} u1={0.05} v1={0.10} u2={0.50} v2={0.55} h={22} base="#2E3F4F" />
+          )}
+
+          {/* Mast — L3+ (thin tall column) */}
+          {level >= 3 && (
+            <Box fv={fv} u1={0.72} v1={0.08} u2={0.80} v2={0.22} h={36} base="#4A5E6A" />
+          )}
+
+          {/* Satellite dish — L4+ */}
+          {level >= 4 && (
+            <Box fv={fv} u1={0.60} v1={0.05} u2={0.95} v2={0.35} h={10} base="#3D5060" />
+          )}
+
+          {/* Communications tower — L5 */}
+          {level >= 5 && (
+            <Box fv={fv} u1={0.08} v1={0.60} u2={0.45} v2={0.92} h={14} base="#2E3F4F" />
+          )}
+        </g>
+      );
+    }
+
+    // ── Youth Academy ──────────────────────────────────────────────────────
+    case 'YOUTH_ACADEMY': {
+      // L1: small grass patch + cones
+      // L2: + changing room shed
+      // L3: school building
+      // L4: + practice pitch
+      // L5: full academy campus
+      return (
+        <g style={no}>
+          {/* Grass base */}
+          <Patch fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} fill="#1C3A1A" />
+
+          {/* Practice patch */}
+          <Patch fv={fv} u1={0.40} v1={0.10} u2={0.96} v2={0.90} fill="#245520" />
+
+          {/* Changing room shed — L2+ */}
+          {level >= 2 && (
+            <Box fv={fv} u1={0.04} v1={0.60} u2={0.34} v2={0.95} h={14} base="#5B7E8A" />
+          )}
+
+          {/* School building — L3+ */}
+          {level >= 3 && (
+            <Box fv={fv} u1={0.04} v1={0.05} u2={0.35} v2={0.55} h={24} base="#5B7E8A" />
+          )}
+
+          {/* Full pitch — L4+ */}
+          {level >= 4 && (
+            <Patch fv={fv} u1={0.38} v1={0.08} u2={0.97} v2={0.92} fill="url(#pat-grass)" />
+          )}
+
+          {/* Campus hub block — L5 */}
+          {level >= 5 && (
+            <Box fv={fv} u1={0.04} v1={0.05} u2={0.34} v2={0.95} h={30} base="#4A6E7A" />
+          )}
+        </g>
+      );
+    }
+
+    // ── Club Office ────────────────────────────────────────────────────────
+    case 'CLUB_OFFICE': {
+      // L1: porta-cabin
+      // L2: small office (2 storeys)
+      // L3: proper 3-storey block
+      // L4: main office complex
+      // L5: HQ tower with helipad
+      return (
+        <g style={no}>
+          {/* Tarmac base */}
+          <Patch fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} fill="#1A2230" />
+
+          {/* Car park markings */}
+          <Patch fv={fv} u1={0.60} v1={0.60} u2={0.95} v2={0.95} fill="#22303A" />
+
+          {/* Porta-cabin — L1 */}
+          <Box fv={fv} u1={0.20} v1={0.25} u2={0.80} v2={0.65} h={14} base="#4A5E72" />
+
+          {/* Second storey — L2+ */}
+          {level >= 2 && (
+            <Box fv={fv} u1={0.25} v1={0.20} u2={0.75} v2={0.60} h={28} base="#4A5E72" />
+          )}
+
+          {/* 3-storey office — L3+ */}
+          {level >= 3 && (
+            <Box fv={fv} u1={0.10} v1={0.10} u2={0.90} v2={0.70} h={42} base="#4A5E72" />
+          )}
+
+          {/* Complex annex — L4+ */}
+          {level >= 4 && (
+            <Box fv={fv} u1={0.60} v1={0.60} u2={0.95} v2={0.95} h={24} base="#3A4E62" />
+          )}
+
+          {/* HQ tower — L5 */}
+          {level >= 5 && (
+            <Box fv={fv} u1={0.25} v1={0.08} u2={0.75} v2={0.55} h={62} base="#4A5E72" />
+          )}
+        </g>
+      );
+    }
+
+    // ── Club Commercial ────────────────────────────────────────────────────
+    case 'CLUB_COMMERCIAL': {
+      // L1: market stall / trestle table
+      // L2: + small shop unit
+      // L3: commercial unit with shopfront
+      // L4: + merchandise store
+      // L5: full commercial centre
+      return (
+        <g style={no}>
+          {/* Paved surface */}
+          <Patch fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} fill="#2A2010" />
+
+          {/* Market stall — L1 */}
+          <Box fv={fv} u1={0.25} v1={0.30} u2={0.75} v2={0.70} h={8} base="#C8A060" />
+
+          {/* Shop unit — L2+ */}
+          {level >= 2 && (
+            <Box fv={fv} u1={0.10} v1={0.10} u2={0.55} v2={0.55} h={18} base="#8B6F52" />
+          )}
+
+          {/* Commercial shopfront — L3+ */}
+          {level >= 3 && (
+            <Box fv={fv} u1={0.05} v1={0.05} u2={0.95} v2={0.65} h={24} base="#8B6F52" />
+          )}
+
+          {/* Merchandise store — L4+ */}
+          {level >= 4 && (
+            <Box fv={fv} u1={0.10} v1={0.65} u2={0.55} v2={0.95} h={20} base="#7A6040" />
+          )}
+
+          {/* Full centre — L5 */}
+          {level >= 5 && (
+            <Box fv={fv} u1={0.55} v1={0.60} u2={0.95} v2={0.95} h={28} base="#8B6F52" />
+          )}
+        </g>
+      );
+    }
+
+    // ── Food & Beverage ────────────────────────────────────────────────────
+    case 'FOOD_AND_BEVERAGE': {
+      // L1: hot dog cart (tiny box, front-centre)
+      // L2: + beer van (mid-left)
+      // L3: kiosk booth
+      // L4: + second stall
+      // L5: full concessions unit
+      return (
+        <g style={no}>
+          {/* Gravel surface */}
+          <Patch fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} fill="#281C10" />
+
+          {/* Hot dog cart — L1 */}
+          <Box fv={fv} u1={0.38} v1={0.55} u2={0.62} v2={0.85} h={10} base="#C86428" />
+
+          {/* Beer van — L2+ */}
+          {level >= 2 && (
+            <Box fv={fv} u1={0.05} v1={0.50} u2={0.35} v2={0.92} h={14} base="#4A5C3A" />
+          )}
+
+          {/* Kiosk — L3+ */}
+          {level >= 3 && (
+            <Box fv={fv} u1={0.35} v1={0.08} u2={0.92} v2={0.48} h={18} base="#7A4228" />
+          )}
+
+          {/* Second stall — L4+ */}
+          {level >= 4 && (
+            <Box fv={fv} u1={0.05} v1={0.05} u2={0.32} v2={0.45} h={14} base="#7A4228" />
+          )}
+
+          {/* Full concessions unit — L5 */}
+          {level >= 5 && (
+            <Box fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} h={22} base="#7A4228" />
+          )}
+        </g>
+      );
+    }
+
+    // ── Fan Zone ───────────────────────────────────────────────────────────
+    case 'FAN_ZONE': {
+      // L1: banner poles + open space
+      // L2: + merch table
+      // L3: entertainment pavilion
+      // L4: + big screen structure
+      // L5: full fan zone with covered areas
+      return (
+        <g style={no}>
+          {/* Paved plaza */}
+          <Patch fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} fill="#1E1428" />
+
+          {/* Banner pole left — L1 */}
+          <Box fv={fv} u1={0.10} v1={0.10} u2={0.16} v2={0.20} h={28} base="#5C4A6A" />
+          {/* Banner pole right — L1 */}
+          <Box fv={fv} u1={0.84} v1={0.10} u2={0.90} v2={0.20} h={28} base="#5C4A6A" />
+
+          {/* Merch table — L2+ */}
+          {level >= 2 && (
+            <Box fv={fv} u1={0.30} v1={0.60} u2={0.70} v2={0.90} h={8} base="#7A5C8A" />
+          )}
+
+          {/* Entertainment pavilion — L3+ */}
+          {level >= 3 && (
+            <Box fv={fv} u1={0.10} v1={0.10} u2={0.90} v2={0.55} h={16} base="#5C4A6A" />
+          )}
+
+          {/* Big screen structure — L4+ */}
+          {level >= 4 && (
+            <Box fv={fv} u1={0.35} v1={0.55} u2={0.65} v2={0.70} h={22} base="#3A2848" />
+          )}
+
+          {/* Covered side wings — L5 */}
+          {level >= 5 && (
+            <>
+              <Box fv={fv} u1={0.04} v1={0.55} u2={0.32} v2={0.95} h={12} base="#5C4A6A" />
+              <Box fv={fv} u1={0.68} v1={0.55} u2={0.96} v2={0.95} h={12} base="#5C4A6A" />
+            </>
+          )}
+        </g>
+      );
+    }
+
+    // ── Grounds & Security ─────────────────────────────────────────────────
+    case 'GROUNDS_SECURITY': {
+      // L1: barrier + small gatehouse
+      // L2: + turnstile block
+      // L3: security booth complex
+      // L4: + CCTV tower
+      // L5: full security hub
+      return (
+        <g style={no}>
+          {/* Concrete base */}
+          <Patch fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} fill="#1A1E22" />
+
+          {/* Gatehouse — L1 */}
+          <Box fv={fv} u1={0.38} v1={0.35} u2={0.62} v2={0.65} h={14} base="#3D4F58" />
+
+          {/* Turnstile block — L2+ */}
+          {level >= 2 && (
+            <Box fv={fv} u1={0.10} v1={0.62} u2={0.38} v2={0.92} h={10} base="#3D4F58" />
+          )}
+
+          {/* Security booth complex — L3+ */}
+          {level >= 3 && (
+            <Box fv={fv} u1={0.05} v1={0.05} u2={0.65} v2={0.60} h={20} base="#3D4F58" />
+          )}
+
+          {/* CCTV tower — L4+ */}
+          {level >= 4 && (
+            <Box fv={fv} u1={0.75} v1={0.08} u2={0.85} v2={0.22} h={32} base="#2E3F48" />
+          )}
+
+          {/* Security hub — L5 */}
+          {level >= 5 && (
+            <Box fv={fv} u1={0.65} v1={0.55} u2={0.96} v2={0.96} h={22} base="#3D4F58" />
+          )}
+        </g>
+      );
+    }
+
+    // ── Stadium / Pitch ────────────────────────────────────────────────────
+    case 'STADIUM': {
+      // The pitch itself — grass stripes + centre circle suggestion
+      return (
+        <g style={no}>
+          {/* Grass surface */}
+          <Patch fv={fv} u1={0.05} v1={0.05} u2={0.95} v2={0.95} fill="url(#pat-grass)" />
+          {/* Centre spot */}
+          <Patch fv={fv} u1={0.45} v1={0.45} u2={0.55} v2={0.55} fill="rgba(255,255,255,0.12)" />
+        </g>
+      );
+    }
+
+    default:
+      return null;
+  }
+}

--- a/packages/frontend/src/components/isometric/FacilityPlotContents.tsx
+++ b/packages/frontend/src/components/isometric/FacilityPlotContents.tsx
@@ -12,6 +12,12 @@
  *   u = left→right across plot (NW→NE edge)
  *   v = back→front (NW→SW edge)
  *   Heights are screen pixels, same unit as blockPaths bh param.
+ *
+ * PAINTER'S ORDER RULE: within each facility, elements MUST be listed in
+ * ascending v order (back → front).  This is independent of the level at
+ * which each object first appears — a L3 object that sits at v=0.10 must
+ * render before a L2 object at v=0.70, even though the L2 object unlocks
+ * earlier.  Violating this rule causes the "floating" Z-fighting artefact.
  */
 
 import { FacilityType } from '@calculating-glory/domain';
@@ -77,35 +83,30 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
   switch (facilityType) {
 
     // ── Training Ground ────────────────────────────────────────────────────
+    // Back→front: shed(v2=0.30) < hut(v2=0.35) < gym(v2=0.92) < pavilion(v2=0.95)
     case 'TRAINING_GROUND': {
-      // L1: small pitch marking on grass
-      // L2: + changing hut (back-left)
-      // L3: + equipment shed (back-right)
-      // L4: + small gym block (front-right)
-      // L5: + covered stand / pavilion (front)
       return (
         <g style={no}>
-          {/* Grass pitch surface */}
+          {/* Ground: grass pitch surface */}
           <Patch fv={fv} u1={0.08} v1={0.10} u2={0.92} v2={0.88} fill="#2D5A1B" />
-          {/* Pitch markings */}
           <Patch fv={fv} u1={0.10} v1={0.12} u2={0.90} v2={0.86} fill="url(#pat-grass)" />
 
-          {/* Changing hut — L2+ */}
-          {level >= 2 && (
-            <Box fv={fv} u1={0.05} v1={0.05} u2={0.28} v2={0.35} h={18} base="#7A5C3A" />
-          )}
-
-          {/* Equipment shed — L3+ */}
+          {/* BACK: equipment shed (v2=0.30) — L3+ */}
           {level >= 3 && (
             <Box fv={fv} u1={0.72} v1={0.05} u2={0.95} v2={0.30} h={14} base="#6B4F30" />
           )}
 
-          {/* Gym block — L4+ */}
+          {/* BACK: changing hut (v2=0.35) — L2+ */}
+          {level >= 2 && (
+            <Box fv={fv} u1={0.05} v1={0.05} u2={0.28} v2={0.35} h={18} base="#7A5C3A" />
+          )}
+
+          {/* FRONT: gym block (v2=0.92) — L4+ */}
           {level >= 4 && (
             <Box fv={fv} u1={0.65} v1={0.62} u2={0.95} v2={0.92} h={22} base="#7A5C3A" />
           )}
 
-          {/* Covered pavilion / stand — L5 */}
+          {/* FRONT: covered pavilion / stand (v2=0.95) — L5 */}
           {level >= 5 && (
             <Box fv={fv} u1={0.05} v1={0.68} u2={0.55} v2={0.95} h={16} base="#8B6F52" />
           )}
@@ -114,84 +115,76 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
     }
 
     // ── Medical Centre ─────────────────────────────────────────────────────
+    // Back→front: clinic(v2=0.55) < tent(v2=0.60) < walkway(v2=0.72) < ambulance(v2=0.95) < annex(v2=0.96)
     case 'MEDICAL_CENTER': {
-      // L1: first-aid tent (small, white)
-      // L2: + ambulance bay (darker block)
-      // L3: clinic building
-      // L4: larger clinic + covered walkway
-      // L5: full medical centre complex
       return (
         <g style={no}>
           {/* Base tarmac surface */}
           <Patch fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} fill="#2A3540" />
 
-          {/* First-aid tent — L1 */}
-          <Box fv={fv} u1={0.30} v1={0.20} u2={0.70} v2={0.60} h={14} base="#C8D8DC" />
-          {/* Red cross marker on tent top */}
-
-          {/* Ambulance bay — L2+ */}
-          {level >= 2 && (
-            <Box fv={fv} u1={0.05} v1={0.60} u2={0.45} v2={0.95} h={10} base="#3D5060" />
-          )}
-
-          {/* Clinic building — L3+ */}
-          {level >= 3 && (
+          {/* BACK: clinic building (v2=0.55) — L3+ replaces tent */}
+          {level >= 3 ? (
             <>
               <Box fv={fv} u1={0.10} v1={0.05} u2={0.90} v2={0.55} h={26} base="#8FA8B0" />
-              {/* Red cross on face */}
-              <Patch fv={fv} u1={0.42} v1={0.08} u2={0.58} v2={0.30} fill="#E53935" />
+              {/* Red cross marking on clinic roof */}
+              <Patch fv={fv} u1={0.42} v1={0.08} u2={0.58} v2={0.25} fill="#E53935" />
             </>
+          ) : (
+            /* BACK: first-aid tent (v2=0.60) — L1–2 only */
+            <Box fv={fv} u1={0.30} v1={0.20} u2={0.70} v2={0.60} h={14} base="#C8D8DC" />
           )}
 
-          {/* Covered walkway — L4+ */}
+          {/* MID: covered walkway (v2=0.72) — L4+ */}
           {level >= 4 && (
             <Box fv={fv} u1={0.05} v1={0.55} u2={0.95} v2={0.72} h={8} base="#6A8890" />
           )}
 
-          {/* Full centre annex — L5 */}
+          {/* FRONT: ambulance bay (v2=0.95) — L2+ */}
+          {level >= 2 && (
+            <Box fv={fv} u1={0.05} v1={0.62} u2={0.45} v2={0.95} h={10} base="#3D5060" />
+          )}
+
+          {/* FRONT: full centre annex (v2=0.96) — L5 */}
           {level >= 5 && (
-            <Box fv={fv} u1={0.05} v1={0.72} u2={0.55} v2={0.96} h={20} base="#8FA8B0" />
+            <Box fv={fv} u1={0.50} v1={0.72} u2={0.96} v2={0.96} h={20} base="#8FA8B0" />
           )}
         </g>
       );
     }
 
     // ── Scout Network ──────────────────────────────────────────────────────
+    // Back→front: dish(v2=0.35) < mast(v2=0.22)* < office(v2=0.55) < table(v2=0.65) < caravan(v2=0.88) < tower(v2=0.92)
+    // *mast is very thin — render early so caravan face isn't clipped by it
     case 'SCOUT_NETWORK': {
-      // L1: fold-out table + laptop (tiny flat box)
-      // L2: + caravan / mobile unit
-      // L3: small office + comms mast
-      // L4: + satellite dish (small cylinder on top)
-      // L5: full comms tower
       return (
         <g style={no}>
           {/* Dark gravel base */}
           <Patch fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} fill="#1A2530" />
 
-          {/* Table — L1 */}
-          <Box fv={fv} u1={0.35} v1={0.35} u2={0.65} v2={0.65} h={6} base="#4A5E6A" />
-
-          {/* Caravan — L2+ */}
-          {level >= 2 && (
-            <Box fv={fv} u1={0.55} v1={0.55} u2={0.92} v2={0.88} h={16} base="#3A5060" />
-          )}
-
-          {/* Office block — L3+ */}
-          {level >= 3 && (
-            <Box fv={fv} u1={0.05} v1={0.10} u2={0.50} v2={0.55} h={22} base="#2E3F4F" />
-          )}
-
-          {/* Mast — L3+ (thin tall column) */}
-          {level >= 3 && (
-            <Box fv={fv} u1={0.72} v1={0.08} u2={0.80} v2={0.22} h={36} base="#4A5E6A" />
-          )}
-
-          {/* Satellite dish — L4+ */}
+          {/* BACK: satellite dish (v2=0.35) — L4+ */}
           {level >= 4 && (
             <Box fv={fv} u1={0.60} v1={0.05} u2={0.95} v2={0.35} h={10} base="#3D5060" />
           )}
 
-          {/* Communications tower — L5 */}
+          {/* BACK: comms mast — thin column (v2=0.22) — L3+ */}
+          {level >= 3 && (
+            <Box fv={fv} u1={0.72} v1={0.08} u2={0.80} v2={0.22} h={36} base="#4A5E6A" />
+          )}
+
+          {/* BACK: office block (v2=0.55) — L3+ */}
+          {level >= 3 && (
+            <Box fv={fv} u1={0.05} v1={0.10} u2={0.50} v2={0.55} h={22} base="#2E3F4F" />
+          )}
+
+          {/* MID: fold-out table (v2=0.65) — L1 */}
+          <Box fv={fv} u1={0.35} v1={0.35} u2={0.65} v2={0.65} h={6} base="#4A5E6A" />
+
+          {/* FRONT: caravan / mobile unit (v2=0.88) — L2+ */}
+          {level >= 2 && (
+            <Box fv={fv} u1={0.55} v1={0.55} u2={0.92} v2={0.88} h={16} base="#3A5060" />
+          )}
+
+          {/* FRONT: comms tower (v2=0.92) — L5 */}
           {level >= 5 && (
             <Box fv={fv} u1={0.08} v1={0.60} u2={0.45} v2={0.92} h={14} base="#2E3F4F" />
           )}
@@ -200,36 +193,31 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
     }
 
     // ── Youth Academy ──────────────────────────────────────────────────────
+    // Left half buildings — back→front: school(v2=0.55) < changing room(v2=0.95)
+    // Right half pitch — flat patches, no height conflict
     case 'YOUTH_ACADEMY': {
-      // L1: small grass patch + cones
-      // L2: + changing room shed
-      // L3: school building
-      // L4: + practice pitch
-      // L5: full academy campus
       return (
         <g style={no}>
-          {/* Grass base */}
+          {/* Ground: grass base */}
           <Patch fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} fill="#1C3A1A" />
-
-          {/* Practice patch */}
+          {/* Right side: practice patch (always visible) */}
           <Patch fv={fv} u1={0.40} v1={0.10} u2={0.96} v2={0.90} fill="#245520" />
-
-          {/* Changing room shed — L2+ */}
-          {level >= 2 && (
-            <Box fv={fv} u1={0.04} v1={0.60} u2={0.34} v2={0.95} h={14} base="#5B7E8A" />
-          )}
-
-          {/* School building — L3+ */}
-          {level >= 3 && (
-            <Box fv={fv} u1={0.04} v1={0.05} u2={0.35} v2={0.55} h={24} base="#5B7E8A" />
-          )}
-
-          {/* Full pitch — L4+ */}
+          {/* Right side: full grass pitch overlay — L4+ */}
           {level >= 4 && (
             <Patch fv={fv} u1={0.38} v1={0.08} u2={0.97} v2={0.92} fill="url(#pat-grass)" />
           )}
 
-          {/* Campus hub block — L5 */}
+          {/* BACK LEFT: school building (v2=0.55) — L3+ */}
+          {level >= 3 && level < 5 && (
+            <Box fv={fv} u1={0.04} v1={0.05} u2={0.35} v2={0.55} h={24} base="#5B7E8A" />
+          )}
+
+          {/* FRONT LEFT: changing room shed (v2=0.95) — L2+ */}
+          {level >= 2 && level < 5 && (
+            <Box fv={fv} u1={0.04} v1={0.60} u2={0.34} v2={0.95} h={14} base="#5B7E8A" />
+          )}
+
+          {/* L5: campus hub replaces individual left-side buildings */}
           {level >= 5 && (
             <Box fv={fv} u1={0.04} v1={0.05} u2={0.34} v2={0.95} h={30} base="#4A6E7A" />
           )}
@@ -238,115 +226,113 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
     }
 
     // ── Club Office ────────────────────────────────────────────────────────
+    // Back→front: HQ tower(v2=0.55) < 3-storey(v2=0.70) < 2nd storey(v2=0.60)* < annex(v2=0.95)
+    // *lower-level structures are subsumed at higher levels — suppress when superseded
     case 'CLUB_OFFICE': {
-      // L1: porta-cabin
-      // L2: small office (2 storeys)
-      // L3: proper 3-storey block
-      // L4: main office complex
-      // L5: HQ tower with helipad
       return (
         <g style={no}>
-          {/* Tarmac base */}
+          {/* Tarmac base + car park markings */}
           <Patch fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} fill="#1A2230" />
-
-          {/* Car park markings */}
           <Patch fv={fv} u1={0.60} v1={0.60} u2={0.95} v2={0.95} fill="#22303A" />
 
-          {/* Porta-cabin — L1 */}
-          <Box fv={fv} u1={0.20} v1={0.25} u2={0.80} v2={0.65} h={14} base="#4A5E72" />
+          {/* BACK: HQ tower (v2=0.55) — L5 */}
+          {level >= 5 && (
+            <Box fv={fv} u1={0.28} v1={0.08} u2={0.72} v2={0.55} h={62} base="#4A5E72" />
+          )}
 
-          {/* Second storey — L2+ */}
-          {level >= 2 && (
+          {/* BACK-MID: 3-storey office (v2=0.70) — L3–4, subsumed at L5 by tower+annex */}
+          {level >= 3 && level < 5 && (
+            <Box fv={fv} u1={0.10} v1={0.10} u2={0.90} v2={0.70} h={42} base="#4A5E72" />
+          )}
+          {/* At L5, keep the wide base but shorter — tower rises from centre */}
+          {level >= 5 && (
+            <Box fv={fv} u1={0.10} v1={0.10} u2={0.90} v2={0.70} h={28} base="#3A4E62" />
+          )}
+
+          {/* BACK-MID: 2-storey office (v2=0.60) — L2 only */}
+          {level === 2 && (
             <Box fv={fv} u1={0.25} v1={0.20} u2={0.75} v2={0.60} h={28} base="#4A5E72" />
           )}
 
-          {/* 3-storey office — L3+ */}
-          {level >= 3 && (
-            <Box fv={fv} u1={0.10} v1={0.10} u2={0.90} v2={0.70} h={42} base="#4A5E72" />
+          {/* BACK-MID: porta-cabin (v2=0.65) — L1 only */}
+          {level === 1 && (
+            <Box fv={fv} u1={0.20} v1={0.25} u2={0.80} v2={0.65} h={14} base="#4A5E72" />
           )}
 
-          {/* Complex annex — L4+ */}
+          {/* FRONT: complex annex (v2=0.95) — L4+ */}
           {level >= 4 && (
-            <Box fv={fv} u1={0.60} v1={0.60} u2={0.95} v2={0.95} h={24} base="#3A4E62" />
-          )}
-
-          {/* HQ tower — L5 */}
-          {level >= 5 && (
-            <Box fv={fv} u1={0.25} v1={0.08} u2={0.75} v2={0.55} h={62} base="#4A5E72" />
+            <Box fv={fv} u1={0.60} v1={0.62} u2={0.96} v2={0.96} h={24} base="#3A4E62" />
           )}
         </g>
       );
     }
 
     // ── Club Commercial ────────────────────────────────────────────────────
+    // Back→front: shop(v2=0.55) < shopfront(v2=0.65) < stall(v2=0.70) < store(v2=0.95) < wing(v2=0.95)
     case 'CLUB_COMMERCIAL': {
-      // L1: market stall / trestle table
-      // L2: + small shop unit
-      // L3: commercial unit with shopfront
-      // L4: + merchandise store
-      // L5: full commercial centre
       return (
         <g style={no}>
           {/* Paved surface */}
           <Patch fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} fill="#2A2010" />
 
-          {/* Market stall — L1 */}
-          <Box fv={fv} u1={0.25} v1={0.30} u2={0.75} v2={0.70} h={8} base="#C8A060" />
-
-          {/* Shop unit — L2+ */}
-          {level >= 2 && (
+          {/* BACK: shop unit (v2=0.55) — L2 only, subsumed by shopfront at L3 */}
+          {level === 2 && (
             <Box fv={fv} u1={0.10} v1={0.10} u2={0.55} v2={0.55} h={18} base="#8B6F52" />
           )}
 
-          {/* Commercial shopfront — L3+ */}
+          {/* BACK: commercial shopfront (v2=0.65) — L3+ */}
           {level >= 3 && (
             <Box fv={fv} u1={0.05} v1={0.05} u2={0.95} v2={0.65} h={24} base="#8B6F52" />
           )}
 
-          {/* Merchandise store — L4+ */}
-          {level >= 4 && (
-            <Box fv={fv} u1={0.10} v1={0.65} u2={0.55} v2={0.95} h={20} base="#7A6040" />
+          {/* MID: market stall (v2=0.70) — L1 only */}
+          {level === 1 && (
+            <Box fv={fv} u1={0.25} v1={0.30} u2={0.75} v2={0.70} h={8} base="#C8A060" />
           )}
 
-          {/* Full centre — L5 */}
+          {/* FRONT: merchandise store (v2=0.95, left) — L4+ */}
+          {level >= 4 && (
+            <Box fv={fv} u1={0.05} v1={0.65} u2={0.50} v2={0.95} h={20} base="#7A6040" />
+          )}
+
+          {/* FRONT: full centre wing (v2=0.95, right) — L5 */}
           {level >= 5 && (
-            <Box fv={fv} u1={0.55} v1={0.60} u2={0.95} v2={0.95} h={28} base="#8B6F52" />
+            <Box fv={fv} u1={0.52} v1={0.62} u2={0.96} v2={0.96} h={28} base="#8B6F52" />
           )}
         </g>
       );
     }
 
     // ── Food & Beverage ────────────────────────────────────────────────────
+    // Back→front: second stall(v2=0.45) < kiosk(v2=0.48) < beer van(v2=0.92) < hot dog cart(v2=0.85)
+    // Hot dog cart sits mid-front; beer van is further front-left; kiosk is back-right
     case 'FOOD_AND_BEVERAGE': {
-      // L1: hot dog cart (tiny box, front-centre)
-      // L2: + beer van (mid-left)
-      // L3: kiosk booth
-      // L4: + second stall
-      // L5: full concessions unit
       return (
         <g style={no}>
           {/* Gravel surface */}
           <Patch fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} fill="#281C10" />
 
-          {/* Hot dog cart — L1 */}
-          <Box fv={fv} u1={0.38} v1={0.55} u2={0.62} v2={0.85} h={10} base="#C86428" />
-
-          {/* Beer van — L2+ */}
-          {level >= 2 && (
-            <Box fv={fv} u1={0.05} v1={0.50} u2={0.35} v2={0.92} h={14} base="#4A5C3A" />
-          )}
-
-          {/* Kiosk — L3+ */}
-          {level >= 3 && (
-            <Box fv={fv} u1={0.35} v1={0.08} u2={0.92} v2={0.48} h={18} base="#7A4228" />
-          )}
-
-          {/* Second stall — L4+ */}
+          {/* BACK: second stall (v2=0.45) — L4+ */}
           {level >= 4 && (
             <Box fv={fv} u1={0.05} v1={0.05} u2={0.32} v2={0.45} h={14} base="#7A4228" />
           )}
 
-          {/* Full concessions unit — L5 */}
+          {/* BACK: kiosk (v2=0.48) — L3+ */}
+          {level >= 3 && (
+            <Box fv={fv} u1={0.35} v1={0.08} u2={0.92} v2={0.48} h={18} base="#7A4228" />
+          )}
+
+          {/* FRONT: hot dog cart (v2=0.85) — L1–2 (subsumed by kiosk at L3+) */}
+          {level < 3 && (
+            <Box fv={fv} u1={0.38} v1={0.55} u2={0.62} v2={0.85} h={10} base="#C86428" />
+          )}
+
+          {/* FRONT: beer van (v2=0.92) — L2+ */}
+          {level >= 2 && level < 5 && (
+            <Box fv={fv} u1={0.05} v1={0.52} u2={0.35} v2={0.92} h={14} base="#4A5C3A" />
+          )}
+
+          {/* L5: full concessions replaces individual stalls */}
           {level >= 5 && (
             <Box fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} h={22} base="#7A4228" />
           )}
@@ -355,38 +341,33 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
     }
 
     // ── Fan Zone ───────────────────────────────────────────────────────────
+    // Back→front: poles(v2=0.20) < pavilion(v2=0.55) < screen(v2=0.70) < table(v2=0.90) < wings(v2=0.95)
     case 'FAN_ZONE': {
-      // L1: banner poles + open space
-      // L2: + merch table
-      // L3: entertainment pavilion
-      // L4: + big screen structure
-      // L5: full fan zone with covered areas
       return (
         <g style={no}>
           {/* Paved plaza */}
           <Patch fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} fill="#1E1428" />
 
-          {/* Banner pole left — L1 */}
+          {/* BACK: banner poles (v2=0.20) — L1+ */}
           <Box fv={fv} u1={0.10} v1={0.10} u2={0.16} v2={0.20} h={28} base="#5C4A6A" />
-          {/* Banner pole right — L1 */}
           <Box fv={fv} u1={0.84} v1={0.10} u2={0.90} v2={0.20} h={28} base="#5C4A6A" />
 
-          {/* Merch table — L2+ */}
-          {level >= 2 && (
-            <Box fv={fv} u1={0.30} v1={0.60} u2={0.70} v2={0.90} h={8} base="#7A5C8A" />
-          )}
-
-          {/* Entertainment pavilion — L3+ */}
+          {/* BACK-MID: entertainment pavilion (v2=0.55) — L3+ */}
           {level >= 3 && (
             <Box fv={fv} u1={0.10} v1={0.10} u2={0.90} v2={0.55} h={16} base="#5C4A6A" />
           )}
 
-          {/* Big screen structure — L4+ */}
+          {/* MID: big screen structure (v2=0.70) — L4+ */}
           {level >= 4 && (
             <Box fv={fv} u1={0.35} v1={0.55} u2={0.65} v2={0.70} h={22} base="#3A2848" />
           )}
 
-          {/* Covered side wings — L5 */}
+          {/* FRONT: merch table (v2=0.90) — L2 only */}
+          {level === 2 && (
+            <Box fv={fv} u1={0.30} v1={0.60} u2={0.70} v2={0.90} h={8} base="#7A5C8A" />
+          )}
+
+          {/* FRONT: covered side wings (v2=0.95) — L5 */}
           {level >= 5 && (
             <>
               <Box fv={fv} u1={0.04} v1={0.55} u2={0.32} v2={0.95} h={12} base="#5C4A6A" />
@@ -398,36 +379,34 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
     }
 
     // ── Grounds & Security ─────────────────────────────────────────────────
+    // Back→front: CCTV tower(v2=0.22) < booth complex(v2=0.60) < gatehouse(v2=0.65) < turnstile(v2=0.92) < hub(v2=0.96)
     case 'GROUNDS_SECURITY': {
-      // L1: barrier + small gatehouse
-      // L2: + turnstile block
-      // L3: security booth complex
-      // L4: + CCTV tower
-      // L5: full security hub
       return (
         <g style={no}>
           {/* Concrete base */}
           <Patch fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} fill="#1A1E22" />
 
-          {/* Gatehouse — L1 */}
-          <Box fv={fv} u1={0.38} v1={0.35} u2={0.62} v2={0.65} h={14} base="#3D4F58" />
-
-          {/* Turnstile block — L2+ */}
-          {level >= 2 && (
-            <Box fv={fv} u1={0.10} v1={0.62} u2={0.38} v2={0.92} h={10} base="#3D4F58" />
-          )}
-
-          {/* Security booth complex — L3+ */}
-          {level >= 3 && (
-            <Box fv={fv} u1={0.05} v1={0.05} u2={0.65} v2={0.60} h={20} base="#3D4F58" />
-          )}
-
-          {/* CCTV tower — L4+ */}
+          {/* BACK: CCTV tower — thin column (v2=0.22) — L4+ */}
           {level >= 4 && (
             <Box fv={fv} u1={0.75} v1={0.08} u2={0.85} v2={0.22} h={32} base="#2E3F48" />
           )}
 
-          {/* Security hub — L5 */}
+          {/* BACK-MID: security booth complex (v2=0.60) — L3+ */}
+          {level >= 3 && (
+            <Box fv={fv} u1={0.05} v1={0.05} u2={0.65} v2={0.60} h={20} base="#3D4F58" />
+          )}
+
+          {/* MID: gatehouse (v2=0.65) — L1–2 only */}
+          {level < 3 && (
+            <Box fv={fv} u1={0.38} v1={0.35} u2={0.62} v2={0.65} h={14} base="#3D4F58" />
+          )}
+
+          {/* FRONT: turnstile block (v2=0.92) — L2+ */}
+          {level >= 2 && level < 5 && (
+            <Box fv={fv} u1={0.10} v1={0.62} u2={0.38} v2={0.92} h={10} base="#3D4F58" />
+          )}
+
+          {/* FRONT: security hub (v2=0.96) — L5 */}
           {level >= 5 && (
             <Box fv={fv} u1={0.65} v1={0.55} u2={0.96} v2={0.96} h={22} base="#3D4F58" />
           )}
@@ -437,12 +416,9 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
 
     // ── Stadium / Pitch ────────────────────────────────────────────────────
     case 'STADIUM': {
-      // The pitch itself — grass stripes + centre circle suggestion
       return (
         <g style={no}>
-          {/* Grass surface */}
           <Patch fv={fv} u1={0.05} v1={0.05} u2={0.95} v2={0.95} fill="url(#pat-grass)" />
-          {/* Centre spot */}
           <Patch fv={fv} u1={0.45} v1={0.45} u2={0.55} v2={0.55} fill="rgba(255,255,255,0.12)" />
         </g>
       );

--- a/packages/frontend/src/components/isometric/FacilityPlotContents.tsx
+++ b/packages/frontend/src/components/isometric/FacilityPlotContents.tsx
@@ -21,7 +21,7 @@
  */
 
 import { FacilityType } from '@calculating-glory/domain';
-import { FootprintVertices, subObjectFootprint, blockPaths, footprintPath, shadeColor } from './isometric-utils';
+import { FootprintVertices, subObjectFootprint, blockPaths, footprintPath, shadeColor, facePatch } from './isometric-utils';
 
 interface Props {
   facilityType: FacilityType;
@@ -55,6 +55,58 @@ function Box({
       <path d={bp.left}  fill={lc} />
       <path d={bp.right} fill={rc} />
       <path d={bp.top}   fill={base} />
+    </g>
+  );
+}
+
+/**
+ * Single rectangular detail patch on one vertical face of a Box.
+ * Pass the same u1/v1/u2/v2/h as the parent Box so the sfv is recomputed
+ * consistently.  s/t coords: s=left→right across face, t=0 top → 1 ground.
+ */
+function FaceDetail({
+  fv, u1, v1, u2, v2, h, side, s1, t1, s2, t2, fill,
+}: {
+  fv: FootprintVertices; u1: number; v1: number; u2: number; v2: number;
+  h: number; side: 'left' | 'right';
+  s1: number; t1: number; s2: number; t2: number; fill: string;
+}) {
+  const sfv = subObjectFootprint(fv, u1, v1, u2, v2);
+  return <path d={facePatch(sfv, h, side, s1, t1, s2, t2)} fill={fill} style={{ pointerEvents: 'none' }} />;
+}
+
+/**
+ * Uniform grid of windows on one vertical face of a Box.
+ * margin controls the inset from all four edges of the face; gap is the
+ * fraction of a cell left as wall between windows.
+ */
+function FaceWindows({
+  fv, u1, v1, u2, v2, h, side, cols, rows, fill, margin = 0.10, gap = 0.20,
+}: {
+  fv: FootprintVertices; u1: number; v1: number; u2: number; v2: number;
+  h: number; side: 'left' | 'right'; cols: number; rows: number;
+  fill: string; margin?: number; gap?: number;
+}) {
+  const sfv = subObjectFootprint(fv, u1, v1, u2, v2);
+  const cw = (1 - 2 * margin) / cols;
+  const rh = (1 - 2 * margin) / rows;
+  return (
+    <g style={{ pointerEvents: 'none' }}>
+      {Array.from({ length: rows }).flatMap((_, r) =>
+        Array.from({ length: cols }).map((_, c) => {
+          const s1 = margin + c * cw + cw * gap * 0.5;
+          const s2 = margin + (c + 1) * cw - cw * gap * 0.5;
+          const t1 = margin + r * rh + rh * gap * 0.5;
+          const t2 = margin + (r + 1) * rh - rh * gap * 0.5;
+          return (
+            <path
+              key={`${r}-${c}`}
+              d={facePatch(sfv, h, side, s1, t1, s2, t2)}
+              fill={fill}
+            />
+          );
+        })
+      )}
     </g>
   );
 }
@@ -117,6 +169,7 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
     // ── Medical Centre ─────────────────────────────────────────────────────
     // Back→front: clinic(v2=0.55) < tent(v2=0.60) < walkway(v2=0.72) < ambulance(v2=0.95) < annex(v2=0.96)
     case 'MEDICAL_CENTER': {
+      const WIN_MED = 'rgba(220,235,240,0.55)'; // frosted clinical white
       return (
         <g style={no}>
           {/* Base tarmac surface */}
@@ -128,6 +181,14 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
               <Box fv={fv} u1={0.10} v1={0.05} u2={0.90} v2={0.55} h={26} base="#8FA8B0" />
               {/* Red cross marking on clinic roof */}
               <Patch fv={fv} u1={0.42} v1={0.08} u2={0.58} v2={0.25} fill="#E53935" />
+              {/* Red cross on left & right face walls */}
+              <FaceDetail fv={fv} u1={0.10} v1={0.05} u2={0.90} v2={0.55} h={26} side="left"  s1={0.38} t1={0.18} s2={0.62} t2={0.55} fill="#E53935" />
+              <FaceDetail fv={fv} u1={0.10} v1={0.05} u2={0.90} v2={0.55} h={26} side="left"  s1={0.22} t1={0.30} s2={0.78} t2={0.44} fill="#E53935" />
+              <FaceDetail fv={fv} u1={0.10} v1={0.05} u2={0.90} v2={0.55} h={26} side="right" s1={0.38} t1={0.18} s2={0.62} t2={0.55} fill="#E53935" />
+              <FaceDetail fv={fv} u1={0.10} v1={0.05} u2={0.90} v2={0.55} h={26} side="right" s1={0.22} t1={0.30} s2={0.78} t2={0.44} fill="#E53935" />
+              {/* Windows either side of cross */}
+              <FaceWindows fv={fv} u1={0.10} v1={0.05} u2={0.90} v2={0.55} h={26} side="left"  cols={2} rows={1} fill={WIN_MED} margin={0.08} gap={0.50} />
+              <FaceWindows fv={fv} u1={0.10} v1={0.05} u2={0.90} v2={0.55} h={26} side="right" cols={2} rows={1} fill={WIN_MED} margin={0.08} gap={0.50} />
             </>
           ) : (
             /* BACK: first-aid tent (v2=0.60) — L1–2 only */
@@ -146,7 +207,11 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
 
           {/* FRONT: full centre annex (v2=0.96) — L5 */}
           {level >= 5 && (
-            <Box fv={fv} u1={0.50} v1={0.72} u2={0.96} v2={0.96} h={20} base="#8FA8B0" />
+            <>
+              <Box fv={fv} u1={0.50} v1={0.72} u2={0.96} v2={0.96} h={20} base="#8FA8B0" />
+              <FaceWindows fv={fv} u1={0.50} v1={0.72} u2={0.96} v2={0.96} h={20} side="left"  cols={2} rows={1} fill={WIN_MED} />
+              <FaceWindows fv={fv} u1={0.50} v1={0.72} u2={0.96} v2={0.96} h={20} side="right" cols={2} rows={1} fill={WIN_MED} />
+            </>
           )}
         </g>
       );
@@ -229,6 +294,8 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
     // Back→front: HQ tower(v2=0.55) < 3-storey(v2=0.70) < 2nd storey(v2=0.60)* < annex(v2=0.95)
     // *lower-level structures are subsumed at higher levels — suppress when superseded
     case 'CLUB_OFFICE': {
+      const WIN = 'rgba(120,170,255,0.52)';   // blue glass windows
+      const WIN_DIM = 'rgba(80,120,200,0.40)'; // darker glass for lower floors
       return (
         <g style={no}>
           {/* Tarmac base + car park markings */}
@@ -237,31 +304,55 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
 
           {/* BACK: HQ tower (v2=0.55) — L5 */}
           {level >= 5 && (
-            <Box fv={fv} u1={0.28} v1={0.08} u2={0.72} v2={0.55} h={62} base="#4A5E72" />
+            <>
+              <Box fv={fv} u1={0.28} v1={0.08} u2={0.72} v2={0.55} h={62} base="#4A5E72" />
+              <FaceWindows fv={fv} u1={0.28} v1={0.08} u2={0.72} v2={0.55} h={62} side="left"  cols={2} rows={5} fill={WIN} margin={0.12} />
+              <FaceWindows fv={fv} u1={0.28} v1={0.08} u2={0.72} v2={0.55} h={62} side="right" cols={2} rows={5} fill={WIN} margin={0.12} />
+            </>
           )}
 
           {/* BACK-MID: 3-storey office (v2=0.70) — L3–4, subsumed at L5 by tower+annex */}
           {level >= 3 && level < 5 && (
-            <Box fv={fv} u1={0.10} v1={0.10} u2={0.90} v2={0.70} h={42} base="#4A5E72" />
+            <>
+              <Box fv={fv} u1={0.10} v1={0.10} u2={0.90} v2={0.70} h={42} base="#4A5E72" />
+              <FaceWindows fv={fv} u1={0.10} v1={0.10} u2={0.90} v2={0.70} h={42} side="left"  cols={3} rows={2} fill={WIN} />
+              <FaceWindows fv={fv} u1={0.10} v1={0.10} u2={0.90} v2={0.70} h={42} side="right" cols={3} rows={2} fill={WIN} />
+            </>
           )}
           {/* At L5, keep the wide base but shorter — tower rises from centre */}
           {level >= 5 && (
-            <Box fv={fv} u1={0.10} v1={0.10} u2={0.90} v2={0.70} h={28} base="#3A4E62" />
+            <>
+              <Box fv={fv} u1={0.10} v1={0.10} u2={0.90} v2={0.70} h={28} base="#3A4E62" />
+              <FaceWindows fv={fv} u1={0.10} v1={0.10} u2={0.90} v2={0.70} h={28} side="left"  cols={3} rows={1} fill={WIN_DIM} />
+              <FaceWindows fv={fv} u1={0.10} v1={0.10} u2={0.90} v2={0.70} h={28} side="right" cols={3} rows={1} fill={WIN_DIM} />
+            </>
           )}
 
           {/* BACK-MID: 2-storey office (v2=0.60) — L2 only */}
           {level === 2 && (
-            <Box fv={fv} u1={0.25} v1={0.20} u2={0.75} v2={0.60} h={28} base="#4A5E72" />
+            <>
+              <Box fv={fv} u1={0.25} v1={0.20} u2={0.75} v2={0.60} h={28} base="#4A5E72" />
+              <FaceWindows fv={fv} u1={0.25} v1={0.20} u2={0.75} v2={0.60} h={28} side="left"  cols={2} rows={1} fill={WIN} />
+              <FaceWindows fv={fv} u1={0.25} v1={0.20} u2={0.75} v2={0.60} h={28} side="right" cols={2} rows={1} fill={WIN} />
+            </>
           )}
 
           {/* BACK-MID: porta-cabin (v2=0.65) — L1 only */}
           {level === 1 && (
-            <Box fv={fv} u1={0.20} v1={0.25} u2={0.80} v2={0.65} h={14} base="#4A5E72" />
+            <>
+              <Box fv={fv} u1={0.20} v1={0.25} u2={0.80} v2={0.65} h={14} base="#4A5E72" />
+              <FaceWindows fv={fv} u1={0.20} v1={0.25} u2={0.80} v2={0.65} h={14} side="left"  cols={1} rows={1} fill={WIN} margin={0.15} />
+              <FaceWindows fv={fv} u1={0.20} v1={0.25} u2={0.80} v2={0.65} h={14} side="right" cols={1} rows={1} fill={WIN} margin={0.15} />
+            </>
           )}
 
           {/* FRONT: complex annex (v2=0.95) — L4+ */}
           {level >= 4 && (
-            <Box fv={fv} u1={0.60} v1={0.62} u2={0.96} v2={0.96} h={24} base="#3A4E62" />
+            <>
+              <Box fv={fv} u1={0.60} v1={0.62} u2={0.96} v2={0.96} h={24} base="#3A4E62" />
+              <FaceWindows fv={fv} u1={0.60} v1={0.62} u2={0.96} v2={0.96} h={24} side="left"  cols={2} rows={1} fill={WIN_DIM} />
+              <FaceWindows fv={fv} u1={0.60} v1={0.62} u2={0.96} v2={0.96} h={24} side="right" cols={2} rows={1} fill={WIN_DIM} />
+            </>
           )}
         </g>
       );
@@ -270,6 +361,8 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
     // ── Club Commercial ────────────────────────────────────────────────────
     // Back→front: shop(v2=0.55) < shopfront(v2=0.65) < stall(v2=0.70) < store(v2=0.95) < wing(v2=0.95)
     case 'CLUB_COMMERCIAL': {
+      const SIGN = '#FDD835';      // gold signage stripe
+      const WIN_SHOP = 'rgba(255,220,100,0.35)'; // warm shop-window glow
       return (
         <g style={no}>
           {/* Paved surface */}
@@ -277,12 +370,23 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
 
           {/* BACK: shop unit (v2=0.55) — L2 only, subsumed by shopfront at L3 */}
           {level === 2 && (
-            <Box fv={fv} u1={0.10} v1={0.10} u2={0.55} v2={0.55} h={18} base="#8B6F52" />
+            <>
+              <Box fv={fv} u1={0.10} v1={0.10} u2={0.55} v2={0.55} h={18} base="#8B6F52" />
+              <FaceDetail fv={fv} u1={0.10} v1={0.10} u2={0.55} v2={0.55} h={18} side="left"  s1={0} t1={0} s2={1} t2={0.18} fill={SIGN} />
+              <FaceDetail fv={fv} u1={0.10} v1={0.10} u2={0.55} v2={0.55} h={18} side="right" s1={0} t1={0} s2={1} t2={0.18} fill={SIGN} />
+            </>
           )}
 
           {/* BACK: commercial shopfront (v2=0.65) — L3+ */}
           {level >= 3 && (
-            <Box fv={fv} u1={0.05} v1={0.05} u2={0.95} v2={0.65} h={24} base="#8B6F52" />
+            <>
+              <Box fv={fv} u1={0.05} v1={0.05} u2={0.95} v2={0.65} h={24} base="#8B6F52" />
+              {/* Gold sign band + large shop window */}
+              <FaceDetail   fv={fv} u1={0.05} v1={0.05} u2={0.95} v2={0.65} h={24} side="left"  s1={0} t1={0} s2={1} t2={0.18} fill={SIGN} />
+              <FaceDetail   fv={fv} u1={0.05} v1={0.05} u2={0.95} v2={0.65} h={24} side="right" s1={0} t1={0} s2={1} t2={0.18} fill={SIGN} />
+              <FaceWindows  fv={fv} u1={0.05} v1={0.05} u2={0.95} v2={0.65} h={24} side="left"  cols={2} rows={1} fill={WIN_SHOP} margin={0.08} gap={0.15} />
+              <FaceWindows  fv={fv} u1={0.05} v1={0.05} u2={0.95} v2={0.65} h={24} side="right" cols={2} rows={1} fill={WIN_SHOP} margin={0.08} gap={0.15} />
+            </>
           )}
 
           {/* MID: market stall (v2=0.70) — L1 only */}
@@ -292,12 +396,20 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
 
           {/* FRONT: merchandise store (v2=0.95, left) — L4+ */}
           {level >= 4 && (
-            <Box fv={fv} u1={0.05} v1={0.65} u2={0.50} v2={0.95} h={20} base="#7A6040" />
+            <>
+              <Box fv={fv} u1={0.05} v1={0.65} u2={0.50} v2={0.95} h={20} base="#7A6040" />
+              <FaceDetail fv={fv} u1={0.05} v1={0.65} u2={0.50} v2={0.95} h={20} side="left"  s1={0} t1={0} s2={1} t2={0.18} fill={SIGN} />
+              <FaceDetail fv={fv} u1={0.05} v1={0.65} u2={0.50} v2={0.95} h={20} side="right" s1={0} t1={0} s2={1} t2={0.18} fill={SIGN} />
+            </>
           )}
 
           {/* FRONT: full centre wing (v2=0.95, right) — L5 */}
           {level >= 5 && (
-            <Box fv={fv} u1={0.52} v1={0.62} u2={0.96} v2={0.96} h={28} base="#8B6F52" />
+            <>
+              <Box fv={fv} u1={0.52} v1={0.62} u2={0.96} v2={0.96} h={28} base="#8B6F52" />
+              <FaceDetail fv={fv} u1={0.52} v1={0.62} u2={0.96} v2={0.96} h={28} side="left"  s1={0} t1={0} s2={1} t2={0.14} fill={SIGN} />
+              <FaceDetail fv={fv} u1={0.52} v1={0.62} u2={0.96} v2={0.96} h={28} side="right" s1={0} t1={0} s2={1} t2={0.14} fill={SIGN} />
+            </>
           )}
         </g>
       );
@@ -307,6 +419,8 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
     // Back→front: second stall(v2=0.45) < kiosk(v2=0.48) < beer van(v2=0.92) < hot dog cart(v2=0.85)
     // Hot dog cart sits mid-front; beer van is further front-left; kiosk is back-right
     case 'FOOD_AND_BEVERAGE': {
+      const AWNING = '#FF5722';   // vivid orange awning stripe
+      const AWNING2 = '#E64A19';  // darker variant for second stall
       return (
         <g style={no}>
           {/* Gravel surface */}
@@ -314,17 +428,29 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
 
           {/* BACK: second stall (v2=0.45) — L4+ */}
           {level >= 4 && (
-            <Box fv={fv} u1={0.05} v1={0.05} u2={0.32} v2={0.45} h={14} base="#7A4228" />
+            <>
+              <Box fv={fv} u1={0.05} v1={0.05} u2={0.32} v2={0.45} h={14} base="#7A4228" />
+              <FaceDetail fv={fv} u1={0.05} v1={0.05} u2={0.32} v2={0.45} h={14} side="left"  s1={0} t1={0} s2={1} t2={0.22} fill={AWNING2} />
+              <FaceDetail fv={fv} u1={0.05} v1={0.05} u2={0.32} v2={0.45} h={14} side="right" s1={0} t1={0} s2={1} t2={0.22} fill={AWNING2} />
+            </>
           )}
 
           {/* BACK: kiosk (v2=0.48) — L3+ */}
           {level >= 3 && (
-            <Box fv={fv} u1={0.35} v1={0.08} u2={0.92} v2={0.48} h={18} base="#7A4228" />
+            <>
+              <Box fv={fv} u1={0.35} v1={0.08} u2={0.92} v2={0.48} h={18} base="#7A4228" />
+              <FaceDetail fv={fv} u1={0.35} v1={0.08} u2={0.92} v2={0.48} h={18} side="left"  s1={0} t1={0} s2={1} t2={0.20} fill={AWNING} />
+              <FaceDetail fv={fv} u1={0.35} v1={0.08} u2={0.92} v2={0.48} h={18} side="right" s1={0} t1={0} s2={1} t2={0.20} fill={AWNING} />
+            </>
           )}
 
           {/* FRONT: hot dog cart (v2=0.85) — L1–2 (subsumed by kiosk at L3+) */}
           {level < 3 && (
-            <Box fv={fv} u1={0.38} v1={0.55} u2={0.62} v2={0.85} h={10} base="#C86428" />
+            <>
+              <Box fv={fv} u1={0.38} v1={0.55} u2={0.62} v2={0.85} h={10} base="#C86428" />
+              <FaceDetail fv={fv} u1={0.38} v1={0.55} u2={0.62} v2={0.85} h={10} side="left"  s1={0} t1={0} s2={1} t2={0.25} fill={AWNING} />
+              <FaceDetail fv={fv} u1={0.38} v1={0.55} u2={0.62} v2={0.85} h={10} side="right" s1={0} t1={0} s2={1} t2={0.25} fill={AWNING} />
+            </>
           )}
 
           {/* FRONT: beer van (v2=0.92) — L2+ */}
@@ -334,7 +460,11 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
 
           {/* L5: full concessions replaces individual stalls */}
           {level >= 5 && (
-            <Box fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} h={22} base="#7A4228" />
+            <>
+              <Box fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} h={22} base="#7A4228" />
+              <FaceDetail fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} h={22} side="left"  s1={0} t1={0} s2={1} t2={0.15} fill={AWNING} />
+              <FaceDetail fv={fv} u1={0.04} v1={0.04} u2={0.96} v2={0.96} h={22} side="right" s1={0} t1={0} s2={1} t2={0.15} fill={AWNING} />
+            </>
           )}
         </g>
       );
@@ -343,6 +473,8 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
     // ── Fan Zone ───────────────────────────────────────────────────────────
     // Back→front: poles(v2=0.20) < pavilion(v2=0.55) < screen(v2=0.70) < table(v2=0.90) < wings(v2=0.95)
     case 'FAN_ZONE': {
+      const BANNER = '#AB47BC'; // vivid purple banner stripe
+      const SCREEN = '#0D0D18'; // near-black screen face
       return (
         <g style={no}>
           {/* Paved plaza */}
@@ -354,12 +486,22 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
 
           {/* BACK-MID: entertainment pavilion (v2=0.55) — L3+ */}
           {level >= 3 && (
-            <Box fv={fv} u1={0.10} v1={0.10} u2={0.90} v2={0.55} h={16} base="#5C4A6A" />
+            <>
+              <Box fv={fv} u1={0.10} v1={0.10} u2={0.90} v2={0.55} h={16} base="#5C4A6A" />
+              {/* Banner stripe across top of pavilion faces */}
+              <FaceDetail fv={fv} u1={0.10} v1={0.10} u2={0.90} v2={0.55} h={16} side="left"  s1={0} t1={0} s2={1} t2={0.25} fill={BANNER} />
+              <FaceDetail fv={fv} u1={0.10} v1={0.10} u2={0.90} v2={0.55} h={16} side="right" s1={0} t1={0} s2={1} t2={0.25} fill={BANNER} />
+            </>
           )}
 
           {/* MID: big screen structure (v2=0.70) — L4+ */}
           {level >= 4 && (
-            <Box fv={fv} u1={0.35} v1={0.55} u2={0.65} v2={0.70} h={22} base="#3A2848" />
+            <>
+              <Box fv={fv} u1={0.35} v1={0.55} u2={0.65} v2={0.70} h={22} base="#3A2848" />
+              {/* Screen face — dark panel on the front faces */}
+              <FaceDetail fv={fv} u1={0.35} v1={0.55} u2={0.65} v2={0.70} h={22} side="left"  s1={0.08} t1={0.08} s2={0.92} t2={0.88} fill={SCREEN} />
+              <FaceDetail fv={fv} u1={0.35} v1={0.55} u2={0.65} v2={0.70} h={22} side="right" s1={0.08} t1={0.08} s2={0.92} t2={0.88} fill={SCREEN} />
+            </>
           )}
 
           {/* FRONT: merch table (v2=0.90) — L2 only */}
@@ -371,7 +513,11 @@ export function FacilityPlotContents({ facilityType, fv, level }: Props) {
           {level >= 5 && (
             <>
               <Box fv={fv} u1={0.04} v1={0.55} u2={0.32} v2={0.95} h={12} base="#5C4A6A" />
+              <FaceDetail fv={fv} u1={0.04} v1={0.55} u2={0.32} v2={0.95} h={12} side="left"  s1={0} t1={0} s2={1} t2={0.30} fill={BANNER} />
+              <FaceDetail fv={fv} u1={0.04} v1={0.55} u2={0.32} v2={0.95} h={12} side="right" s1={0} t1={0} s2={1} t2={0.30} fill={BANNER} />
               <Box fv={fv} u1={0.68} v1={0.55} u2={0.96} v2={0.95} h={12} base="#5C4A6A" />
+              <FaceDetail fv={fv} u1={0.68} v1={0.55} u2={0.96} v2={0.95} h={12} side="left"  s1={0} t1={0} s2={1} t2={0.30} fill={BANNER} />
+              <FaceDetail fv={fv} u1={0.68} v1={0.55} u2={0.96} v2={0.95} h={12} side="right" s1={0} t1={0} s2={1} t2={0.30} fill={BANNER} />
             </>
           )}
         </g>

--- a/packages/frontend/src/components/isometric/isometric-utils.ts
+++ b/packages/frontend/src/components/isometric/isometric-utils.ts
@@ -162,6 +162,56 @@ export function blockPaths(fv: FootprintVertices, bh: number): BlockPaths {
 }
 
 // ---------------------------------------------------------------------------
+// Vertical face patch (windows, doors, signs, awnings)
+// ---------------------------------------------------------------------------
+
+/**
+ * SVG path for a rectangular patch on one vertical face of an isometric box.
+ *
+ * Use this to add windows, doors, signs, or awning stripes to any Box.
+ * The same sfv + bh passed to blockPaths() should be passed here.
+ *
+ * Face coordinate system:
+ *   s: 0 = near (left) edge of the face, 1 = far (right) edge
+ *   t: 0 = top of the face (height bh), 1 = ground level
+ *
+ * @param sfv   Sub-object footprint vertices
+ * @param bh    Block height in pixels (same value used in blockPaths)
+ * @param side  'left' = SW parallelogram face, 'right' = SE parallelogram face
+ * @param s1    Horizontal start (0–1)
+ * @param t1    Vertical start   (0–1, 0=top)
+ * @param s2    Horizontal end
+ * @param t2    Vertical end
+ */
+export function facePatch(
+  sfv: FootprintVertices,
+  bh: number,
+  side: 'left' | 'right',
+  s1: number, t1: number,
+  s2: number, t2: number,
+): string {
+  let TL: {x:number;y:number}, TR: {x:number;y:number},
+      BR: {x:number;y:number}, BL: {x:number;y:number};
+  if (side === 'left') {
+    TL = { x: sfv.left.x,   y: sfv.left.y - bh };
+    TR = { x: sfv.bottom.x, y: sfv.bottom.y - bh };
+    BR = { x: sfv.bottom.x, y: sfv.bottom.y };
+    BL = { x: sfv.left.x,   y: sfv.left.y };
+  } else {
+    TL = { x: sfv.bottom.x, y: sfv.bottom.y - bh };
+    TR = { x: sfv.right.x,  y: sfv.right.y - bh };
+    BR = { x: sfv.right.x,  y: sfv.right.y };
+    BL = { x: sfv.bottom.x, y: sfv.bottom.y };
+  }
+  const p = (s: number, t: number) => ({
+    x: TL.x*(1-s)*(1-t) + TR.x*s*(1-t) + BR.x*s*t + BL.x*(1-s)*t,
+    y: TL.y*(1-s)*(1-t) + TR.y*s*(1-t) + BR.y*s*t + BL.y*(1-s)*t,
+  });
+  const a = p(s1,t1), b = p(s2,t1), c = p(s2,t2), d = p(s1,t2);
+  return `M ${a.x},${a.y} L ${b.x},${b.y} L ${c.x},${c.y} L ${d.x},${d.y} Z`;
+}
+
+// ---------------------------------------------------------------------------
 // Plot sub-object geometry
 // ---------------------------------------------------------------------------
 

--- a/packages/frontend/src/components/isometric/isometric-utils.ts
+++ b/packages/frontend/src/components/isometric/isometric-utils.ts
@@ -162,6 +162,59 @@ export function blockPaths(fv: FootprintVertices, bh: number): BlockPaths {
 }
 
 // ---------------------------------------------------------------------------
+// Plot sub-object geometry
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a normalised rectangle (u1,v1)→(u2,v2) within a plot's ground diamond
+ * to a FootprintVertices for use with blockPaths().
+ *
+ * Coordinate system on the plot diamond:
+ *   u=0 → NW edge,  u=1 → NE edge
+ *   v=0 → back (NW→NE), v=1 → front (SW→SE)
+ *
+ * Example: subObjectFootprint(fv, 0.1, 0.1, 0.5, 0.6) places a box in the
+ * back-left quarter of the plot.
+ */
+export function subObjectFootprint(
+  fv: FootprintVertices,
+  u1: number, v1: number,
+  u2: number, v2: number,
+): FootprintVertices {
+  const TL = fv.top, TR = fv.right, BL = fv.left;
+  const p = (u: number, v: number) => ({
+    x: TL.x + u * (TR.x - TL.x) + v * (BL.x - TL.x),
+    y: TL.y + u * (TR.y - TL.y) + v * (BL.y - TL.y),
+  });
+  return { top: p(u1,v1), right: p(u2,v1), bottom: p(u2,v2), left: p(u1,v2) };
+}
+
+// ---------------------------------------------------------------------------
+// Tier geometry
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Colour utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Adjust a hex colour by a percentage.
+ * Positive percent = lighter, negative = darker.
+ * e.g. shadeColor('#448AFF', -15) → 15% darker version of that blue
+ */
+export function shadeColor(hex: string, percent: number): string {
+  const clean = hex.replace('#', '');
+  const r = parseInt(clean.slice(0, 2), 16);
+  const g = parseInt(clean.slice(2, 4), 16);
+  const b = parseInt(clean.slice(4, 6), 16);
+  const factor = 1 + percent / 100;
+  const nr = Math.min(255, Math.max(0, Math.round(r * factor)));
+  const ng = Math.min(255, Math.max(0, Math.round(g * factor)));
+  const nb = Math.min(255, Math.max(0, Math.round(b * factor)));
+  return `#${nr.toString(16).padStart(2, '0')}${ng.toString(16).padStart(2, '0')}${nb.toString(16).padStart(2, '0')}`;
+}
+
+// ---------------------------------------------------------------------------
 // Helpers for icon / label placement
 // ---------------------------------------------------------------------------
 

--- a/packages/frontend/src/components/isometric/stadium-layout.ts
+++ b/packages/frontend/src/components/isometric/stadium-layout.ts
@@ -7,11 +7,14 @@
  *
  *   LEFT COLUMN           CENTRE              RIGHT COLUMN
  *   ─────────────────────────────────────────────────────
- *   Training (0,1)      The Pitch (7,2)      Club Office  (14,1)
- *   Medical  (0,5)                           Commercial   (14,5)
- *   Scout    (0,8)                           Food & Bev   (14,8)
+ *   Training (0,1)      The Pitch (6,1)      Club Office  (15,1)
+ *   Medical  (0,5)       8×7 plot            Commercial   (15,5)
+ *   Scout    (0,8)    (1-tile stand border)  Food & Bev   (15,8)
  *   Youth    (0,11)
  *                   Fan Zone (6,11)  Security (11,11)
+ *
+ * The STADIUM plot is sized 8×7 (was 6×5) so that future stand sub-objects
+ * can fill the 1-tile border around the 6×5 grass pitch within the same plot.
  *
  * Every facility is represented by exactly one CoreUnitDef.  The STADIUM
  * facility is visualised as The Pitch only — The Stands will be added in a
@@ -84,7 +87,7 @@ export const STADIUM_LAYOUT: CoreUnitDef[] = [
     facilityType: 'STADIUM',
     label:        'The Pitch',
     icon:         '⚽',
-    gc: 7, gr: 2, cols: 6, rows: 5,
+    gc: 6, gr: 1, cols: 8, rows: 7,
     colors: {
       ground:    '#2D5A1B',
       base:      '#3A7D2C',
@@ -155,7 +158,7 @@ export const STADIUM_LAYOUT: CoreUnitDef[] = [
     facilityType: 'CLUB_OFFICE',
     label:        'Club Office',
     icon:         '🏢',
-    gc: 14, gr: 1, cols: 3, rows: 3,
+    gc: 15, gr: 1, cols: 3, rows: 3,
     colors: {
       ground:    '#141E2E',
       base:      '#4A5E72',
@@ -168,7 +171,7 @@ export const STADIUM_LAYOUT: CoreUnitDef[] = [
     facilityType: 'CLUB_COMMERCIAL',
     label:        'Commercial Centre',
     icon:         '💰',
-    gc: 14, gr: 5, cols: 3, rows: 2,
+    gc: 15, gr: 5, cols: 3, rows: 2,
     colors: {
       ground:   '#2A1C08',
       base:     '#8B6F52',
@@ -181,7 +184,7 @@ export const STADIUM_LAYOUT: CoreUnitDef[] = [
     facilityType: 'FOOD_AND_BEVERAGE',
     label:        'Food & Beverage',
     icon:         '🍔',
-    gc: 14, gr: 8, cols: 3, rows: 2,
+    gc: 15, gr: 8, cols: 3, rows: 2,
     colors: {
       ground:   '#281408',
       base:     '#7A4228',

--- a/packages/frontend/src/components/isometric/stadium-layout.ts
+++ b/packages/frontend/src/components/isometric/stadium-layout.ts
@@ -7,21 +7,23 @@
  *
  *   LEFT COLUMN           CENTRE              RIGHT COLUMN
  *   ─────────────────────────────────────────────────────
- *   Training (1,1)      The Pitch (7,2)      Club Office (15,1)
- *   Medical  (1,5)                           Commercial  (15,5)
- *   Scout    (1,7)                           Food & Bev  (15,9)
- *   Youth    (1,9)
+ *   Training (0,1)      The Pitch (7,2)      Club Office  (14,1)
+ *   Medical  (0,5)                           Commercial   (14,5)
+ *   Scout    (0,8)                           Food & Bev   (14,8)
+ *   Youth    (0,11)
  *                   Fan Zone (6,11)  Security (11,11)
  *
  * Every facility is represented by exactly one CoreUnitDef.  The STADIUM
  * facility is visualised as The Pitch only — The Stands will be added in a
  * later PR as a separate surrounding element driven by STADIUM level.
  *
- * Shading model (Gemini visual spec, PR 6):
- *   Top face:  base colour (100% light)
- *   SW face:   base colour + rgba(0,0,0,0.30) overlay (70% light)
- *   SE face:   base colour + rgba(0,0,0,0.55) overlay (45% light)
- *   Highlight: 1px rgba(255,255,255,0.20) line on top front edge (T→R)
+ * Visual model:
+ *   Each facility is a PLOT that fills with sub-objects as levels increase.
+ *   Level 0: grass-textured plot with a faint dashed outline only.
+ *   Level 1–5: sub-objects from FacilityPlotContents rendered within the plot.
+ *   The `colors.base` token is the primary material used by plot sub-objects.
+ *   The `colors.ground` token is the plot base fill (soil/tarmac/concrete).
+ *   See FacilityPlotContents.tsx for per-facility progression details.
  */
 
 import { FacilityType } from '@calculating-glory/domain';
@@ -31,26 +33,24 @@ import { FacilityType } from '@calculating-glory/domain';
 // ---------------------------------------------------------------------------
 
 export interface CoreUnitColors {
-  /** Ground tile fill (level 0 — empty plot). */
+  /**
+   * Ground base fill for this plot type (level 1+ only).
+   * Level 0 always uses url(#pat-ground) from the SVG defs.
+   */
   ground: string;
   /**
-   * Building base colour — applied at 100% on the top face.
-   * SW face receives an rgba(0,0,0,0.30) overlay; SE face gets rgba(0,0,0,0.55).
-   * This produces 3-tone shading from a single hue without pre-baking hex values.
+   * Primary colour token for sub-objects in this plot.
+   * Used as the base colour for all FacilityPlotContents Box components.
+   * Should be muted/realistic; vivid colour belongs in flagColor.
    */
   base: string;
-  /**
-   * Optional SVG fill override for the top face (e.g. 'url(#pat-grass)').
-   * When set, the top face renders this pattern on top of the base colour.
-   */
-  topPattern?: string;
-  /**
-   * Optional SVG fill overlay for the SW face (e.g. 'url(#pat-concrete)').
-   * Applied on top of the base colour + 30% dark overlay.
-   */
-  swPattern?: string;
   /** Icon / pip text colour. */
   label: string;
+  /**
+   * Accent colour used to identify this facility (future use: hover glow,
+   * upgrade button highlight, chart colour).
+   */
+  flagColor: string;
 }
 
 export interface CoreUnitDef {
@@ -70,12 +70,6 @@ export interface CoreUnitDef {
   cols: number;
   /** Footprint depth in tiles. */
   rows: number;
-  /**
-   * Building block height in pixels for each level (indices 0–5).
-   * Level 0 = empty ground plot (height 0 = flat diamond only).
-   * Levels 1–5 = increasingly tall/wide buildings.
-   */
-  blockHeights: [number, number, number, number, number, number];
   colors: CoreUnitColors;
 }
 
@@ -85,19 +79,17 @@ export interface CoreUnitDef {
 
 export const STADIUM_LAYOUT: CoreUnitDef[] = [
   // ── The Pitch ────────────────────────────────────────────────────────────
-  // Central 6×5 footprint.  Driven by the STADIUM facility.
   {
     id:           'pitch',
     facilityType: 'STADIUM',
     label:        'The Pitch',
     icon:         '⚽',
     gc: 7, gr: 2, cols: 6, rows: 5,
-    blockHeights: [4, 8, 12, 16, 20, 24],
     colors: {
-      ground:     '#2D5A1B',
-      base:       '#4CAF50',
-      topPattern: 'url(#pat-grass)',  // grass stripe pattern on top face
-      label:      '#FFFFFF',
+      ground:    '#2D5A1B',
+      base:      '#3A7D2C',
+      label:     '#FFFFFF',
+      flagColor: '#FFFFFF',
     },
   },
 
@@ -108,13 +100,12 @@ export const STADIUM_LAYOUT: CoreUnitDef[] = [
     facilityType: 'TRAINING_GROUND',
     label:        'Training Ground',
     icon:         '🏋',
-    gc: 1, gr: 1, cols: 3, rows: 2,
-    blockHeights: [0, 20, 30, 40, 52, 64],
+    gc: 0, gr: 1, cols: 4, rows: 3,
     colors: {
-      ground:    '#5C4A18',
-      base:      '#FF8F00',
-      swPattern: 'url(#pat-concrete)',  // concrete stipple on SW (shadow) face
+      ground:    '#2E1A0A',
+      base:      '#7A5C3A',
       label:     '#FFFFFF',
+      flagColor: '#FF8F00',
     },
   },
   {
@@ -122,13 +113,12 @@ export const STADIUM_LAYOUT: CoreUnitDef[] = [
     facilityType: 'MEDICAL_CENTER',
     label:        'Medical Centre',
     icon:         '🏥',
-    gc: 1, gr: 5, cols: 2, rows: 2,
-    blockHeights: [0, 20, 30, 40, 52, 64],
+    gc: 0, gr: 5, cols: 3, rows: 2,
     colors: {
-      ground:    '#3A3A3A',
-      base:      '#ECEFF1',
-      swPattern: 'url(#pat-concrete)',
-      label:     '#263238',
+      ground:    '#1C2B30',
+      base:      '#8FA8B0',
+      label:     '#FFFFFF',
+      flagColor: '#E53935',
     },
   },
   {
@@ -136,12 +126,12 @@ export const STADIUM_LAYOUT: CoreUnitDef[] = [
     facilityType: 'SCOUT_NETWORK',
     label:        'Scout Network',
     icon:         '🔭',
-    gc: 1, gr: 7, cols: 2, rows: 2,
-    blockHeights: [0, 16, 24, 34, 44, 56],
+    gc: 0, gr: 8, cols: 3, rows: 2,
     colors: {
-      ground: '#0A1A2A',
-      base:   '#1565C0',
-      label:  '#FFFFFF',
+      ground:   '#0A1520',
+      base:     '#2E3F4F',
+      label:    '#FFFFFF',
+      flagColor:'#29B6F6',
     },
   },
   {
@@ -149,12 +139,12 @@ export const STADIUM_LAYOUT: CoreUnitDef[] = [
     facilityType: 'YOUTH_ACADEMY',
     label:        'Youth Academy',
     icon:         '🌱',
-    gc: 1, gr: 9, cols: 3, rows: 2,
-    blockHeights: [0, 20, 30, 40, 52, 64],
+    gc: 0, gr: 11, cols: 4, rows: 2,
     colors: {
-      ground: '#0D3A3A',
-      base:   '#26C6DA',
-      label:  '#FFFFFF',
+      ground:   '#122020',
+      base:     '#5B7E8A',
+      label:    '#FFFFFF',
+      flagColor:'#26C6DA',
     },
   },
 
@@ -165,13 +155,12 @@ export const STADIUM_LAYOUT: CoreUnitDef[] = [
     facilityType: 'CLUB_OFFICE',
     label:        'Club Office',
     icon:         '🏢',
-    gc: 15, gr: 1, cols: 2, rows: 2,
-    blockHeights: [0, 24, 36, 48, 60, 72],
+    gc: 14, gr: 1, cols: 3, rows: 3,
     colors: {
-      ground:    '#1A2A4A',
-      base:      '#448AFF',
-      swPattern: 'url(#pat-concrete)',
+      ground:    '#141E2E',
+      base:      '#4A5E72',
       label:     '#FFFFFF',
+      flagColor: '#448AFF',
     },
   },
   {
@@ -179,12 +168,12 @@ export const STADIUM_LAYOUT: CoreUnitDef[] = [
     facilityType: 'CLUB_COMMERCIAL',
     label:        'Commercial Centre',
     icon:         '💰',
-    gc: 15, gr: 5, cols: 2, rows: 2,
-    blockHeights: [0, 20, 30, 42, 54, 66],
+    gc: 14, gr: 5, cols: 3, rows: 2,
     colors: {
-      ground: '#3A2A08',
-      base:   '#FDD835',
-      label:  '#212121',
+      ground:   '#2A1C08',
+      base:     '#8B6F52',
+      label:    '#FFFFFF',
+      flagColor:'#FDD835',
     },
   },
   {
@@ -192,12 +181,12 @@ export const STADIUM_LAYOUT: CoreUnitDef[] = [
     facilityType: 'FOOD_AND_BEVERAGE',
     label:        'Food & Beverage',
     icon:         '🍔',
-    gc: 15, gr: 9, cols: 2, rows: 2,
-    blockHeights: [0, 16, 24, 34, 44, 56],
+    gc: 14, gr: 8, cols: 3, rows: 2,
     colors: {
-      ground: '#3A1A08',
-      base:   '#FF7043',
-      label:  '#FFFFFF',
+      ground:   '#281408',
+      base:     '#7A4228',
+      label:    '#FFFFFF',
+      flagColor:'#FF7043',
     },
   },
 
@@ -208,12 +197,12 @@ export const STADIUM_LAYOUT: CoreUnitDef[] = [
     facilityType: 'FAN_ZONE',
     label:        'Fan Zone',
     icon:         '🎉',
-    gc: 6, gr: 11, cols: 3, rows: 2,
-    blockHeights: [0, 14, 22, 32, 42, 52],
+    gc: 6, gr: 11, cols: 4, rows: 2,
     colors: {
-      ground: '#2A0A3A',
-      base:   '#AB47BC',
-      label:  '#FFFFFF',
+      ground:   '#1A0A28',
+      base:     '#5C4A6A',
+      label:    '#FFFFFF',
+      flagColor:'#AB47BC',
     },
   },
   {
@@ -221,13 +210,12 @@ export const STADIUM_LAYOUT: CoreUnitDef[] = [
     facilityType: 'GROUNDS_SECURITY',
     label:        'Grounds & Security',
     icon:         '🎟',
-    gc: 11, gr: 11, cols: 3, rows: 2,
-    blockHeights: [0, 14, 22, 32, 42, 52],
+    gc: 11, gr: 11, cols: 4, rows: 2,
     colors: {
-      ground:    '#2A2A2A',
-      base:      '#78909C',
-      swPattern: 'url(#pat-concrete)',
+      ground:    '#1A1A1A',
+      base:      '#3D4F58',
       label:     '#FFFFFF',
+      flagColor: '#FFD740',
     },
   },
 ];
@@ -239,9 +227,13 @@ export const STADIUM_LAYOUT: CoreUnitDef[] = [
 /**
  * Core units sorted for correct SVG painter's algorithm rendering.
  *
- * Sort key = gc + gr (smaller = further back = rendered first).
- * For multi-tile footprints use the front edge: (gc + cols) + (gr + rows).
+ * Sort key = front corner of the footprint: (gc + cols - 1) + (gr + rows - 1).
+ * This is the isometric tile closest to the viewer for each plot, which is what
+ * determines whether one plot visually overlaps another.
+ * Smaller key = further from viewer = rendered first (painted underneath).
  */
 export const STADIUM_LAYOUT_SORTED: CoreUnitDef[] = [...STADIUM_LAYOUT].sort(
-  (a, b) => (a.gc + a.gr) - (b.gc + b.gr),
+  (a, b) =>
+    (a.gc + a.cols - 1 + a.gr + a.rows - 1) -
+    (b.gc + b.cols - 1 + b.gr + b.rows - 1),
 );


### PR DESCRIPTION
## Summary

Ships the stadium visual overhaul work from the 2026-04-03 session. Five commits that were built but never raised to a PR.

- **Plot-based facility rendering** — each facility now renders as a collection of per-level sub-objects within its grid plot, replacing the previous flat-colour tile approach
- **Painter's algorithm fix** — correct draw order within facility plots so foreground sub-objects always render on top
- **Face detail textures** — windows, awnings, and signage added to facility buildings for visual depth
- **Border cleanup** — plot border outline removed at level 1+; buildings now define their own edges
- **Pitch plot expansion** — pitch plot enlarged and right column shifted to make room for future stands tiles

## Test plan

- [ ] Stadium View loads without errors
- [ ] Each facility renders with correct sub-objects at its current level
- [ ] Upgrading a facility shows the correct higher-level sub-objects
- [ ] No z-order issues — foreground buildings render in front of background ones
- [ ] Face details (windows, awnings, signage) visible on facility buildings
- [ ] No visible plot border outline on built facilities (level 1+)
- [ ] Pitch plot size looks correct; right column tiles align properly
- [ ] Construction state (amber dashes + 🏗) still renders correctly while building

🤖 Generated with [Claude Code](https://claude.com/claude-code)