### PR TITLE
feat: transfer loop UX overhaul — pitch grid, sell-with-jeopardy, manager XI (#56, #57, #58)

### DIFF
--- a/packages/domain/src/__tests__/manager.test.ts
+++ b/packages/domain/src/__tests__/manager.test.ts
@@ -79,6 +79,7 @@ function makeMinimalClub(overrides: Partial<Club> = {}): Club {
     preferredFormation: null,
     squadCapacity: 24,
     manager: null,
+    listedPlayerIds: [],
     ...overrides,
   };
 }

--- a/packages/domain/src/__tests__/match.test.ts
+++ b/packages/domain/src/__tests__/match.test.ts
@@ -151,6 +151,7 @@ describe('clubToTeam', () => {
       preferredFormation: null,
       squadCapacity: 24,
       manager: null,
+      listedPlayerIds: [],
     };
 
     const team = clubToTeam(club);
@@ -185,6 +186,7 @@ describe('clubToTeam', () => {
       preferredFormation: null,
       squadCapacity: 24,
       manager: null,
+      listedPlayerIds: [],
     };
 
     const team = clubToTeam(club);
@@ -212,6 +214,7 @@ describe('clubToTeam', () => {
       preferredFormation: null,
       squadCapacity: 24,
       manager: null,
+      listedPlayerIds: [],
     };
 
     const winningClub: Club = { ...baseClub, form: ['W', 'W', 'W', 'W', 'W'] };

--- a/packages/domain/src/__tests__/reducer-match.test.ts
+++ b/packages/domain/src/__tests__/reducer-match.test.ts
@@ -46,6 +46,7 @@ function makeState(entries: LeagueTableEntry[], playerClubId: string = 'club-1')
       preferredFormation: null,
       squadCapacity: 24,
       manager: null,
+      listedPlayerIds: [],
     },
     league: {
       entries,

--- a/packages/domain/src/__tests__/sell-to-npc.test.ts
+++ b/packages/domain/src/__tests__/sell-to-npc.test.ts
@@ -58,16 +58,16 @@ const freeAgentPlayer: Player = {
   stats: { goals: 0, assists: 0, cleanSheets: 0, appearances: 0, averageRating: 70 },
 };
 
-function stateWithSquad(players: Player[]): GameState {
+function stateWithSquad(players: Player[], listedPlayerIds: string[] = []): GameState {
   const base = buildState([gameStartedEvent]);
-  return { ...base, club: { ...base.club, squad: players } };
+  return { ...base, club: { ...base.club, squad: players, listedPlayerIds } };
 }
 
 // ─── handleCommand: SELL_PLAYER_TO_NPC ────────────────────────────────────────
 
 describe('SELL_PLAYER_TO_NPC command', () => {
   it('returns PLAYER_SOLD event on valid sale', () => {
-    const state = stateWithSquad([squadPlayer]);
+    const state = stateWithSquad([squadPlayer], ['player-1']);
     const result = handleCommand(
       { type: 'SELL_PLAYER_TO_NPC', playerId: 'player-1', npcClubId: 'swinton' },
       state,
@@ -78,7 +78,7 @@ describe('SELL_PLAYER_TO_NPC command', () => {
   });
 
   it('event carries correct fee (transferValue when > 0)', () => {
-    const state = stateWithSquad([squadPlayer]);
+    const state = stateWithSquad([squadPlayer], ['player-1']);
     const result = handleCommand(
       { type: 'SELL_PLAYER_TO_NPC', playerId: 'player-1', npcClubId: 'swinton' },
       state,
@@ -88,7 +88,7 @@ describe('SELL_PLAYER_TO_NPC command', () => {
   });
 
   it('event carries correct fee derived from OVR when transferValue is 0', () => {
-    const state = stateWithSquad([freeAgentPlayer]);
+    const state = stateWithSquad([freeAgentPlayer], ['player-2']);
     const result = handleCommand(
       { type: 'SELL_PLAYER_TO_NPC', playerId: 'player-2', npcClubId: 'bradfield' },
       state,
@@ -99,7 +99,7 @@ describe('SELL_PLAYER_TO_NPC command', () => {
   });
 
   it('event carries playerName and npcClubName', () => {
-    const state = stateWithSquad([squadPlayer]);
+    const state = stateWithSquad([squadPlayer], ['player-1']);
     const result = handleCommand(
       { type: 'SELL_PLAYER_TO_NPC', playerId: 'player-1', npcClubId: 'swinton' },
       state,
@@ -177,7 +177,7 @@ describe('PLAYER_SOLD reducer', () => {
 
 describe('SELL_PLAYER_TO_NPC round-trip', () => {
   it('squad shrinks and budget grows after full command → reduce cycle', () => {
-    const state = stateWithSquad([squadPlayer]);
+    const state = stateWithSquad([squadPlayer], ['player-1']);
     const budgetBefore = state.club.transferBudget;
 
     const result = handleCommand(

--- a/packages/domain/src/__tests__/type-utils.test.ts
+++ b/packages/domain/src/__tests__/type-utils.test.ts
@@ -102,6 +102,7 @@ describe('calculateClubStrength', () => {
       preferredFormation: null,
       squadCapacity: 24,
       manager: null,
+      listedPlayerIds: [],
     };
     // No squad → calculateSquadStrength crashes on division by zero? Let me check...
     // Actually: totalRating / squad.length = 0/0 = NaN → Math.floor(NaN * 100) = NaN
@@ -131,6 +132,7 @@ describe('calculateClubStrength', () => {
       preferredFormation: null,
       squadCapacity: 24,
       manager: null,
+      listedPlayerIds: [],
     };
     const strength = calculateClubStrength(club);
     // squadStrength = floor(70 * 100) = 7000
@@ -156,6 +158,7 @@ describe('calculateClubStrength', () => {
       preferredFormation: null,
       squadCapacity: 24,
       manager: null,
+      listedPlayerIds: [],
     };
     const strength = calculateClubStrength(club);
     // squadStrength = 7000, staffBonus = 0, facilityBonus = 3 * 50 = 150, reputationBonus = 0

--- a/packages/domain/src/commands/handlers.ts
+++ b/packages/domain/src/commands/handlers.ts
@@ -11,7 +11,7 @@ import { validateTransfer, validateFacilityUpgrade, validateStaffHire } from '..
 import { simulateMatch, clubToTeam, generateAITeam, Team } from '../simulation/match';
 import { generateSeasonFixtures, getWeekFixtures, matchSeed } from '../simulation/season';
 import { createRng } from '../simulation/rng';
-import { generateWeekEvents, generatePoachAttempts, generateMoraleThresholdEvents, generateFinancialThresholdEvents, generateDaniFacilityObservationEvents, generateNpcMatchReactionEvents } from '../simulation/events';
+import { generateWeekEvents, generatePoachAttempts, generateMoraleThresholdEvents, generateFinancialThresholdEvents, generateDaniFacilityObservationEvents, generateNpcMatchReactionEvents, generateListedPlayerBids } from '../simulation/events';
 import { computeWeeklyFinancials, computeRunwayBand } from '../simulation/revenue';
 import { detectFormMilestone, FORM_MILESTONE_HEADLINES } from '../simulation/morale';
 import { getTeamsForDivision } from '../data/division-teams';
@@ -80,6 +80,10 @@ export function handleCommand(command: GameCommand, state: GameState): CommandRe
       return handleUpgradeCurriculum(command, state);
     case 'SET_BUDGET_ALLOCATION':
       return handleSetBudgetAllocation(command, state);
+    case 'LIST_PLAYER_FOR_SALE':
+      return handleListPlayerForSale(command, state);
+    case 'UNLIST_PLAYER':
+      return handleUnlistPlayer(command, state);
     default:
       return {
         error: {
@@ -290,8 +294,9 @@ function handleSimulateWeek(command: any, state: GameState): CommandResult {
     };
   }
 
-  // Build Team objects for the player's club and AI opponents
-  const playerTeam = state.club.id ? clubToTeam(state.club) : null;
+  // Build Team objects for the player's club and AI opponents.
+  // Pass the week/season seed so manager XI noise varies each match.
+  const playerTeam = state.club.id ? clubToTeam(state.club, `${baseSeed}-S${season}-W${week}`) : null;
   const teamMap = buildTeamMap(state, playerTeam, baseSeed, season);
 
   // Simulate each match and produce events
@@ -385,9 +390,23 @@ function handleSimulateWeek(command: any, state: GameState): CommandResult {
     });
   }
 
+  // Generate NPC bids for listed players (0–N per week, one per listed player max)
+  const bidEvents = generateListedPlayerBids(state, week, season, baseSeed);
+  for (const pendingEvent of bidEvents) {
+    events.push({
+      type: 'CLUB_EVENT_OCCURRED',
+      timestamp: now,
+      eventId: pendingEvent.id,
+      templateId: pendingEvent.templateId,
+      week,
+      clubId: state.club.id,
+      pendingEvent
+    });
+  }
+
   // Generate morale threshold events (0 or 1 per week — only if no other events fired)
   // Only fires when the inbox would otherwise be clear to avoid stacking.
-  const hasNewEvents = clubEvents.length > 0 || poachEvents.length > 0;
+  const hasNewEvents = clubEvents.length > 0 || poachEvents.length > 0 || bidEvents.length > 0;
   if (!hasNewEvents) {
     const moraleEvents = generateMoraleThresholdEvents(state, week, season);
     for (const pendingEvent of moraleEvents) {
@@ -1061,6 +1080,16 @@ function handleSellPlayerToNpc(command: any, state: GameState): CommandResult {
     };
   }
 
+  // Player must be on the transfer list — sales must go through the list → bid flow
+  if (!(state.club.listedPlayerIds ?? []).includes(command.playerId)) {
+    return {
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: `Player '${player.name}' must be listed for sale before a direct sale can be completed`,
+      },
+    };
+  }
+
   // Fee: use player's transferValue if set, otherwise derive from computed OVR
   const ovr = computeOverallRating(player);
   const fee = player.transferValue > 0
@@ -1081,6 +1110,43 @@ function handleSellPlayerToNpc(command: any, state: GameState): CommandResult {
   ];
 
   return { events };
+}
+
+function handleListPlayerForSale(command: any, state: GameState): CommandResult {
+  const player = state.club.squad.find(p => p.id === command.playerId);
+  if (!player) {
+    return { error: { code: 'PLAYER_NOT_FOUND', message: `Player '${command.playerId}' not found in squad` } };
+  }
+  if ((state.club.listedPlayerIds ?? []).includes(command.playerId)) {
+    return { error: { code: 'VALIDATION_FAILED', message: `Player '${player.name}' is already listed for sale` } };
+  }
+  return {
+    events: [{
+      type: 'PLAYER_LISTED',
+      timestamp: Date.now(),
+      playerId: player.id,
+      clubId: state.club.id,
+      playerName: player.name,
+    }],
+  };
+}
+
+function handleUnlistPlayer(command: any, state: GameState): CommandResult {
+  const player = state.club.squad.find(p => p.id === command.playerId);
+  if (!player) {
+    return { error: { code: 'PLAYER_NOT_FOUND', message: `Player '${command.playerId}' not found in squad` } };
+  }
+  if (!(state.club.listedPlayerIds ?? []).includes(command.playerId)) {
+    return { error: { code: 'VALIDATION_FAILED', message: `Player '${player.name}' is not currently listed` } };
+  }
+  return {
+    events: [{
+      type: 'PLAYER_UNLISTED',
+      timestamp: Date.now(),
+      playerId: player.id,
+      clubId: state.club.id,
+    }],
+  };
 }
 
 function handleBeginNextSeason(_command: any, state: GameState): CommandResult {

--- a/packages/domain/src/commands/types.ts
+++ b/packages/domain/src/commands/types.ts
@@ -33,7 +33,9 @@ export type GameCommand =
   | AcceptTakeoverCommand
   | AcceptIntroSponsorDealCommand
   | UpgradeCurriculumCommand
-  | SetBudgetAllocationCommand;
+  | SetBudgetAllocationCommand
+  | ListPlayerForSaleCommand
+  | UnlistPlayerCommand;
 
 export interface MakeTransferCommand {
   type: 'MAKE_TRANSFER';
@@ -173,6 +175,16 @@ export interface SetBudgetAllocationCommand {
   transfer: number;
   infrastructure: number;
   wages: number;
+}
+
+export interface ListPlayerForSaleCommand {
+  type: 'LIST_PLAYER_FOR_SALE';
+  playerId: string;
+}
+
+export interface UnlistPlayerCommand {
+  type: 'UNLIST_PLAYER';
+  playerId: string;
 }
 
 export interface CommandResult {

--- a/packages/domain/src/events/types.ts
+++ b/packages/domain/src/events/types.ts
@@ -49,7 +49,9 @@ export type GameEvent =
   | RunwayBandChangedEvent
   | MoraleTickerEvent
   | BoardBailoutEvent
-  | BudgetAllocationSetEvent;
+  | BudgetAllocationSetEvent
+  | PlayerListedEvent
+  | PlayerUnlistedEvent;
 
 export interface TransferCompletedEvent {
   type: 'TRANSFER_COMPLETED';
@@ -427,6 +429,24 @@ export interface BoardBailoutEvent {
   timestamp: number;
   shortfall: number;
   penalty: number;
+}
+
+/** Owner listed a player as available for sale. NPC bids can now arrive. */
+export interface PlayerListedEvent {
+  type: 'PLAYER_LISTED';
+  timestamp: number;
+  playerId: string;
+  clubId: string;
+  /** Stored for use in news ticker / inbox copy */
+  playerName: string;
+}
+
+/** Owner withdrew a player from the transfer list (no sale agreed). */
+export interface PlayerUnlistedEvent {
+  type: 'PLAYER_UNLISTED';
+  timestamp: number;
+  playerId: string;
+  clubId: string;
 }
 
 /** Player reallocated their budget pools during a transfer window. */

--- a/packages/domain/src/reducers/index.ts
+++ b/packages/domain/src/reducers/index.ts
@@ -117,6 +117,22 @@ export function reduceEvent(state: GameState, event: GameEvent): GameState {
           },
         },
       };
+    case 'PLAYER_LISTED':
+      return {
+        ...state,
+        club: {
+          ...state.club,
+          listedPlayerIds: [...(state.club.listedPlayerIds ?? []), event.playerId],
+        },
+      };
+    case 'PLAYER_UNLISTED':
+      return {
+        ...state,
+        club: {
+          ...state.club,
+          listedPlayerIds: (state.club.listedPlayerIds ?? []).filter(id => id !== event.playerId),
+        },
+      };
     default:
       return state;
   }
@@ -259,6 +275,7 @@ function handleGameStarted(state: GameState, event: GameStartedEvent): GameState
       squad: inheritedSquad,
       squadCapacity: 24,
       manager: null,
+      listedPlayerIds: [],
       stadium: {
         ...state.club.stadium,
         name: event.stadiumName ?? deriveStadiumName(event.clubName),
@@ -294,7 +311,8 @@ function handlePlayerSold(state: GameState, event: any): GameState {
     club: {
       ...state.club,
       squad: state.club.squad.filter(p => p.id !== event.playerId),
-      transferBudget: state.club.transferBudget + event.fee
+      transferBudget: state.club.transferBudget + event.fee,
+      listedPlayerIds: (state.club.listedPlayerIds ?? []).filter(id => id !== event.playerId),
     }
   };
 }
@@ -888,6 +906,7 @@ function handlePlayerReleased(state: GameState, event: PlayerReleasedEvent): Gam
       ...state.club,
       squad: state.club.squad.filter(p => p.id !== event.playerId),
       transferBudget: state.club.transferBudget + event.releaseFee,
+      listedPlayerIds: (state.club.listedPlayerIds ?? []).filter(id => id !== event.playerId),
     },
   };
 }
@@ -1005,6 +1024,7 @@ function handlePreSeasonStarted(state: GameState, event: PreSeasonStartedEvent):
       form: [],
       trainingFocus: null,
       preferredFormation: null,
+      listedPlayerIds: [], // clear transfer listings at start of each season
     },
   };
 }
@@ -1136,6 +1156,7 @@ function handleTakeoverAccepted(state: GameState, event: TakeoverAcceptedEvent):
       squadCapacity:  24,
       facilities:     getDefaultFacilities(),
       manager:        null,
+      listedPlayerIds: [],
       staff:          [],
       reputation:     newReputation,
     },
@@ -1167,6 +1188,7 @@ function createEmptyClub(): Club {
     preferredFormation: null,
     squadCapacity: 24,
     manager: null,
+    listedPlayerIds: [],
   };
 }
 

--- a/packages/domain/src/simulation/events.ts
+++ b/packages/domain/src/simulation/events.ts
@@ -17,6 +17,7 @@ import { createRng } from './rng';
 import { getTeamsForDivision } from '../data/division-teams';
 import { avgSquadMorale, isUnsettled } from './morale';
 import { computeOverallRating } from '../types/player';
+import { isTransferWindowOpen } from '../types/facility';
 
 /**
  * Check whether a template's prerequisite has been met.
@@ -337,6 +338,7 @@ export function generatePoachAttempts(
     description: `${npcClub.name} have submitted a formal bid of ${feeStr} for ${target.name}. How do you respond?`,
     severity: 'major',
     metadata: {
+      eventKind: 'poach',
       poachTargetPlayerId: target.id,
       npcClubId: npcClub.id,
       npcClubName: npcClub.name,
@@ -381,6 +383,119 @@ export function generatePoachAttempts(
   };
 
   return [poachEvent];
+}
+
+// ── NPC bids on listed players ─────────────────────────────────────────────────
+
+/**
+ * Generate 0–N NPC bids for players the owner has listed for sale.
+ * At most one bid per listed player per week (no per-week global cap —
+ * multiple listed players can each receive a bid in the same week).
+ *
+ * Only fires during an open transfer window (weeks 1–4 and 23–26).
+ * Listing is allowed outside a window; bids only arrive within one.
+ *
+ * Bid probability scales with player OVR (better players attract more interest):
+ *   OVR 40–49 → ~20%/week  |  OVR 50–59 → ~35%/week  |  OVR 60+ → ~55%/week
+ */
+export function generateListedPlayerBids(
+  state: GameState,
+  week: number,
+  season: number,
+  seed: string,
+): PendingClubEvent[] {
+  // Bids only arrive during open transfer windows
+  if (!isTransferWindowOpen(week, state.phase)) return [];
+  if (state.phase === 'PRE_SEASON' || state.phase === 'SEASON_END') return [];
+
+  const listed = (state.club.listedPlayerIds ?? []);
+  if (listed.length === 0) return [];
+
+  const npcClubs = getTeamsForDivision(state.division).filter(t => t.id !== state.club.id);
+  if (npcClubs.length === 0) return [];
+
+  const bids: PendingClubEvent[] = [];
+  const rng = createRng(`${seed}-S${season}-W${week}-bids`);
+
+  for (const playerId of listed) {
+    const player = state.club.squad.find(p => p.id === playerId);
+    if (!player) continue; // stale listing — player already left
+
+    // Skip if a bid for this player is already pending in the inbox
+    const alreadyPending = state.pendingEvents.some(
+      e => e.templateId === 'npc-bid' && !e.resolved && e.metadata?.poachTargetPlayerId === playerId
+    );
+    if (alreadyPending) continue;
+
+    const ovr = computeOverallRating(player);
+
+    // Bid probability: ~20% for OVR 40, scaling to ~55% for OVR 60+
+    const bidChance = 0.20 + Math.max(0, ovr - 40) * 0.0175;
+    if (rng.next() > bidChance) continue;
+
+    const npcClub = npcClubs[rng.nextInt(0, npcClubs.length - 1)];
+    const fee = offeredFee(player.wage, ovr);
+    const counterFee = Math.round(fee * 1.25);
+
+    const feeStr = (fee / 100).toLocaleString('en-GB', {
+      style: 'currency', currency: 'GBP', maximumFractionDigits: 0,
+    });
+    const counterFeeStr = (counterFee / 100).toLocaleString('en-GB', {
+      style: 'currency', currency: 'GBP', maximumFractionDigits: 0,
+    });
+
+    const bidEvent: PendingClubEvent = {
+      id: `evt-S${season}-W${week}-bid-${playerId.slice(-6)}`,
+      templateId: 'npc-bid',
+      week,
+      title: `${npcClub.name} want to sign ${player.name}`,
+      description: `${npcClub.name} have come in for ${player.name} with a bid of ${feeStr}. They're on your transfer list — what's your response?`,
+      severity: 'major',
+      // bankTopic drives the maths challenge question on the counter-offer choice
+      bankTopic: 'PERCENTAGES',
+      metadata: {
+        eventKind: 'bid',
+        poachTargetPlayerId: player.id,
+        npcClubId: npcClub.id,
+        npcClubName: npcClub.name,
+        offeredFee: fee,
+        playerName: player.name,
+        playerPosition: player.position,
+        playerOverall: ovr,
+        playerWage: player.wage,
+      },
+      choices: [
+        {
+          id: 'accept',
+          label: 'Accept the bid',
+          description: `Sell ${player.name} to ${npcClub.name} for ${feeStr}. The funds arrive immediately.`,
+          budgetEffect: fee,
+          reputationEffect: 2,
+          playerLeaves: true,
+        },
+        {
+          id: 'counter',
+          label: `Counter at ${counterFeeStr}`,
+          description: `Demand 25% more. Answer the maths question correctly to negotiate an extra 5% premium on top.`,
+          budgetEffect: counterFee,
+          mathsCorrectBudgetEffect: Math.round(counterFee * 1.05),
+          reputationEffect: 3,
+          playerLeaves: true,
+          requiresMath: true,
+        },
+        {
+          id: 'reject',
+          label: 'Reject the bid',
+          description: `Turn down the offer. ${player.name} stays on the list but this bid lapses.`,
+        },
+      ],
+      resolved: false,
+    };
+
+    bids.push(bidEvent);
+  }
+
+  return bids;
 }
 
 // ── Morale threshold events ────────────────────────────────────────────────────

--- a/packages/domain/src/simulation/match.ts
+++ b/packages/domain/src/simulation/match.ts
@@ -9,9 +9,10 @@
  * team strength, which changes results even with the same seed.
  */
 
-import { createRng, Rng } from './rng';
+import { createRng, Rng, seededIntNoise } from './rng';
 import { Club } from '../types/club';
-import { Player } from '../types/player';
+import { Player, Position, computeOverallRating } from '../types/player';
+import { Formation, FORMATION_CONFIG } from '../types/formation';
 import { isUnsettled } from './morale';
 
 /** Base expected goals for an average-vs-average matchup (League Two realistic) */
@@ -146,6 +147,53 @@ export function simulateMatch(
   };
 }
 
+const POSITION_ORDER: Position[] = ['GK', 'DEF', 'MID', 'FWD'];
+
+/**
+ * Select the manager's starting XI from the squad.
+ *
+ * The manager assesses each player through a noise-adjusted OVR lens.
+ * A poor manager (low tactical rating) may misjudge player quality and
+ * field a weaker player over a stronger one. An elite manager always
+ * selects the optimal XI.
+ *
+ * noiseRange:
+ *   tactical = 0   → ±20  (routinely wrong — frequent poor picks)
+ *   tactical = 50  → ±10  (occasional errors)
+ *   tactical = 100 → ±0   (always optimal)
+ *
+ * The weekSeed ensures mistakes rotate each match rather than being
+ * permanently fixed to the same player.
+ *
+ * If no formation is set, returns the full squad (no selection applied).
+ */
+export function selectManagerXI(
+  squad: Player[],
+  formation: Formation | null,
+  managerTactical: number,
+  weekSeed: string,
+): Player[] {
+  if (!formation) return squad;
+  const config = FORMATION_CONFIG[formation];
+  if (!config) return squad;
+
+  const noiseRange = Math.max(0, 20 - (managerTactical / 100) * 20);
+  const xi: Player[] = [];
+
+  for (const pos of POSITION_ORDER) {
+    const slots = config.slots[pos];
+    const candidates = squad.filter(p => p.position === pos);
+    const sorted = candidates.slice().sort((a, b) => {
+      const aOvr = computeOverallRating(a) + seededIntNoise(a.id + weekSeed, noiseRange);
+      const bOvr = computeOverallRating(b) + seededIntNoise(b.id + weekSeed, noiseRange);
+      return bOvr - aOvr;
+    });
+    xi.push(...sorted.slice(0, slots));
+  }
+
+  return xi;
+}
+
 /**
  * Build a Team from the player's Club.
  *
@@ -161,9 +209,17 @@ export function simulateMatch(
  *   FITNESS         → teamModifier    + 0.03
  *   SET_PIECES      → attackStrength  × 1.03
  *   YOUTH_INTEGRATION → no match effect (developmental only)
+ *
+ * weekSeed is used to seed the manager's XI selection noise.
+ * Pass the current week/season string for match-accurate selection.
+ * Defaults to 'default' for backward-compatible tests.
  */
-export function clubToTeam(club: Club): Team {
-  const { attack, defence } = calculatePositionalStrengths(club.squad);
+export function clubToTeam(club: Club, weekSeed: string = 'default'): Team {
+  // The manager selects the starting XI; a poor manager may misread the squad.
+  // No manager → apply a low tactical quality (20) as a penalty.
+  const managerTactical = club.manager ? club.manager.attributes.tactical : 20;
+  const xi = selectManagerXI(club.squad, club.preferredFormation, managerTactical, weekSeed);
+  const { attack, defence } = calculatePositionalStrengths(xi.length > 0 ? xi : club.squad);
   const { modifier, fanZoneBonus } = calculateTeamModifier(club);
 
   // Apply training focus multipliers after base calculation.

--- a/packages/domain/src/simulation/rng.ts
+++ b/packages/domain/src/simulation/rng.ts
@@ -57,6 +57,25 @@ export function createRng(seed: string): Rng {
 }
 
 /**
+ * Deterministic integer noise in the range [−range, +range].
+ *
+ * Uses a fast inline hash so it's cheap to call per-player per-week.
+ * If range === 0 (e.g. a perfect manager) always returns 0.
+ *
+ * Used by selectManagerXI to add per-player, per-week variation to
+ * apparent OVR, simulating a manager's imperfect player assessment.
+ */
+export function seededIntNoise(seed: string, range: number): number {
+  if (range === 0) return 0;
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) {
+    h = (Math.imul(31, h) + seed.charCodeAt(i)) | 0;
+  }
+  const span = range * 2 + 1;
+  return (Math.abs(h) % span) - range;
+}
+
+/**
  * Fisher-Yates shuffle with seeded RNG. Returns a new array.
  */
 export function seededShuffle<T>(arr: readonly T[], seed: string): T[] {

--- a/packages/domain/src/types/club.ts
+++ b/packages/domain/src/types/club.ts
@@ -55,6 +55,13 @@ export interface Club {
 
   /** Currently hired manager (null = no manager appointed) */
   manager: Manager | null;
+
+  /**
+   * IDs of squad players currently listed for sale.
+   * NPC clubs will only submit bids for listed players during an open
+   * transfer window. Cleared on PRE_SEASON_STARTED.
+   */
+  listedPlayerIds: string[];
 }
 
 /**

--- a/packages/domain/src/types/game-state-updated.ts
+++ b/packages/domain/src/types/game-state-updated.ts
@@ -75,6 +75,13 @@ export interface PendingClubEvent {
    * Not present on standard club events.
    */
   metadata?: {
+    /**
+     * Discriminant for transfer-related inbox events.
+     * 'poach' = NPC approaching to buy one of your players (inbound).
+     * 'bid'   = NPC responding to your transfer listing (outbound).
+     * Used by PendingEventCard to render the correct player-snapshot strip.
+     */
+    eventKind?: 'poach' | 'bid';
     poachTargetPlayerId?: string;
     npcClubId?: string;
     npcClubName?: string;

--- a/packages/frontend/src/components/command-centre/PendingEventCard.tsx
+++ b/packages/frontend/src/components/command-centre/PendingEventCard.tsx
@@ -294,7 +294,7 @@ export function PendingEventCard({ event, dispatch, onError, onMathChallenge }: 
 
       <p className="text-xs text-txt-muted mb-3 leading-relaxed">{event.description}</p>
 
-      {/* Poach: player snapshot strip */}
+      {/* Poach: player snapshot strip (inbound — NPC approaching to buy your player) */}
       {event.templateId === 'npc-poach' && event.metadata?.playerName && (
         <div className="mb-3 flex items-center gap-3 bg-bg-raised rounded-card border border-white/5 px-3 py-2">
           <div className="flex flex-col gap-0.5 flex-1 min-w-0">
@@ -307,6 +307,42 @@ export function PendingEventCard({ event, dispatch, onError, onMathChallenge }: 
             <div className="text-right shrink-0">
               <span className="text-data-blue font-bold text-sm">{event.metadata.playerOverall}</span>
               <div className="text-[10px] text-txt-muted">OVR</div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Bid: player snapshot strip (outbound — NPC responding to your transfer listing) */}
+      {event.templateId === 'npc-bid' && event.metadata?.playerName && (
+        <div className="mb-3 rounded-card border border-white/5 bg-bg-raised overflow-hidden">
+          {/* Player row */}
+          <div className="flex items-center gap-3 px-3 py-2">
+            <div className="flex flex-col gap-0.5 flex-1 min-w-0">
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs font-semibold text-txt-primary truncate">{event.metadata.playerName}</span>
+                <span className="text-[10px] text-txt-muted bg-bg-elevated px-1.5 py-0.5 rounded-tag border border-white/5">
+                  Listed for sale
+                </span>
+              </div>
+              <span className="text-[10px] text-txt-muted">
+                {event.metadata.playerPosition}
+                {event.metadata.playerWage ? ` · ${formatMoney(event.metadata.playerWage)}/wk` : ''}
+              </span>
+            </div>
+            {event.metadata.playerOverall !== undefined && (
+              <div className="text-right shrink-0">
+                <span className="text-data-blue font-bold text-sm">{event.metadata.playerOverall}</span>
+                <div className="text-[10px] text-txt-muted">OVR</div>
+              </div>
+            )}
+          </div>
+          {/* Bid offer row */}
+          {event.metadata.offeredFee !== undefined && (
+            <div className="flex items-center justify-between px-3 py-1.5 border-t border-white/5 bg-pitch-green/5">
+              <span className="text-[10px] text-txt-muted">Offer from {event.metadata.npcClubName ?? 'unknown club'}</span>
+              <span className="text-xs font-bold text-pitch-green">
+                {formatMoney(event.metadata.offeredFee)}
+              </span>
             </div>
           )}
         </div>

--- a/packages/frontend/src/components/transfer-market/TransferMarketSlideOver.tsx
+++ b/packages/frontend/src/components/transfer-market/TransferMarketSlideOver.tsx
@@ -13,6 +13,7 @@ import {
   getScoutLevel,
   computeOverallRating,
   isTransferWindowOpen,
+  selectManagerXI,
 } from '@calculating-glory/domain';
 
 // ─── Types ─────────────────────────────────────────────────────────────────────
@@ -26,7 +27,8 @@ interface TransferMarketSlideOverProps {
 type Tab = 'free-agents' | 'my-squad';
 type SortKey = 'rating' | 'attack' | 'defence' | 'wage';
 type PlayerWillingness = 'eager' | 'neutral' | 'reluctant';
-type SquadViewMode = 'formation' | 'list';
+/** formation = manage mode (list + sell/release); list = flat list; lineup = manager's selected XI */
+type SquadViewMode = 'formation' | 'list' | 'lineup';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -126,69 +128,16 @@ function getRivalClubName(playerId: string, clubNames: string[]): string {
 
 // ─── Formation gap panel ───────────────────────────────────────────────────────
 
-interface FormationGapPanelProps {
-  state: GameState;
-}
+// ─── Pitch Grid ────────────────────────────────────────────────────────────────
+// Replaces SquadFormationView. Renders players in spatial formation rows
+// (FWD at top → GK at bottom), with circle slots, vacant gaps, and a depth rail.
 
-const POSITION_ORDER: Position[] = ['GK', 'DEF', 'MID', 'FWD'];
-
-function FormationGapPanel({ state }: FormationGapPanelProps) {
-  const formation = state.club.preferredFormation;
-  if (!formation) return null;
-
-  const config = FORMATION_CONFIG[formation];
-  const squadByPosition = POSITION_ORDER.reduce<Record<Position, number>>((acc, pos) => {
-    acc[pos] = state.club.squad.filter(p => p.position === pos).length;
-    return acc;
-  }, { GK: 0, DEF: 0, MID: 0, FWD: 0 });
-
-  return (
-    <div className="bg-bg-raised rounded-card border border-white/5 px-4 py-2.5 flex flex-col gap-1.5">
-      <div className="flex items-center justify-between">
-        <span className="text-xs text-txt-muted">Formation target</span>
-        <span className="text-xs font-semibold text-txt-primary">{config.label}</span>
-      </div>
-      <div className="flex gap-3">
-        {POSITION_ORDER.map(pos => {
-          const target = config.slots[pos];
-          const have = squadByPosition[pos];
-          const gap = have - target;
-          const isShort = gap < 0;
-          const isSurplus = gap > 0;
-          return (
-            <div key={pos} className="flex flex-col items-center gap-0.5 flex-1">
-              <span className="text-[10px] text-txt-muted">{pos}</span>
-              <span className={`text-sm font-bold ${isShort ? 'text-alert-red' : isSurplus ? 'text-warn-amber' : 'text-pitch-green'}`}>
-                {have}/{target}
-              </span>
-              <span className={`text-[10px] font-semibold ${isShort ? 'text-alert-red' : isSurplus ? 'text-warn-amber' : 'text-pitch-green'}`}>
-                {isShort ? `−${Math.abs(gap)}` : isSurplus ? `+${gap}` : '✓'}
-              </span>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-// ─── Squad formation view ──────────────────────────────────────────────────────
-
-interface SquadFormationViewProps {
-  squad: Player[];
-  formation: Formation;
-  currentWeek: number;
-  clubId: string;
-  scoutLevel: number;
-  onFillPosition: (pos: Position) => void;
-  onRelease: (playerId: string) => void;
-  onSellToNpc: (playerId: string, npcClubId: string) => void;
-}
+const PITCH_ROW_ORDER: Position[] = ['FWD', 'MID', 'DEF', 'GK'];
 
 function ovrBorderClass(ovr: number): string {
-  if (ovr >= 70) return 'border-pitch-green/40';
-  if (ovr >= 55) return 'border-warn-amber/40';
-  return 'border-alert-red/30';
+  if (ovr >= 70) return 'border-pitch-green/50';
+  if (ovr >= 55) return 'border-warn-amber/50';
+  return 'border-alert-red/40';
 }
 
 function ovrTextClass(ovr: number): string {
@@ -197,88 +146,189 @@ function ovrTextClass(ovr: number): string {
   return 'text-alert-red';
 }
 
-function SquadFormationView({
-  squad, formation, currentWeek, clubId, scoutLevel, onFillPosition, onRelease, onSellToNpc,
-}: SquadFormationViewProps) {
+interface PitchGridProps {
+  squad: Player[];
+  formation: Formation;
+  currentWeek: number;
+  clubId: string;
+  scoutLevel: number;
+  listedPlayerIds: string[];
+  isWindowOpen: boolean;
+  /** 'manage': players expand to full card with list/release actions */
+  mode: 'manage' | 'lineup';
+  /** Players the manager has selected for the XI (lineup mode only) */
+  managerXI?: Player[];
+  onFillPosition: (pos: Position) => void;
+  onRelease: (playerId: string) => void;
+  onList: (playerId: string) => void;
+  onUnlist: (playerId: string) => void;
+}
+
+function PitchGrid({
+  squad, formation, currentWeek, clubId, scoutLevel, listedPlayerIds, isWindowOpen,
+  mode, managerXI, onFillPosition, onRelease, onList, onUnlist,
+}: PitchGridProps) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const config = FORMATION_CONFIG[formation];
   if (!config) return null;
 
+  // In lineup mode, use the manager's XI to determine which players fill slots
+  const xiSet = new Set((managerXI ?? []).map(p => p.id));
+  const xi = mode === 'lineup' ? (managerXI ?? []) : squad;
+
+  // Surplus = players in squad not placed in any formation slot
+  const formationPlayers = PITCH_ROW_ORDER.flatMap(pos => {
+    const inPos = (mode === 'lineup' ? xi : squad)
+      .filter(p => p.position === pos)
+      .sort((a, b) => computeOverallRating(b) - computeOverallRating(a));
+    return inPos.slice(0, config.slots[pos]);
+  });
+  const formationPlayerIds = new Set(formationPlayers.map(p => p.id));
+  const depth = squad.filter(p => !formationPlayerIds.has(p.id));
+
   return (
-    <div className="flex flex-col gap-4">
-      {POSITION_ORDER.map(pos => {
-        const target = config.slots[pos];
-        const players = squad
-          .filter(p => p.position === pos)
-          .sort((a, b) => computeOverallRating(b) - computeOverallRating(a));
-        const have = players.length;
-        const gap = have - target;
-        const isShort = gap < 0;
-        const isSurplus = gap > 0;
-        const vacantCount = Math.max(0, -gap);
+    <div className="flex flex-col gap-3">
+      {/* ── Pitch ── */}
+      <div className="bg-pitch-green/5 rounded-xl border border-white/5 p-3 flex flex-col gap-3">
+        {PITCH_ROW_ORDER.map(pos => {
+          const target = config.slots[pos];
+          const available = (mode === 'lineup' ? xi : squad)
+            .filter(p => p.position === pos)
+            .sort((a, b) => computeOverallRating(b) - computeOverallRating(a));
+          const placed = available.slice(0, target);
+          const vacantCount = Math.max(0, target - placed.length);
+          const have = squad.filter(p => p.position === pos).length;
+          const gap = have - target;
+          const isShort = gap < 0;
+          const isSurplus = gap > 0;
 
-        return (
-          <div key={pos}>
-            {/* Position section header */}
-            <div className="flex items-center gap-2 mb-1.5">
-              <span className="text-[10px] font-bold px-1.5 py-0.5 rounded border bg-bg-raised text-txt-muted border-white/10">
-                {pos}
-              </span>
-              <span className="text-xs text-txt-muted">{have}/{target}</span>
-              <span className={`text-xs font-semibold ${isShort ? 'text-alert-red' : isSurplus ? 'text-warn-amber' : 'text-pitch-green'}`}>
-                {isShort ? `−${Math.abs(gap)} needed` : isSurplus ? `+${gap} surplus` : '✓'}
-              </span>
+          return (
+            <div key={pos} className="flex flex-col gap-1.5">
+              {/* Row label + gap indicator */}
+              <div className="flex items-center gap-2">
+                <span className="text-[10px] font-bold px-1.5 py-0.5 rounded border bg-bg-raised text-txt-muted border-white/10 w-8 text-center">{pos}</span>
+                <span className={`text-[10px] font-semibold ${isShort ? 'text-alert-red' : isSurplus ? 'text-warn-amber' : 'text-pitch-green'}`}>
+                  {isShort ? `−${Math.abs(gap)} needed` : isSurplus ? `+${gap} surplus` : '✓'}
+                </span>
+              </div>
+
+              {/* Slot row */}
+              <div className="flex flex-wrap gap-2 justify-start">
+                {placed.map(player => {
+                  const ovr = computeOverallRating(player);
+                  const isExpanded = expandedId === player.id;
+                  const isListed = listedPlayerIds.includes(player.id);
+                  const isInXI = mode === 'lineup' ? xiSet.has(player.id) : true;
+
+                  return (
+                    <div key={player.id} className="flex flex-col gap-1">
+                      {/* Circle chip */}
+                      <button
+                        onClick={() => mode === 'manage' ? setExpandedId(isExpanded ? null : player.id) : undefined}
+                        className={`relative w-16 h-16 rounded-full border-2 flex flex-col items-center justify-center transition-colors ${ovrBorderClass(ovr)} ${
+                          mode === 'manage' ? 'hover:bg-white/5 cursor-pointer' : 'cursor-default'
+                        } ${isExpanded ? 'bg-white/5' : 'bg-bg-raised'} ${
+                          mode === 'lineup' && !isInXI ? 'opacity-50' : ''
+                        }`}
+                      >
+                        <span className={`text-sm font-bold leading-none ${ovrTextClass(ovr)}`}>{ovr}</span>
+                        <span className="text-[8px] text-txt-muted leading-tight w-14 truncate text-center px-1">
+                          {player.name.split(' ').pop()}
+                        </span>
+                        {isListed && (
+                          <span className="absolute -top-1 -right-1 text-[9px] bg-warn-amber/20 text-warn-amber border border-warn-amber/40 rounded-full w-4 h-4 flex items-center justify-center leading-none">
+                            £
+                          </span>
+                        )}
+                      </button>
+
+                      {/* Expanded card */}
+                      {isExpanded && mode === 'manage' && (
+                        <div className="w-48">
+                          <SquadPlayerCard
+                            player={player}
+                            currentWeek={currentWeek}
+                            clubId={clubId}
+                            scoutLevel={scoutLevel}
+                            isListed={isListed}
+                            isWindowOpen={isWindowOpen}
+                            onRelease={() => { onRelease(player.id); setExpandedId(null); }}
+                            onList={() => { onList(player.id); setExpandedId(null); }}
+                            onUnlist={() => { onUnlist(player.id); setExpandedId(null); }}
+                          />
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+
+                {/* Vacant slots */}
+                {Array.from({ length: vacantCount }).map((_, i) => (
+                  <button
+                    key={`vacant-${pos}-${i}`}
+                    onClick={() => onFillPosition(pos)}
+                    className="w-16 h-16 rounded-full border-2 border-dashed border-white/20 flex flex-col items-center justify-center hover:border-white/40 transition-colors bg-bg-raised"
+                  >
+                    <span className="text-[10px] text-txt-muted font-semibold">+</span>
+                    <span className="text-[8px] text-data-blue">{pos}</span>
+                  </button>
+                ))}
+              </div>
             </div>
+          );
+        })}
+      </div>
 
-            {/* Player chips + vacant slots */}
-            <div className="flex flex-wrap gap-2">
-              {players.map(player => {
-                const ovr = computeOverallRating(player);
-                const isExpanded = expandedId === player.id;
-                return (
-                  <div key={player.id} className="flex flex-col gap-1 min-w-[140px] max-w-[200px]">
-                    <button
-                      onClick={() => setExpandedId(isExpanded ? null : player.id)}
-                      className={`bg-bg-raised border rounded-card px-3 py-2 text-left w-full transition-colors hover:border-white/20 ${ovrBorderClass(ovr)} ${isExpanded ? 'border-opacity-80' : ''}`}
-                    >
-                      <div className="flex items-center justify-between gap-1">
-                        <span className="text-xs font-semibold text-txt-primary truncate">{player.name}</span>
-                        <span className={`text-sm font-bold shrink-0 ${ovrTextClass(ovr)}`}>{ovr}</span>
-                      </div>
-                      <div className="text-[10px] text-txt-muted mt-0.5">
-                        Age {player.age} · {formatMoney(player.wage)}/wk
-                      </div>
-                    </button>
-
-                    {isExpanded && (
+      {/* ── Depth rail ── */}
+      {depth.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <span className="text-[10px] text-txt-muted font-semibold uppercase tracking-wide">
+            {mode === 'lineup' ? 'Bench' : 'Squad Depth'}
+          </span>
+          <div className="flex flex-wrap gap-2">
+            {depth.map(player => {
+              const ovr = computeOverallRating(player);
+              const isListed = listedPlayerIds.includes(player.id);
+              const isExpanded = expandedId === player.id;
+              return (
+                <div key={player.id} className="flex flex-col gap-1">
+                  <button
+                    onClick={() => mode === 'manage' ? setExpandedId(isExpanded ? null : player.id) : undefined}
+                    className={`relative w-14 h-14 rounded-full border-2 flex flex-col items-center justify-center opacity-60 transition-colors ${ovrBorderClass(ovr)} ${
+                      mode === 'manage' ? 'hover:opacity-80 cursor-pointer' : 'cursor-default'
+                    } bg-bg-raised`}
+                  >
+                    <span className={`text-xs font-bold leading-none ${ovrTextClass(ovr)}`}>{ovr}</span>
+                    <span className="text-[8px] text-txt-muted leading-tight w-12 truncate text-center px-1">
+                      {player.name.split(' ').pop()}
+                    </span>
+                    {isListed && (
+                      <span className="absolute -top-1 -right-1 text-[9px] bg-warn-amber/20 text-warn-amber border border-warn-amber/40 rounded-full w-4 h-4 flex items-center justify-center leading-none">
+                        £
+                      </span>
+                    )}
+                  </button>
+                  {isExpanded && mode === 'manage' && (
+                    <div className="w-48">
                       <SquadPlayerCard
                         player={player}
                         currentWeek={currentWeek}
                         clubId={clubId}
                         scoutLevel={scoutLevel}
+                        isListed={isListed}
+                        isWindowOpen={isWindowOpen}
                         onRelease={() => { onRelease(player.id); setExpandedId(null); }}
-                        onSellToNpc={npcClubId => { onSellToNpc(player.id, npcClubId); setExpandedId(null); }}
+                        onList={() => { onList(player.id); setExpandedId(null); }}
+                        onUnlist={() => { onUnlist(player.id); setExpandedId(null); }}
                       />
-                    )}
-                  </div>
-                );
-              })}
-
-              {/* Vacant slots */}
-              {Array.from({ length: vacantCount }).map((_, i) => (
-                <button
-                  key={`vacant-${i}`}
-                  onClick={() => onFillPosition(pos)}
-                  className="bg-bg-raised border border-dashed border-white/20 rounded-card px-3 py-2 text-left hover:border-white/40 transition-colors min-w-[140px]"
-                >
-                  <div className="text-xs text-txt-muted font-semibold">+ VACANT</div>
-                  <div className="text-[10px] text-data-blue mt-0.5">Find a {pos} →</div>
-                </button>
-              ))}
-            </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
           </div>
-        );
-      })}
+        </div>
+      )}
     </div>
   );
 }
@@ -573,22 +623,26 @@ interface SquadPlayerCardProps {
   currentWeek: number;
   clubId: string;
   scoutLevel: number;
+  isListed: boolean;
+  /** Whether the transfer window is currently open — gates listing. */
+  isWindowOpen: boolean;
   onRelease: () => void;
-  onSellToNpc: (npcClubId: string) => void;
+  onList: () => void;
+  onUnlist: () => void;
 }
 
-type SquadAction = 'idle' | 'confirm-release' | 'pick-club' | 'confirm-sell';
+type SquadAction = 'idle' | 'confirm-release';
 
 /** Players with OVR >= 65 and morale >= 70 are considered fan favourites. */
 function isFanFavourite(player: Player): boolean {
   return computeOverallRating(player) >= 65 && (player.morale ?? 0) >= 70;
 }
 
-function SquadPlayerCard({ player, currentWeek, clubId, scoutLevel, onRelease, onSellToNpc }: SquadPlayerCardProps) {
+function SquadPlayerCard({
+  player, currentWeek, scoutLevel, isListed, isWindowOpen, onRelease, onList, onUnlist,
+}: SquadPlayerCardProps) {
   const [action, setAction] = useState<SquadAction>('idle');
-  const [selectedClubId, setSelectedClubId] = useState('');
-  const [done, setDone] = useState<'released' | 'sold' | null>(null);
-  const [soldToClubName, setSoldToClubName] = useState<string | null>(null);
+  const [done, setDone] = useState<'released' | 'listed' | 'unlisted' | null>(null);
 
   const isFreeAgent = player.contractExpiresWeek === 0;
   const isExpired = !isFreeAgent && currentWeek >= player.contractExpiresWeek;
@@ -596,61 +650,25 @@ function SquadPlayerCard({ player, currentWeek, clubId, scoutLevel, onRelease, o
     ? Math.round((player.contractExpiresWeek - currentWeek) * player.wage * 0.5)
     : 0;
 
-  const playerOvr = computeOverallRating(player);
-  const sellFee = player.transferValue > 0
-    ? player.transferValue
-    : Math.max(10_000, playerOvr * playerOvr * 500);
-
   const fanFav = isFanFavourite(player);
 
-  // All 23 NPC clubs (excluding player's own club)
-  const npcClubs = LEAGUE_TWO_TEAMS.filter(t => t.id !== clubId);
-  const selectedClub = npcClubs.find(t => t.id === selectedClubId);
-
   function contractBadge() {
-    if (isFreeAgent) {
-      return <span className="text-[10px] bg-pitch-green/20 text-pitch-green border border-pitch-green/40 px-1.5 py-0.5 rounded">Free agent</span>;
-    }
-    if (isExpired) {
-      return <span className="text-[10px] bg-pitch-green/20 text-pitch-green border border-pitch-green/40 px-1.5 py-0.5 rounded">Out of contract</span>;
-    }
+    if (isFreeAgent) return <span className="text-[10px] bg-pitch-green/20 text-pitch-green border border-pitch-green/40 px-1.5 py-0.5 rounded">Free agent</span>;
+    if (isExpired) return <span className="text-[10px] bg-pitch-green/20 text-pitch-green border border-pitch-green/40 px-1.5 py-0.5 rounded">Out of contract</span>;
     const weeksLeft = player.contractExpiresWeek - currentWeek;
     return <span className="text-[10px] text-txt-muted" title={`Contract expires week ${player.contractExpiresWeek}`}>Contract: {weeksLeft}w left</span>;
   }
 
-  function handleConfirmRelease() {
-    onRelease();
-    setDone('released');
-    setAction('idle');
-  }
-
-  function handleConfirmSell() {
-    onSellToNpc(selectedClubId);
-    setSoldToClubName(selectedClub?.name ?? null);
-    setDone('sold');
-    setAction('idle');
-  }
-
-  function cancel() {
-    setAction('idle');
-    setSelectedClubId('');
-  }
-
   return (
-    <div className={`bg-bg-raised rounded-card border p-3 flex flex-col gap-2 ${
-      fanFav ? 'border-purple-500/30' : 'border-white/5'
-    }`}>
+    <div className={`bg-bg-raised rounded-card border p-3 flex flex-col gap-2 ${fanFav ? 'border-purple-500/30' : 'border-white/5'}`}>
       {/* Header row */}
       <div className="flex items-start justify-between gap-2">
         <div className="flex flex-col gap-0.5 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
             <span className="font-semibold text-txt-primary text-sm truncate">{player.name}</span>
-            <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${POSITION_COLOUR[player.position]}`}>
-              {player.position}
-            </span>
-            {fanFav && (
-              <span className="text-[10px] text-purple-400 font-semibold">♥ Fan favourite</span>
-            )}
+            <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${POSITION_COLOUR[player.position]}`}>{player.position}</span>
+            {fanFav && <span className="text-[10px] text-purple-400 font-semibold">♥ Fan favourite</span>}
+            {isListed && <span className="text-[10px] text-warn-amber font-semibold bg-warn-amber/10 border border-warn-amber/30 px-1.5 py-0.5 rounded">£ Listed</span>}
           </div>
           <div className="flex items-center gap-2 flex-wrap">
             <span className="text-xs text-txt-muted">Age {player.age} · {formatMoney(player.wage)}/wk</span>
@@ -675,11 +693,10 @@ function SquadPlayerCard({ player, currentWeek, clubId, scoutLevel, onRelease, o
       {/* Actions */}
       {done === 'released' ? (
         <div className="text-xs text-warn-amber font-semibold">Released{fanFav ? ' — the fans won\'t forget.' : ''}</div>
-      ) : done === 'sold' ? (
-        <div className="text-xs text-pitch-green font-semibold">
-          {soldToClubName ? `${soldToClubName} sign ${player.name} for ${formatMoney(sellFee)}.` : `Sold for ${formatMoney(sellFee)}.`}
-          {fanFav ? <span className="text-warn-amber"> The fans won't forget that easily.</span> : null}
-        </div>
+      ) : done === 'listed' ? (
+        <div className="text-xs text-warn-amber font-semibold">{player.name} is on the transfer list. Bids will arrive when the window opens.</div>
+      ) : done === 'unlisted' ? (
+        <div className="text-xs text-txt-muted">Listing withdrawn. {player.name} is no longer for sale.</div>
       ) : action === 'confirm-release' ? (
         <div className="flex flex-col gap-1.5 text-xs">
           {fanFav && (
@@ -691,49 +708,38 @@ function SquadPlayerCard({ player, currentWeek, clubId, scoutLevel, onRelease, o
             <span className="text-txt-muted">
               Release {player.name}{releaseFee > 0 ? ` (${formatMoney(releaseFee)} fee)` : ' for free'}?
             </span>
-            <button onClick={handleConfirmRelease} className="px-2 py-0.5 bg-alert-red/20 text-alert-red border border-alert-red/40 rounded hover:bg-alert-red/30 transition-colors">Yes</button>
-            <button onClick={cancel} className="px-2 py-0.5 bg-white/5 text-txt-muted border border-white/10 rounded hover:bg-white/10 transition-colors">Cancel</button>
+            <button onClick={() => { onRelease(); setDone('released'); setAction('idle'); }} className="px-2 py-0.5 bg-alert-red/20 text-alert-red border border-alert-red/40 rounded hover:bg-alert-red/30 transition-colors">Yes</button>
+            <button onClick={() => setAction('idle')} className="px-2 py-0.5 bg-white/5 text-txt-muted border border-white/10 rounded hover:bg-white/10 transition-colors">Cancel</button>
           </div>
         </div>
-      ) : action === 'pick-club' ? (
-        <div className="flex flex-col gap-1.5 text-xs">
-          {fanFav && (
-            <div className="text-[10px] text-purple-400 bg-purple-500/5 border border-purple-500/20 rounded px-2 py-1">
-              ♥ Are you sure? {player.name} is a fan favourite.
-            </div>
-          )}
-          <span className="text-txt-muted">Sell to club for <span className="text-pitch-green font-semibold">{formatMoney(sellFee)}</span>:</span>
-          <select
-            value={selectedClubId}
-            onChange={e => { setSelectedClubId(e.target.value); setAction('confirm-sell'); }}
-            className="bg-bg-raised text-txt-primary text-xs border border-white/10 rounded px-2 py-1 focus:outline-none"
-          >
-            <option value="">— pick a club —</option>
-            {npcClubs.map(t => (
-              <option key={t.id} value={t.id}>{t.name}</option>
-            ))}
-          </select>
-          <button onClick={cancel} className="text-txt-muted hover:text-txt-primary transition-colors text-left">Cancel</button>
-        </div>
-      ) : action === 'confirm-sell' ? (
-        <div className="flex items-center gap-2 flex-wrap text-xs">
-          <span className="text-txt-muted">
-            Sell {player.name} to {selectedClub?.name} for <span className="text-pitch-green font-semibold">{formatMoney(sellFee)}</span>?
-          </span>
-          <button onClick={handleConfirmSell} className="px-2 py-0.5 bg-pitch-green/20 text-pitch-green border border-pitch-green/40 rounded hover:bg-pitch-green/30 transition-colors">Confirm</button>
-          <button onClick={() => setAction('pick-club')} className="px-2 py-0.5 bg-white/5 text-txt-muted border border-white/10 rounded hover:bg-white/10 transition-colors">Back</button>
-        </div>
       ) : (
-        <div className="flex gap-2">
-          <button
-            onClick={() => setAction('pick-club')}
-            className="flex-1 text-xs py-1.5 rounded bg-pitch-green/10 text-pitch-green border border-pitch-green/30 hover:bg-pitch-green/20 transition-colors"
-          >
-            Sell ({formatMoney(sellFee)})
-          </button>
+        <div className="flex flex-col gap-1.5">
+          {/* Transfer listing row */}
+          {isListed ? (
+            <button
+              onClick={() => { onUnlist(); setDone('unlisted'); }}
+              className="w-full text-xs py-1.5 rounded bg-warn-amber/10 text-warn-amber border border-warn-amber/30 hover:bg-warn-amber/20 transition-colors"
+            >
+              Withdraw listing
+            </button>
+          ) : (
+            <button
+              onClick={isWindowOpen ? () => { onList(); setDone('listed'); } : undefined}
+              disabled={!isWindowOpen}
+              title={isWindowOpen ? undefined : 'Transfer window is closed'}
+              className={`w-full text-xs py-1.5 rounded border transition-colors ${
+                isWindowOpen
+                  ? 'bg-pitch-green/10 text-pitch-green border-pitch-green/30 hover:bg-pitch-green/20'
+                  : 'bg-white/5 text-txt-muted border-white/10 opacity-50 cursor-not-allowed'
+              }`}
+            >
+              {isWindowOpen ? 'List for sale' : 'List for sale (window closed)'}
+            </button>
+          )}
+          {/* Release row */}
           <button
             onClick={() => setAction('confirm-release')}
-            className="flex-1 text-xs py-1.5 rounded bg-alert-red/10 text-alert-red border border-alert-red/30 hover:bg-alert-red/20 transition-colors"
+            className="w-full text-xs py-1.5 rounded bg-alert-red/10 text-alert-red border border-alert-red/30 hover:bg-alert-red/20 transition-colors"
           >
             {releaseFee > 0 ? `Release (${formatMoney(releaseFee)} fee)` : 'Release (free)'}
           </button>
@@ -791,7 +797,9 @@ export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMa
   const [squadViewMode, setSquadViewMode] = useState<SquadViewMode>('formation');
 
   const currentTotalWages = state.club.squad.reduce((sum, p) => sum + p.wage, 0);
-  const wageRunway = currentTotalWages > 0 ? state.club.wageReserve / currentTotalWages : Infinity;
+  // wageReserve fallback: some saves use `wageReserve`, others expose it directly on club
+  const wageReserve = (state.club as any).wageReserve ?? 0;
+  const wageRunway = currentTotalWages > 0 ? wageReserve / currentTotalWages : Infinity;
   const squadCount = state.club.squad.length;
   const squadCapacity = state.club.squadCapacity;
   const scoutLevel = getScoutLevel(state.club.facilities);
@@ -836,10 +844,24 @@ export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMa
     if (result.error) onError(result.error);
   }
 
-  function handleSellToNpc(playerId: string, npcClubId: string) {
-    const result = dispatch({ type: 'SELL_PLAYER_TO_NPC', playerId, npcClubId });
+  function handleListPlayer(playerId: string) {
+    const result = dispatch({ type: 'LIST_PLAYER_FOR_SALE', playerId });
     if (result.error) onError(result.error);
   }
+
+  function handleUnlistPlayer(playerId: string) {
+    const result = dispatch({ type: 'UNLIST_PLAYER', playerId });
+    if (result.error) onError(result.error);
+  }
+
+  const isWindowOpen = isTransferWindowOpen(state.currentWeek, state.phase);
+  const listedPlayerIds = state.club.listedPlayerIds ?? [];
+
+  // Manager's XI — used for the lineup view
+  const managerTactical = state.club.manager?.attributes.tactical ?? 20;
+  const managerXI = state.club.preferredFormation
+    ? selectManagerXI(state.club.squad, state.club.preferredFormation, managerTactical, String(state.currentWeek))
+    : state.club.squad;
 
   function handleFillPosition(pos: Position) {
     setPositionFilter(pos);
@@ -863,7 +885,7 @@ export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMa
       {/* ── Budget / squad bar ─────────────────────────────────────────────── */}
       <div className="bg-bg-raised rounded-card border border-white/5 px-4 py-2 flex items-center gap-4 text-sm flex-wrap">
         <span className="text-txt-muted">
-          Wage runway: <span className={wageRunway < 8 ? 'text-alert-red font-semibold' : 'text-pitch-green font-semibold'}>{wageRunway === Infinity ? '∞' : `${Math.floor(wageRunway)}w`}</span>
+          Wage runway: <span className={wageRunway < 8 ? 'text-alert-red font-semibold' : 'text-pitch-green font-semibold'}>{wageRunway === Infinity || !isFinite(wageRunway) ? '∞' : `${Math.floor(wageRunway)}w`}</span>
         </span>
         <span className="text-white/20">|</span>
         <span className="text-txt-muted">
@@ -872,9 +894,6 @@ export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMa
           </span>
         </span>
       </div>
-
-      {/* ── Formation gap panel ───────────────────────────────────────────── */}
-      <FormationGapPanel state={state} />
 
       {/* ── Tabs ──────────────────────────────────────────────────────────── */}
       <div className="flex items-center gap-1">
@@ -894,17 +913,21 @@ export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMa
         {/* View mode toggle — only visible on My Squad tab */}
         {activeTab === 'my-squad' && (
           <div className="ml-auto flex gap-1">
-            {(['formation', 'list'] as SquadViewMode[]).map(mode => (
+            {([
+              { id: 'formation', label: '⊞ Manage' },
+              { id: 'lineup',    label: '▶ Lineup' },
+              { id: 'list',      label: '≡ List'   },
+            ] as { id: SquadViewMode; label: string }[]).map(({ id, label }) => (
               <button
-                key={mode}
-                onClick={() => setSquadViewMode(mode)}
+                key={id}
+                onClick={() => setSquadViewMode(id)}
                 className={`px-2 py-1 text-xs rounded transition-colors ${
-                  squadViewMode === mode
+                  squadViewMode === id
                     ? 'bg-white/10 text-txt-primary border border-white/20'
                     : 'text-txt-muted border border-white/5 hover:border-white/10'
                 }`}
               >
-                {mode === 'formation' ? '⊞ Formation' : '≡ List'}
+                {label}
               </button>
             ))}
           </div>
@@ -952,7 +975,7 @@ export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMa
               <FreeAgentCard
                 key={player.id}
                 player={player}
-                canAfford={(currentTotalWages + player.wage) > 0 ? state.club.wageReserve / (currentTotalWages + player.wage) >= 8 : true}
+                canAfford={(currentTotalWages + player.wage) > 0 ? wageReserve / (currentTotalWages + player.wage) >= 8 : true}
                 hasSquadRoom={squadCount < squadCapacity}
                 scoutLevel={scoutLevel}
                 willingness={computeWillingness(player, player.wage, tablePosition)}
@@ -963,17 +986,34 @@ export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMa
               />
             ))
           )
-        ) : squadViewMode === 'formation' && state.club.preferredFormation ? (
-          <SquadFormationView
-            squad={state.club.squad}
-            formation={state.club.preferredFormation}
-            currentWeek={state.currentWeek}
-            clubId={state.club.id}
-            scoutLevel={scoutLevel}
-            onFillPosition={handleFillPosition}
-            onRelease={handleRelease}
-            onSellToNpc={handleSellToNpc}
-          />
+        ) : (squadViewMode === 'formation' || squadViewMode === 'lineup') && state.club.preferredFormation ? (
+          <>
+            {squadViewMode === 'lineup' && (
+              <div className="bg-bg-raised rounded-card border border-white/5 px-3 py-2 text-xs text-txt-muted">
+                <span className="font-semibold text-txt-primary">Manager's XI</span>
+                {state.club.manager ? (
+                  <span className="ml-2">{state.club.manager.name} · Tactical {state.club.manager.attributes.tactical}/100</span>
+                ) : (
+                  <span className="ml-2 text-warn-amber">No manager hired — selection quality is poor</span>
+                )}
+              </div>
+            )}
+            <PitchGrid
+              squad={state.club.squad}
+              formation={state.club.preferredFormation}
+              currentWeek={state.currentWeek}
+              clubId={state.club.id}
+              scoutLevel={scoutLevel}
+              listedPlayerIds={listedPlayerIds}
+              isWindowOpen={isWindowOpen}
+              mode={squadViewMode === 'lineup' ? 'lineup' : 'manage'}
+              managerXI={squadViewMode === 'lineup' ? managerXI : undefined}
+              onFillPosition={handleFillPosition}
+              onRelease={handleRelease}
+              onList={handleListPlayer}
+              onUnlist={handleUnlistPlayer}
+            />
+          </>
         ) : (
           filteredSquad.length === 0 ? (
             <div className="text-txt-muted text-sm text-center py-8">No players match your filters.</div>
@@ -985,8 +1025,11 @@ export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMa
                 currentWeek={state.currentWeek}
                 clubId={state.club.id}
                 scoutLevel={scoutLevel}
+                isListed={listedPlayerIds.includes(player.id)}
+                isWindowOpen={isWindowOpen}
                 onRelease={() => handleRelease(player.id)}
-                onSellToNpc={npcClubId => handleSellToNpc(player.id, npcClubId)}
+                onList={() => handleListPlayer(player.id)}
+                onUnlist={() => handleUnlistPlayer(player.id)}
               />
             ))
           )


### PR DESCRIPTION
## Summary

- **#57 — Formation pitch grid**: Replaces the flat `SquadFormationView` and `FormationGapPanel` with a spatial `PitchGrid` component (FWD→MID→DEF→GK rows, circle slots, OVR colour-coding, per-row gap indicators, listed badge, depth rail for surplus players)
- **#56 — Manager's XI view**: New read-only `lineup` mode in My Squad tab shows which XI the manager would field using `selectManagerXI` — a noise-weighted selection where poor managers (low tactical rating) make occasional mis-picks that rotate each week via a seed. Owner can see the reality but can only fix it by recruiting or hiring a better manager.
- **#58 — Sell with jeopardy**: Instant sell removed. Players must be listed first → NPC clubs submit bids during open windows → three-choice inbox event (accept / counter at +25% via % maths challenge / reject). Full domain event loop: `LIST_PLAYER_FOR_SALE` → `PLAYER_LISTED` → `generateListedPlayerBids` → `PendingClubEvent{templateId: 'npc-bid'}` → `RESOLVE_CLUB_EVENT`.

## Domain changes

- `seededIntNoise(seed, range)` in `rng.ts` — per-player, per-week noise for manager assessment
- `selectManagerXI(squad, formation, managerTactical, weekSeed)` in `match.ts`, exported from index
- `clubToTeam` now passes a week seed so match strength reflects manager selection noise
- `listedPlayerIds: string[]` on `Club`
- `LIST_PLAYER_FOR_SALE` / `UNLIST_PLAYER` commands, `PLAYER_LISTED` / `PLAYER_UNLISTED` events, handlers, reducers
- `SELL_PLAYER_TO_NPC` gated: player must be listed before a direct sale completes
- `generateListedPlayerBids` in `simulation/events.ts`: per-listed-player bid probability, one pending bid cap, window-gated
- `eventKind: 'poach' | 'bid'` discriminant on `PendingClubEvent.metadata`

## Frontend changes

- `PitchGrid` component (replaces `SquadFormationView` + `FormationGapPanel`)
- Three-mode toggle in My Squad: ⊞ Manage / ▶ Lineup / ≡ List
- List for Sale / Withdraw Listing buttons (window-gated) on player cards
- `npc-bid` rendering case in `PendingEventCard` with player snapshot strip and offered fee

## Test plan

- [ ] Domain builds clean: `npm run build` in `packages/domain`
- [ ] 478 domain tests pass: `npm test` in `packages/domain`
- [ ] Frontend compiles: `npx tsc --noEmit` in `packages/frontend`
- [ ] List a player → advance weeks inside transfer window → bid arrives in inbox
- [ ] Accept bid → player leaves squad, budget credited
- [ ] Counter bid → % maths challenge fires → correct answer → higher fee credited
- [ ] Reject bid → player stays, listing cleared
- [ ] Lineup tab with quality-1 manager shows visibly sub-optimal picks
- [ ] Lineup tab with quality-5 manager always shows optimal XI
- [ ] Vacant slot in pitch grid → clicking fills position filter on Free Agents tab
- [ ] All six formations render correct slot counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)