### PR TITLE
feat(#83): season arc — club records, board confidence drift, head-to-head history

### DIFF
--- a/packages/domain/src/reducers/index.ts
+++ b/packages/domain/src/reducers/index.ts
@@ -146,6 +146,8 @@ export function buildState(events: GameEvent[]): GameState {
     npcStrengths: {},
     resolvedEventWeeks: {},
     mathsOutcomes: {},
+    clubRecords: { biggestWin: null, longestWinStreak: 0 },
+    currentWinStreak: 0,
   };
 
   return events.reduce(reduceEvent, initialState);
@@ -327,19 +329,60 @@ function handleMatchSimulated(state: GameState, event: MatchSimulatedEvent): Gam
 
   // Layer 1: result morale delta — applied when the player's club played this fixture
   let squad = state.club.squad;
+  const opponentId = state.club.id === homeTeamId ? awayTeamId : homeTeamId;
   if (clubResult && squad.length > 0) {
     const playerEntry   = sorted.find(e => e.clubId === state.club.id);
-    const opponentId    = state.club.id === homeTeamId ? awayTeamId : homeTeamId;
     const opponentEntry = sorted.find(e => e.clubId === opponentId);
     const playerPos     = playerEntry?.position   ?? 12;
     const opponentPos   = opponentEntry?.position ?? 12;
     squad = applyResultMoraleDelta(squad, clubResult, playerPos, opponentPos, clubForm);
   }
 
+  // Layer 2: club records + board confidence drift (only when player's club played)
+  let clubRecords = state.clubRecords;
+  let currentWinStreak = state.currentWinStreak ?? 0;
+  let boardConfidence = state.boardConfidence;
+
+  if (clubResult) {
+    const isHome = state.club.id === homeTeamId;
+    const playerGoals   = isHome ? homeGoals : awayGoals;
+    const opponentGoals = isHome ? awayGoals : homeGoals;
+    const margin        = playerGoals - opponentGoals;
+    const opponentEntry = state.league.entries.find(e => e.clubId === opponentId);
+    const opponentName  = opponentEntry?.clubName ?? 'Unknown';
+
+    // Update win streak
+    if (clubResult === 'W') {
+      currentWinStreak += 1;
+    } else {
+      currentWinStreak = 0;
+    }
+
+    // Update all-time records
+    const existingMargin = clubRecords.biggestWin
+      ? clubRecords.biggestWin.playerGoals - clubRecords.biggestWin.opponentGoals
+      : -1;
+
+    clubRecords = {
+      biggestWin:
+        clubResult === 'W' && margin > existingMargin
+          ? { playerGoals, opponentGoals, opponentName, week: state.currentWeek + 1, season: state.season }
+          : clubRecords.biggestWin,
+      longestWinStreak: Math.max(clubRecords.longestWinStreak, currentWinStreak),
+    };
+
+    // Board confidence drift — small per-match signal so form builds pressure
+    const confDelta = clubResult === 'W' ? 2 : clubResult === 'L' ? -3 : 0;
+    boardConfidence = Math.max(5, Math.min(95, boardConfidence + confDelta));
+  }
+
   return {
     ...state,
     league: { ...state.league, entries: sorted },
-    club: { ...state.club, form: clubForm, squad }
+    club: { ...state.club, form: clubForm, squad },
+    clubRecords,
+    currentWinStreak,
+    boardConfidence,
   };
 }
 

--- a/packages/domain/src/types/game-state-updated.ts
+++ b/packages/domain/src/types/game-state-updated.ts
@@ -240,6 +240,40 @@ export interface GameState {
    * (e.g. a "re-inspection pass" hop vs "re-inspection fail" hop).
    */
   mathsOutcomes: Record<string, 'correct' | 'wrong'>;
+
+  /**
+   * All-time club records — persists across seasons.
+   * Updated whenever a new record is set during a match.
+   */
+  clubRecords: ClubRecords;
+
+  /**
+   * Current consecutive win streak (reset to 0 on draw or loss).
+   * Used to update clubRecords.longestWinStreak in real time.
+   */
+  currentWinStreak: number;
+}
+
+// ── Club Records ──────────────────────────────────────────────────────────────
+
+export interface ClubBestWin {
+  /** Goals scored by the player's club */
+  playerGoals: number;
+  /** Goals conceded */
+  opponentGoals: number;
+  /** Name of the beaten opponent */
+  opponentName: string;
+  /** Week the result happened */
+  week: number;
+  /** Season it happened in */
+  season: number;
+}
+
+export interface ClubRecords {
+  /** Biggest ever win by goal margin (null until first win by 2+ goals). */
+  biggestWin: ClubBestWin | null;
+  /** Longest ever consecutive win streak. */
+  longestWinStreak: number;
 }
 
 /**

--- a/packages/frontend/src/components/command-centre/CommandCentre.tsx
+++ b/packages/frontend/src/components/command-centre/CommandCentre.tsx
@@ -104,6 +104,7 @@ export function CommandCentre({ state, events, dispatch, isLoading, onNavigateTo
           freeAgents={state.freeAgentPool ?? []}
           pendingEvents={state.pendingEvents}
           currentWeek={state.currentWeek}
+          clubRecords={state.clubRecords}
         />
         {dim('news-ticker')}
       </div>

--- a/packages/frontend/src/components/command-centre/NewsTicker.tsx
+++ b/packages/frontend/src/components/command-centre/NewsTicker.tsx
@@ -1,4 +1,4 @@
-import { GameEvent, MatchSimulatedEvent, MoraleTickerEvent, Player, PendingClubEvent, avgSquadMorale, isUnsettled } from '@calculating-glory/domain';
+import { GameEvent, MatchSimulatedEvent, MoraleTickerEvent, Player, PendingClubEvent, avgSquadMorale, isUnsettled, ClubRecords } from '@calculating-glory/domain';
 import { LeagueTableEntry } from '@calculating-glory/domain';
 
 // ── Ordinal helper ──────────────────────────────────────────────────────────
@@ -19,6 +19,7 @@ interface NewsTickerProps {
   freeAgents?: Player[];
   pendingEvents?: PendingClubEvent[];
   currentWeek?: number;
+  clubRecords?: ClubRecords;
 }
 
 // ── Season arc headlines ────────────────────────────────────────────────────
@@ -33,6 +34,7 @@ function buildSeasonArcHeadlines(
   clubName: string,
   leagueEntries: LeagueTableEntry[],
   currentWeek?: number,
+  clubRecords?: ClubRecords,
 ): string[] {
   if (!currentWeek || currentWeek < 3) return [];
 
@@ -107,9 +109,17 @@ function buildSeasonArcHeadlines(
     });
     const prevBest = margins.length > 0 ? Math.max(...margins) : 0;
     if (lastDiff > prevBest) {
-      const opponentId = lastIsHome ? lastMatch.awayTeamId : lastMatch.homeTeamId;
+      const opponentId   = lastIsHome ? lastMatch.awayTeamId : lastMatch.homeTeamId;
       const opponentName = nameMap.get(opponentId) ?? 'opposition';
-      headlines.push(`★ SEASON BEST — ${lastP}–${lastO} vs ${opponentName} — ${clubName}'s biggest win this season`);
+      const allTimeBest  = clubRecords?.biggestWin
+        ? clubRecords.biggestWin.playerGoals - clubRecords.biggestWin.opponentGoals
+        : 0;
+      const isAllTimeRecord = lastDiff > allTimeBest;
+      if (isAllTimeRecord) {
+        headlines.push(`🏆 ALL-TIME CLUB RECORD — ${lastP}–${lastO} vs ${opponentName} — ${clubName}'s biggest ever win`);
+      } else {
+        headlines.push(`★ SEASON BEST — ${lastP}–${lastO} vs ${opponentName} — ${clubName}'s biggest win this season`);
+      }
     }
   }
 
@@ -205,7 +215,8 @@ function buildHeadlines(
   nameMap: Map<string, string>,
   squad: Player[],
   leagueEntries: LeagueTableEntry[],
-  currentWeek?: number
+  currentWeek?: number,
+  clubRecords?: ClubRecords
 ): string[] {
   const headlines: string[] = [];
 
@@ -266,13 +277,13 @@ function buildHeadlines(
     }
   }
 
-  const arcHeadlines = buildSeasonArcHeadlines(events, clubId, clubName, leagueEntries, currentWeek);
+  const arcHeadlines = buildSeasonArcHeadlines(events, clubId, clubName, leagueEntries, currentWeek, clubRecords as ClubRecords | undefined);
   return [...headlines.slice(-30).reverse(), ...buildMoraleHeadlines(squad), ...milestoneHeadlines, ...arcHeadlines];
 }
 
-export function NewsTicker({ events, clubId, clubName, stadiumName, leagueEntries, squad, freeAgents, pendingEvents, currentWeek }: NewsTickerProps) {
+export function NewsTicker({ events, clubId, clubName, stadiumName, leagueEntries, squad, freeAgents, pendingEvents, currentWeek, clubRecords }: NewsTickerProps) {
   const nameMap = new Map<string, string>(leagueEntries.map(e => [e.clubId, e.clubName]));
-  const eventHeadlines = buildHeadlines(events, clubId, clubName, stadiumName, nameMap, squad, leagueEntries, currentWeek);
+  const eventHeadlines = buildHeadlines(events, clubId, clubName, stadiumName, nameMap, squad, leagueEntries, currentWeek, clubRecords);
   const rumourHeadlines = freeAgents && freeAgents.length > 0 ? buildRumourHeadlines(freeAgents, clubName) : [];
   const poachHeadlines = pendingEvents ? buildPoachHeadlines(pendingEvents) : [];
   const headlines = [...poachHeadlines, ...eventHeadlines, ...rumourHeadlines];

--- a/packages/frontend/src/components/owner-box/PreMatchOverlay.tsx
+++ b/packages/frontend/src/components/owner-box/PreMatchOverlay.tsx
@@ -4,6 +4,7 @@ import {
   getWeekFixtures,
   LeagueTable,
   avgSquadMorale,
+  MatchSimulatedEvent,
 } from '@calculating-glory/domain';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -161,6 +162,25 @@ export function PreMatchOverlay({ state, onKickOff, onCancel }: PreMatchOverlayP
   const formation = state.club.preferredFormation;
   const teaser = getNpcTeaser(nextWeek, state.season, !!sixPointer, myForm);
 
+  // Head-to-head: find the most recent previous match vs this opponent
+  const prevMatch = opponentId ? (() => {
+    const matches = (state.events as MatchSimulatedEvent[])
+      .filter(e =>
+        (e as any).type === 'MATCH_SIMULATED' &&
+        (e.homeTeamId === state.club.id || e.awayTeamId === state.club.id) &&
+        (e.homeTeamId === opponentId || e.awayTeamId === opponentId),
+      );
+    const prev = matches[matches.length - 1];
+    if (!prev) return null;
+    const isHome = prev.homeTeamId === state.club.id;
+    const pGoals = isHome ? prev.homeGoals : prev.awayGoals;
+    const oGoals = isHome ? prev.awayGoals : prev.homeGoals;
+    const result: 'W' | 'D' | 'L' = pGoals > oGoals ? 'W' : pGoals < oGoals ? 'L' : 'D';
+    const weekNum = parseInt((prev.matchId ?? '0').split('-W')[1] ?? '0');
+    const seasonNum = parseInt((prev.matchId ?? '0').replace('S', '').split('-')[0] ?? '1');
+    return { pGoals, oGoals, result, week: weekNum, season: seasonNum };
+  })() : null;
+
   return (
     <div className="fixed inset-0 bg-bg-deep flex flex-col z-50">
 
@@ -235,6 +255,22 @@ export function PreMatchOverlay({ state, onKickOff, onCancel }: PreMatchOverlayP
           <FormRow form={myForm} label={state.club.name} />
           <FormRow form={opponentForm} label={opponentName} />
         </div>
+
+        {/* Head-to-head history */}
+        {prevMatch && (
+          <div className="w-full max-w-sm text-center">
+            <p className="text-[10px] text-txt-muted uppercase tracking-wider mb-0.5">Last time you met</p>
+            <p className={`text-xs font-semibold ${
+              prevMatch.result === 'W' ? 'text-pitch-green' :
+              prevMatch.result === 'L' ? 'text-alert-red' : 'text-warn-amber'
+            }`}>
+              {prevMatch.result === 'W' ? 'You won' : prevMatch.result === 'L' ? 'You lost' : 'You drew'}{' '}
+              {prevMatch.pGoals}–{prevMatch.oGoals}
+              {prevMatch.season !== state.season && ` · S${prevMatch.season} W${prevMatch.week}`}
+              {prevMatch.season === state.season && ` · Week ${prevMatch.week}`}
+            </p>
+          </div>
+        )}
 
         {/* Squad morale + flavour row */}
         <div className="flex items-center justify-between w-full max-w-sm">

--- a/packages/frontend/src/components/season-end/SeasonEndScreen.tsx
+++ b/packages/frontend/src/components/season-end/SeasonEndScreen.tsx
@@ -1,4 +1,4 @@
-import { GameState, GameCommand, formatMoney, Division, computeOverallRating, MatchSimulatedEvent } from '@calculating-glory/domain';
+import { GameState, GameCommand, formatMoney, Division, computeOverallRating, MatchSimulatedEvent, ClubRecords } from '@calculating-glory/domain';
 
 // ─── Season highlights helpers ────────────────────────────────────────────────
 
@@ -207,30 +207,54 @@ export function SeasonEndScreen({ state, dispatch }: SeasonEndScreenProps) {
           <div className="bg-bg-raised rounded-card border border-white/5 p-4">
             <div className="text-xs font-bold text-txt-muted uppercase tracking-widest mb-3">Season Highlights</div>
             <div className="flex flex-col gap-3">
-              {highlights.biggestWin && (
-                <div className="flex items-center gap-3">
-                  <span className="text-pitch-green text-base shrink-0">🏆</span>
-                  <div>
-                    <p className="text-xs font-semibold text-txt-primary">
-                      Biggest win: {highlights.biggestWin.playerGoals}–{highlights.biggestWin.opponentGoals} vs {highlights.biggestWin.opponentName}
-                    </p>
-                    <p className="text-[10px] text-txt-muted">Week {highlights.biggestWin.week}</p>
+              {highlights.biggestWin && (() => {
+                const rec = state.clubRecords;
+                const isAllTimeRecord = rec.biggestWin &&
+                  highlights.biggestWin.playerGoals === rec.biggestWin.playerGoals &&
+                  highlights.biggestWin.opponentGoals === rec.biggestWin.opponentGoals &&
+                  highlights.biggestWin.opponentName === rec.biggestWin.opponentName;
+                return (
+                  <div className="flex items-center gap-3">
+                    <span className="text-pitch-green text-base shrink-0">🏆</span>
+                    <div>
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <p className="text-xs font-semibold text-txt-primary">
+                          Biggest win: {highlights.biggestWin.playerGoals}–{highlights.biggestWin.opponentGoals} vs {highlights.biggestWin.opponentName}
+                        </p>
+                        {isAllTimeRecord && (
+                          <span className="text-[10px] font-bold uppercase tracking-wide text-warn-amber bg-warn-amber/10 border border-warn-amber/30 px-1.5 py-0.5 rounded">
+                            Club Record
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-[10px] text-txt-muted">Week {highlights.biggestWin.week}</p>
+                    </div>
                   </div>
-                </div>
-              )}
-              {highlights.longestWinStreak >= 3 && (
-                <div className="flex items-center gap-3">
-                  <span className="text-warn-amber text-base shrink-0">🔥</span>
-                  <div>
-                    <p className="text-xs font-semibold text-txt-primary">
-                      {highlights.longestWinStreak}-game winning streak
-                    </p>
-                    {highlights.longestUnbeaten > highlights.longestWinStreak && (
-                      <p className="text-[10px] text-txt-muted">{highlights.longestUnbeaten} games unbeaten at best</p>
-                    )}
+                );
+              })()}
+              {highlights.longestWinStreak >= 3 && (() => {
+                const isAllTimeStreak = highlights.longestWinStreak >= state.clubRecords.longestWinStreak;
+                return (
+                  <div className="flex items-center gap-3">
+                    <span className="text-warn-amber text-base shrink-0">🔥</span>
+                    <div>
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <p className="text-xs font-semibold text-txt-primary">
+                          {highlights.longestWinStreak}-game winning streak
+                        </p>
+                        {isAllTimeStreak && highlights.longestWinStreak >= 5 && (
+                          <span className="text-[10px] font-bold uppercase tracking-wide text-warn-amber bg-warn-amber/10 border border-warn-amber/30 px-1.5 py-0.5 rounded">
+                            Club Record
+                          </span>
+                        )}
+                      </div>
+                      {highlights.longestUnbeaten > highlights.longestWinStreak && (
+                        <p className="text-[10px] text-txt-muted">{highlights.longestUnbeaten} games unbeaten at best</p>
+                      )}
+                    </div>
                   </div>
-                </div>
-              )}
+                );
+              })()}
               {highlights.longestWinStreak < 3 && highlights.longestUnbeaten >= 4 && (
                 <div className="flex items-center gap-3">
                   <span className="text-warn-amber text-base shrink-0">🔥</span>


### PR DESCRIPTION
## Summary

Completes the remaining #83 season arc scope. Four changes across domain and frontend — the season now has persistent memory and week-to-week pressure.

### Domain

**`ClubRecords` in `GameState`**
Two all-time records tracked from the first match and persisted across seasons:
- `biggestWin` — biggest margin win ever (`ClubBestWin`: goals, opponent, week, season)
- `longestWinStreak` — longest consecutive win run

A `currentWinStreak` counter updates per match (resets on draw/loss) so the longest streak comparison is always accurate without replaying history.

**Board confidence drift per match**
Previously board confidence only changed at season end. Now every match the player's club plays shifts it:
- Win: +2
- Draw: 0
- Loss: −3
- Clamped to 5–95 (season-end still does the big ±20 swings)

A 5-game losing run now actively builds pressure — Val's financial alerts and board confidence UI reflect something the player can feel week to week.

### Frontend

**All-time record headline in ticker**
Season-best win detection already existed. When the new margin also beats the all-time `clubRecords.biggestWin`, the headline upgrades:
- Before: `★ SEASON BEST — 4–0 vs Bradfield City — biggest win this season`
- After: `🏆 ALL-TIME CLUB RECORD — 4–0 vs Bradfield City — biggest ever win`

**Club Record badges in SeasonEndScreen**
Biggest win and longest streak entries in Season Highlights now show an amber "Club Record" pill when the season result matches the stored all-time record.

**Head-to-head in PreMatchOverlay**
Looks up the most recent `MATCH_SIMULATED` event against the upcoming opponent and shows:
- "Last time you met: You won 3–1 · S1 W34"
- Colour-coded (green win / amber draw / red loss)
- Hidden on first-ever meeting (no previous data)

## Test plan

- [ ] Simulate several weeks — board confidence increases on wins, decreases on losses mid-season (not just at season end)
- [ ] Win by 3+ goals — ticker shows `★ SEASON BEST` on first such result
- [ ] Win by more than previous season best → `🏆 ALL-TIME CLUB RECORD` in ticker
- [ ] Season End screen: biggest win shows "Club Record" pill if it matches `state.clubRecords.biggestWin`
- [ ] Streak ≥ 5 at season end: "Club Record" pill on the streak entry if it matches `state.clubRecords.longestWinStreak`
- [ ] Pre-match screen: "Last time you met" shown for repeat opponents (hidden on first meeting)
- [ ] Pre-match screen: head-to-head result is correct (colour, score, season/week label)
- [ ] After season 2: records persist from season 1

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)