### PR TITLE
feat(isometric): responsive stadium SVG for mobile

### DIFF
--- a/packages/frontend/src/components/isometric/IsometricBlueprint.tsx
+++ b/packages/frontend/src/components/isometric/IsometricBlueprint.tsx
@@ -12,7 +12,7 @@
  * handled by the parent (StadiumView / App) in PR 4.
  */
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { GameState, GameCommand, FacilityType, FACILITY_CONFIG } from '@calculating-glory/domain';
 import { SVG_W, SVG_H } from './isometric-utils';
 import { STADIUM_LAYOUT_SORTED } from './stadium-layout';
@@ -62,6 +62,21 @@ export function IsometricBlueprint({
   // Ref so handleMouseMove can read the current hoveredId without stale closures.
   const hoveredIdRef = useRef<string | null>(null);
 
+  // Ref to the container div — used to bound the tooltip within the actual
+  // rendered width (which differs from SVG_W on small screens).
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerW, setContainerW] = useState(SVG_W);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(entries => {
+      setContainerW(entries[0]?.contentRect.width ?? SVG_W);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
   // Fast lookups: facilityType → level / constructionWeeksRemaining
   const levelOf = Object.fromEntries(
     club.facilities.map(f => [f.type, f.level]),
@@ -103,7 +118,7 @@ export function IsometricBlueprint({
     const level = levelOf[def.facilityType] ?? 0;
     const meta  = FACILITY_CONFIG[def.facilityType];
 
-    const tipX = Math.min(tooltip.mouseX + 14, SVG_W - 190);
+    const tipX = Math.min(tooltip.mouseX + 14, containerW - 190);
     const tipY = Math.max(tooltip.mouseY - 64, 4);
 
     return (
@@ -136,16 +151,17 @@ export function IsometricBlueprint({
 
   return (
     <div
-      className="relative w-full overflow-x-auto select-none"
+      ref={containerRef}
+      className="relative w-full select-none"
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
     >
       <svg
-        width={fillParent ? '100%' : SVG_W}
-        height={fillParent ? '100%' : SVG_H}
+        width="100%"
+        height={fillParent ? '100%' : undefined}
         viewBox={`0 0 ${SVG_W} ${SVG_H}`}
-        preserveAspectRatio={fillParent ? 'xMidYMid slice' : undefined}
-        style={{ display: 'block', margin: fillParent ? undefined : '0 auto' }}
+        preserveAspectRatio={fillParent ? 'xMidYMid slice' : 'xMidYMid meet'}
+        style={{ display: 'block' }}
       >
         {/* ── Pattern library ─────────────────────────────────────────── */}
         <defs>


### PR DESCRIPTION
## Summary
- Replaces fixed `SVG_W`/`SVG_H` pixel dimensions with `width="100%"` + `viewBox` so the stadium SVG scales to any container width via natural aspect-ratio behaviour
- Adds a `ResizeObserver` on the container div to track actual rendered width, used to correctly clip tooltip X position on narrow screens (previously hard-coded to `SVG_W - 190 = 898px`)
- Removes `overflow-x-auto` scroll fallback — the scene now shrinks gracefully to ~320px without horizontal scroll
- `fillParent` mode (intro backdrop) keeps `preserveAspectRatio="xMidYMid slice"`; normal mode uses `meet` so the full scene is always visible

## Test plan
- [ ] Desktop: stadium renders at normal size, tooltip positions correctly
- [ ] Narrow viewport (~375px): stadium scales down to fit, no horizontal scroll bar
- [ ] Intro tour: backdrop still fills the hero area (`fillParent` path unchanged)
- [ ] Hover tooltip on narrow screen doesn't clip off right edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)