### PR TITLE
feat: mobile/touch polish (#86)

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Calculating Glory</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/packages/frontend/src/components/command-centre/InboxCard.tsx
+++ b/packages/frontend/src/components/command-centre/InboxCard.tsx
@@ -143,8 +143,9 @@ export function InboxCard({
               >
                 <button
                   onClick={(e) => { e.stopPropagation(); onDismiss(item.idx); }}
-                  className="absolute top-1 right-1.5 text-txt-muted/30 hover:text-txt-muted
-                             opacity-0 group-hover:opacity-100 transition-opacity text-xs2 leading-none"
+                  className="absolute top-0 right-0 flex items-center justify-center w-10 h-10
+                             text-txt-muted/30 hover:text-txt-muted text-xs leading-none
+                             opacity-0 group-hover:opacity-100 transition-opacity"
                   aria-label="Dismiss"
                 >
                   ✕

--- a/packages/frontend/src/components/command-centre/LeagueTable.tsx
+++ b/packages/frontend/src/components/command-centre/LeagueTable.tsx
@@ -120,8 +120,8 @@ export function LeagueTable({ entries, playerClubId, promotionCutoff, relegation
           </div>
         )}
       </div>
-      <div className="overflow-x-auto">
-        <table className="w-full text-xs data-font">
+      <div className="overflow-x-auto scrollbar-thin" role="region" aria-label="League table — scroll to see full stats">
+        <table className="w-full text-xs data-font min-w-[320px]">
           <thead>
             <tr className="text-txt-muted border-b border-bg-raised">
               <th className="text-right pr-2 pb-1 w-6">#</th>

--- a/packages/frontend/src/components/command-centre/SquadAuditTable.tsx
+++ b/packages/frontend/src/components/command-centre/SquadAuditTable.tsx
@@ -25,7 +25,7 @@ function MoraleBar({ player }: { player: Player }) {
       </div>
       {unsettled && (
         <span
-          className="text-[9px] text-alert-red font-bold leading-none"
+          className="text-[11px] text-alert-red font-bold leading-none"
           title="Unsettled — performance debuffed"
         >
           !
@@ -106,8 +106,8 @@ export function SquadAuditTable({ state }: SquadAuditTableProps) {
         </div>
       </div>
 
-      <div className="overflow-x-auto">
-        <table className="w-full text-xs data-font">
+      <div className="overflow-x-auto scrollbar-thin" role="region" aria-label="Squad — scroll to see full stats">
+        <table className="w-full text-xs data-font min-w-[360px]">
           <thead>
             <tr className="text-txt-muted border-b border-bg-raised text-left">
               <th className="pb-1 pr-2">Name</th>

--- a/packages/frontend/src/components/shared/SlideOver.tsx
+++ b/packages/frontend/src/components/shared/SlideOver.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 interface SlideOverProps {
   isOpen: boolean;
@@ -15,6 +15,18 @@ export function SlideOver({ isOpen, onClose, title, children }: SlideOverProps) 
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, [isOpen, onClose]);
+
+  // Swipe-right-to-dismiss (touch only)
+  const touchStartX = useRef<number | null>(null);
+  function handleTouchStart(e: React.TouchEvent) {
+    touchStartX.current = e.touches[0].clientX;
+  }
+  function handleTouchEnd(e: React.TouchEvent) {
+    if (touchStartX.current === null) return;
+    const delta = e.changedTouches[0].clientX - touchStartX.current;
+    touchStartX.current = null;
+    if (delta > 80) onClose();
+  }
 
   return (
     <>
@@ -34,13 +46,18 @@ export function SlideOver({ isOpen, onClose, title, children }: SlideOverProps) 
           'flex flex-col shadow-2xl transition-transform duration-300 ease-out',
           isOpen ? 'translate-x-0' : 'translate-x-full',
         ].join(' ')}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
       >
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-bg-raised shrink-0">
           <h2 className="font-semibold text-txt-primary text-sm tracking-wide">{title}</h2>
+          {/* 44×44px tap target — padding fills the area, ✕ is centred visually */}
           <button
             onClick={onClose}
-            className="text-txt-muted hover:text-txt-primary text-lg leading-none transition-colors"
+            className="flex items-center justify-center w-11 h-11 -mr-2
+                       text-txt-muted hover:text-txt-primary text-lg transition-colors"
+            aria-label="Close"
           >
             ✕
           </button>

--- a/packages/frontend/src/components/social-feed/SocialFeed.tsx
+++ b/packages/frontend/src/components/social-feed/SocialFeed.tsx
@@ -543,8 +543,8 @@ export function SocialFeed({ state, events, dispatch, linkedEvent, practiceMode,
         <div ref={bottomRef} />
       </div>
 
-      {/* Footer */}
-      <div className="shrink-0 border-t border-bg-raised">
+      {/* Footer — pb-safe ensures the keyboard doesn't cover input on iOS notched devices */}
+      <div className="shrink-0 border-t border-bg-raised pb-safe">
         {awaitingAnswer ? (
           <NegotiationKeyboard
             value={keyboardValue}

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -2,6 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ── Safe area utilities (iOS notch / home indicator) ─────────────────────── */
+@layer utilities {
+  .pb-safe {
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+  }
+  .pt-safe {
+    padding-top: env(safe-area-inset-top, 0px);
+  }
+}
+
 @layer base {
   * {
     box-sizing: border-box;


### PR DESCRIPTION
## Summary

Fixes the concrete, code-addressable issues from the mobile audit against iPhone SE (375px). Covers tap targets, safe area, swipe-to-dismiss, unreadable text, and scroll accessibility.

| Fix | File | Before | After |
|-----|------|--------|-------|
| Notch support | `index.html` | `initial-scale=1.0` only | `viewport-fit=cover` added |
| SlideOver close button | `SlideOver.tsx` | ~16px text-only | 44×44px flex button |
| Swipe-to-dismiss | `SlideOver.tsx` | None | Swipe right 80px → close |
| Inbox dismiss button | `InboxCard.tsx` | ~10px no padding | 40×40px flex container |
| Unsettled indicator | `SquadAuditTable.tsx` | 9px (unreadable) | 11px |
| Table min-width | `LeagueTable` + `SquadAuditTable` | No min-width → collapsed columns | `min-w-[320/360px]` |
| Chat footer keyboard | `SocialFeed.tsx` | No inset handling | `pb-safe` utility |
| Safe area utilities | `index.css` | None | `.pb-safe` / `.pt-safe` via `env(safe-area-inset-bottom/top)` |

## What's not in this PR (tracked separately or needs device testing)
- Isometric SVG scaling on 375px — the SVG is 1088px and has `overflow-x-auto`; fixing this properly requires grid refactoring
- TransferMarket card min-width — deferred; inside a SlideOver which takes full width on mobile
- Form input `pattern` attributes — `inputMode="numeric"` is already set correctly
- Load time / bundle size — separate concern

## Test plan
- [ ] Open on iPhone SE (375px) — no horizontal scroll on Command Centre
- [ ] SlideOver: swipe right closes it; close button easily tappable
- [ ] Inbox: dismiss button tappable without precision tapping
- [ ] SquadAuditTable: "!" unsettled indicator readable without zooming
- [ ] SocialFeed: type a maths answer — footer stays visible above keyboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)