### PR TITLE
feat: club identity — top scorer and on-this-day ticker (#84)

### DIFF
--- a/packages/domain/src/reducers/index.ts
+++ b/packages/domain/src/reducers/index.ts
@@ -146,7 +146,7 @@ export function buildState(events: GameEvent[]): GameState {
     npcStrengths: {},
     resolvedEventWeeks: {},
     mathsOutcomes: {},
-    clubRecords: { biggestWin: null, longestWinStreak: 0 },
+    clubRecords: { biggestWin: null, longestWinStreak: 0, topScorer: null },
     currentWinStreak: 0,
   };
 
@@ -364,6 +364,7 @@ function handleMatchSimulated(state: GameState, event: MatchSimulatedEvent): Gam
       : -1;
 
     clubRecords = {
+      ...clubRecords,
       biggestWin:
         clubResult === 'W' && margin > existingMargin
           ? { playerGoals, opponentGoals, opponentName, week: state.currentWeek + 1, season: state.season }
@@ -659,12 +660,30 @@ function handleSeasonEnded(state: GameState, event: any): GameState {
 
   const newDivision = stepDivision(state.division, promoted, relegated);
 
+  // ── Top scorer ───────────────────────────────────────────────────────────────
+  // Attribute season goals to the squad's best forward (or best attacker if no FWD).
+  // Goals = floor(teamGoalsFor × 0.28), minimum 2.
+  // This is a cosmetic figure derived from aggregate match data.
+  const clubEntry = state.league.entries.find(e => e.clubId === state.club.id);
+  const teamGoals = clubEntry?.goalsFor ?? 0;
+  let topScorer = state.clubRecords.topScorer;
+  if (state.club.squad.length > 0 && teamGoals > 0) {
+    const forwards = state.club.squad.filter(p => p.position === 'FWD');
+    const candidates = forwards.length > 0 ? forwards : state.club.squad;
+    const best = candidates.reduce((a, b) =>
+      b.attributes.attack > a.attributes.attack ? b : a
+    );
+    const goals = Math.max(2, Math.floor(teamGoals * 0.28));
+    topScorer = { name: best.name, goals, season: state.season };
+  }
+
   return {
     ...state,
     phase: 'SEASON_END',
     club: { ...state.club, reputation: newReputation },
     boardConfidence: newBoardConfidence,
     division: newDivision,
+    clubRecords: { ...state.clubRecords, topScorer },
   };
 }
 

--- a/packages/domain/src/types/game-state-updated.ts
+++ b/packages/domain/src/types/game-state-updated.ts
@@ -269,11 +269,26 @@ export interface ClubBestWin {
   season: number;
 }
 
+export interface ClubTopScorer {
+  /** Player name */
+  name: string;
+  /** Goals scored */
+  goals: number;
+  /** Season it happened */
+  season: number;
+}
+
 export interface ClubRecords {
   /** Biggest ever win by goal margin (null until first win by 2+ goals). */
   biggestWin: ClubBestWin | null;
   /** Longest ever consecutive win streak. */
   longestWinStreak: number;
+  /**
+   * Top scorer of the most recently completed season.
+   * Computed from the best forward's share of team goals at SEASON_ENDED.
+   * Null until first season completes.
+   */
+  topScorer: ClubTopScorer | null;
 }
 
 /**

--- a/packages/frontend/src/components/command-centre/CommandCentre.tsx
+++ b/packages/frontend/src/components/command-centre/CommandCentre.tsx
@@ -104,6 +104,7 @@ export function CommandCentre({ state, events, dispatch, isLoading, onNavigateTo
           freeAgents={state.freeAgentPool ?? []}
           pendingEvents={state.pendingEvents}
           currentWeek={state.currentWeek}
+          currentSeason={state.season}
           clubRecords={state.clubRecords}
         />
         {dim('news-ticker')}

--- a/packages/frontend/src/components/command-centre/NewsTicker.tsx
+++ b/packages/frontend/src/components/command-centre/NewsTicker.tsx
@@ -19,6 +19,7 @@ interface NewsTickerProps {
   freeAgents?: Player[];
   pendingEvents?: PendingClubEvent[];
   currentWeek?: number;
+  currentSeason?: number;
   clubRecords?: ClubRecords;
 }
 
@@ -207,6 +208,45 @@ function buildRumourHeadlines(freeAgents: Player[], clubName: string): string[] 
   });
 }
 
+// ── "On this day last season" ───────────────────────────────────────────────
+//
+// Surfaces a memorable result from the same week in the previous season.
+// Only fires from season 2 onwards; only on weeks where a match existed.
+
+function buildOnThisDayHeadlines(
+  events: GameEvent[],
+  clubId: string,
+  clubName: string,
+  nameMap: Map<string, string>,
+  currentWeek: number,
+  currentSeason: number,
+): string[] {
+  if (currentSeason < 2 || currentWeek < 1) return [];
+
+  const lastSeason = currentSeason - 1;
+  const matchIdPrefix = `S${lastSeason}-W${currentWeek}`;
+
+  const lastYearMatch = (events as MatchSimulatedEvent[]).find(e =>
+    (e as any).type === 'MATCH_SIMULATED' &&
+    (e.matchId ?? '').startsWith(matchIdPrefix) &&
+    (e.homeTeamId === clubId || e.awayTeamId === clubId),
+  );
+
+  if (!lastYearMatch) return [];
+
+  const isHome = lastYearMatch.homeTeamId === clubId;
+  const pGoals = isHome ? lastYearMatch.homeGoals : lastYearMatch.awayGoals;
+  const oGoals = isHome ? lastYearMatch.awayGoals : lastYearMatch.homeGoals;
+  const opponentId = isHome ? lastYearMatch.awayTeamId : lastYearMatch.homeTeamId;
+  const opponentName = nameMap.get(opponentId) ?? 'opponents';
+
+  const result: 'W' | 'D' | 'L' = pGoals > oGoals ? 'W' : pGoals < oGoals ? 'L' : 'D';
+  const resultWord = result === 'W' ? 'beat' : result === 'L' ? 'lost to' : 'drew with';
+  const emoji = result === 'W' ? '🏆' : result === 'L' ? '📉' : '🤝';
+
+  return [`${emoji} On this day last season — ${clubName} ${resultWord} ${opponentName} ${pGoals}–${oGoals}`];
+}
+
 function buildHeadlines(
   events: GameEvent[],
   clubId: string,
@@ -216,6 +256,7 @@ function buildHeadlines(
   squad: Player[],
   leagueEntries: LeagueTableEntry[],
   currentWeek?: number,
+  currentSeason?: number,
   clubRecords?: ClubRecords
 ): string[] {
   const headlines: string[] = [];
@@ -278,12 +319,15 @@ function buildHeadlines(
   }
 
   const arcHeadlines = buildSeasonArcHeadlines(events, clubId, clubName, leagueEntries, currentWeek, clubRecords as ClubRecords | undefined);
-  return [...headlines.slice(-30).reverse(), ...buildMoraleHeadlines(squad), ...milestoneHeadlines, ...arcHeadlines];
+  const onThisDayHeadlines = (currentWeek !== undefined && currentSeason !== undefined)
+    ? buildOnThisDayHeadlines(events, clubId, clubName, nameMap, currentWeek, currentSeason)
+    : [];
+  return [...headlines.slice(-30).reverse(), ...buildMoraleHeadlines(squad), ...milestoneHeadlines, ...arcHeadlines, ...onThisDayHeadlines];
 }
 
-export function NewsTicker({ events, clubId, clubName, stadiumName, leagueEntries, squad, freeAgents, pendingEvents, currentWeek, clubRecords }: NewsTickerProps) {
+export function NewsTicker({ events, clubId, clubName, stadiumName, leagueEntries, squad, freeAgents, pendingEvents, currentWeek, currentSeason, clubRecords }: NewsTickerProps) {
   const nameMap = new Map<string, string>(leagueEntries.map(e => [e.clubId, e.clubName]));
-  const eventHeadlines = buildHeadlines(events, clubId, clubName, stadiumName, nameMap, squad, leagueEntries, currentWeek, clubRecords);
+  const eventHeadlines = buildHeadlines(events, clubId, clubName, stadiumName, nameMap, squad, leagueEntries, currentWeek, currentSeason, clubRecords);
   const rumourHeadlines = freeAgents && freeAgents.length > 0 ? buildRumourHeadlines(freeAgents, clubName) : [];
   const poachHeadlines = pendingEvents ? buildPoachHeadlines(pendingEvents) : [];
   const headlines = [...poachHeadlines, ...eventHeadlines, ...rumourHeadlines];

--- a/packages/frontend/src/components/season-end/SeasonEndScreen.tsx
+++ b/packages/frontend/src/components/season-end/SeasonEndScreen.tsx
@@ -276,6 +276,19 @@ export function SeasonEndScreen({ state, dispatch }: SeasonEndScreenProps) {
                   </div>
                 </div>
               )}
+              {state.clubRecords.topScorer && state.clubRecords.topScorer.season === season && (
+                <div className="flex items-center gap-3">
+                  <span className="text-warn-amber text-base shrink-0">🥅</span>
+                  <div>
+                    <p className="text-xs font-semibold text-txt-primary">
+                      Top Scorer: {state.clubRecords.topScorer.name}
+                    </p>
+                    <p className="text-[10px] text-txt-muted">
+                      {state.clubRecords.topScorer.goals} goals this season
+                    </p>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary

- **Top scorer per season** — extends `ClubRecords` with `topScorer: { name, goals, season }`, computed in `handleSeasonEnded` from the squad's best forward (by attack rating) taking ~28% of team goals scored. Displayed in SeasonEndScreen's Season Highlights section alongside biggest win and win streak.
- **"On this day last season"** — `NewsTicker` now surfaces a result from the equivalent week in the previous season (S{n-1}-W{currentWeek}), with a W/D/L emoji and plain-English framing ("beat", "lost to", "drew with"). Only fires from season 2 onwards.
- `ClubRecords.biggestWin` and `longestWinStreak` updates now use spread-then-override to safely carry `topScorer` through without losing it.

## Test plan

- [ ] Complete a season and verify Top Scorer appears in the Season Highlights section
- [ ] Top scorer should be a FWD (or if no FWDs, best attacker in squad)
- [ ] Start season 2; check the news ticker for "On this day last season" headlines
- [ ] Verify season 1 shows no "on this day" headlines
- [ ] TypeScript compiles clean: `cd packages/domain && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)