### PR TITLE
feat: manager archetype shells (#109)

### DIFF
--- a/packages/domain/src/data/manager-archetypes.ts
+++ b/packages/domain/src/data/manager-archetypes.ts
@@ -1,0 +1,97 @@
+/**
+ * Manager Archetype Shells
+ *
+ * Five distinct manager personas. Each archetype defines a communication
+ * style, personality, and stat bias — giving hiring decisions character
+ * alongside numerical consequence.
+ *
+ * Archetypes are assigned at pool generation time and are stable for
+ * the lifetime of a save.
+ */
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type ManagerArchetype =
+  | 'PHILOSOPHER'
+  | 'SERGEANT'
+  | 'YOUTH_DEVELOPER'
+  | 'PRAGMATIST'
+  | 'SHOWMAN';
+
+export interface ManagerPersona {
+  archetype: ManagerArchetype;
+  /** Display label shown in UI: "The Philosopher" */
+  label: string;
+  /** One-liner shown in manager picker */
+  shortDesc: string;
+  /**
+   * Tailwind classes for the avatar chip in inbox.
+   * e.g. 'bg-violet-400/20 text-violet-400'
+   */
+  avatarClass: string;
+  /** Tailwind class for the name/sender label */
+  nameClass: string;
+}
+
+// ── Persona definitions ────────────────────────────────────────────────────
+
+export const MANAGER_PERSONAS: Record<ManagerArchetype, ManagerPersona> = {
+  PHILOSOPHER: {
+    archetype: 'PHILOSOPHER',
+    label: 'The Philosopher',
+    shortDesc: 'Meticulous. Builds systems over years. Don\'t expect fireworks.',
+    avatarClass: 'bg-violet-400/20 text-violet-400',
+    nameClass: 'text-violet-400',
+  },
+  SERGEANT: {
+    archetype: 'SERGEANT',
+    label: 'The Sergeant',
+    shortDesc: 'Demanding. High standards. Squad morale can be a casualty.',
+    avatarClass: 'bg-orange-400/20 text-orange-400',
+    nameClass: 'text-orange-400',
+  },
+  YOUTH_DEVELOPER: {
+    archetype: 'YOUTH_DEVELOPER',
+    label: 'The Developer',
+    shortDesc: 'Patient. Builds from within. Won\'t win you anything quickly.',
+    avatarClass: 'bg-emerald-400/20 text-emerald-400',
+    nameClass: 'text-emerald-400',
+  },
+  PRAGMATIST: {
+    archetype: 'PRAGMATIST',
+    label: 'The Pragmatist',
+    shortDesc: 'Steady. Unspectacular. Gets the job done without drama.',
+    avatarClass: 'bg-slate-300/20 text-slate-300',
+    nameClass: 'text-slate-300',
+  },
+  SHOWMAN: {
+    archetype: 'SHOWMAN',
+    label: 'The Showman',
+    shortDesc: 'Charismatic. Volatile. The dressing room loves or hates him.',
+    avatarClass: 'bg-yellow-400/20 text-yellow-400',
+    nameClass: 'text-yellow-400',
+  },
+};
+
+// ── Tier → archetype pools ─────────────────────────────────────────────────
+// Archetypes available per tier, drawn from randomly at generation time.
+
+export const ARCHETYPE_POOL_ELITE: ManagerArchetype[] = [
+  'PHILOSOPHER',
+  'SERGEANT',
+  'SHOWMAN',
+];
+
+export const ARCHETYPE_POOL_MID: ManagerArchetype[] = [
+  'PHILOSOPHER',
+  'PRAGMATIST',
+  'YOUTH_DEVELOPER',
+  'SHOWMAN',
+  'SERGEANT',
+];
+
+export const ARCHETYPE_POOL_BUDGET: ManagerArchetype[] = [
+  'PRAGMATIST',
+  'YOUTH_DEVELOPER',
+  'PHILOSOPHER',
+];

--- a/packages/domain/src/data/manager-generator.ts
+++ b/packages/domain/src/data/manager-generator.ts
@@ -13,6 +13,12 @@
  */
 
 import { Manager, ManagerAttributes } from '../types/staff';
+import {
+  ManagerArchetype,
+  ARCHETYPE_POOL_ELITE,
+  ARCHETYPE_POOL_MID,
+  ARCHETYPE_POOL_BUDGET,
+} from './manager-archetypes';
 import { createRng, Rng } from '../simulation/rng';
 
 // ─── Manager name pool ─────────────────────────────────────────────────────────
@@ -47,6 +53,7 @@ interface ManagerTier {
   /** Weekly wage range in pence */
   wageRange: [number, number];
   contractLengthWeeks: number;
+  archetypePool: ManagerArchetype[];
 }
 
 const TIERS: ManagerTier[] = [
@@ -58,6 +65,7 @@ const TIERS: ManagerTier[] = [
     experienceRange: [75, 95],
     wageRange: [400_000, 700_000],   // £4,000–£7,000/wk
     contractLengthWeeks: 104,        // 2 seasons
+    archetypePool: ARCHETYPE_POOL_ELITE,
   },
   // Mid-tier — three managers. One stat dominates. Affordable.
   {
@@ -67,6 +75,7 @@ const TIERS: ManagerTier[] = [
     experienceRange: [45, 75],
     wageRange: [150_000, 350_000],   // £1,500–£3,500/wk
     contractLengthWeeks: 52,         // 1 season
+    archetypePool: ARCHETYPE_POOL_MID,
   },
   // Budget — three managers. Low stats, very cheap.
   {
@@ -76,6 +85,7 @@ const TIERS: ManagerTier[] = [
     experienceRange: [15, 45],
     wageRange: [50_000, 130_000],    // £500–£1,300/wk
     contractLengthWeeks: 52,
+    archetypePool: ARCHETYPE_POOL_BUDGET,
   },
 ];
 
@@ -83,6 +93,10 @@ const TIERS: ManagerTier[] = [
 
 function randInt(rng: Rng, min: number, max: number): number {
   return Math.round(min + rng.next() * (max - min));
+}
+
+function pickArchetype(rng: Rng, pool: ManagerArchetype[]): ManagerArchetype {
+  return pool[Math.floor(rng.next() * pool.length)];
 }
 
 /**
@@ -112,6 +126,8 @@ export function generateManagerPool(seed: string): Manager[] {
       // Round wage to nearest £100 (10_000 pence)
       const roundedWage = Math.round(wage / 10_000) * 10_000;
 
+      const archetype = pickArchetype(rng, tier.archetypePool);
+
       managers.push({
         id: `mgr-${idCounter++}`,
         name,
@@ -119,6 +135,8 @@ export function generateManagerPool(seed: string): Manager[] {
         wage: roundedWage,
         contractLengthWeeks: tier.contractLengthWeeks,
         contractExpiresWeek: 0, // set on hire
+        archetype,
+        confidence: 60,         // default: settled, neutral
       });
     }
   }

--- a/packages/domain/src/data/manager-message-templates.ts
+++ b/packages/domain/src/data/manager-message-templates.ts
@@ -1,0 +1,256 @@
+/**
+ * Manager Archetype Message Templates
+ *
+ * Each archetype has distinct pools for five situations:
+ *   POST_WIN       — after a victory
+ *   POST_LOSS      — after a defeat
+ *   FORM_GOOD      — 3+ wins in last 5
+ *   FORM_POOR      — 3+ losses in last 5
+ *   WEEKLY_CHECKIN — periodic check-in (every ~3 weeks, no match context needed)
+ *
+ * Placeholders: [MANAGER], [OPPONENT], [SCORE], [POSITION], [TOTAL], [CLUB]
+ *
+ * Voice guide per archetype:
+ *   PHILOSOPHER    — Methodical. Talks in systems, process, structure. Never excited.
+ *   SERGEANT       — Blunt, binary, accountability-first. No excuses. Short sentences.
+ *   YOUTH_DEVELOPER — Patient, nurturing. Long-term arc. References development.
+ *   PRAGMATIST     — Matter-of-fact. Numbers and margins. No drama.
+ *   SHOWMAN        — Theatrical, emotional. Feeds off energy and momentum.
+ */
+
+import { ManagerArchetype } from './manager-archetypes';
+
+// ── Template structure ─────────────────────────────────────────────────────
+
+export interface ManagerMessagePools {
+  postWin:       readonly string[];
+  postLoss:      readonly string[];
+  formGood:      readonly string[];
+  formPoor:      readonly string[];
+  weeklyCheckin: readonly string[];
+}
+
+// ── PHILOSOPHER ────────────────────────────────────────────────────────────
+
+const PHILOSOPHER_POST_WIN: readonly string[] = [
+  'The system is working. I said it would take time to click — and it\'s clicking.',
+  'Good result. More importantly, we\'re seeing the patterns we\'ve worked on come through.',
+  'Three points. Exactly what the structure asks for. We stay the course.',
+  'That was disciplined football. The principles held. Keep building.',
+  'A win built on process, not luck. That\'s the kind of result that compounds.',
+];
+
+const PHILOSOPHER_POST_LOSS: readonly string[] = [
+  'A setback in the process. We identify what broke down, we correct it, we move forward.',
+  'The principles were right. The execution wasn\'t. We work on that this week.',
+  'Results like this are inevitable in a long season. What matters is how we respond.',
+  'I\'ve reviewed the data. There were three moments we\'d do differently. We\'ll address them.',
+  'The structure didn\'t fail us — we failed the structure. That\'s a coaching problem, and I own it.',
+];
+
+const PHILOSOPHER_FORM_GOOD: readonly string[] = [
+  'This is what a well-structured side looks like when it finds its rhythm. Stay patient.',
+  'The patterns we\'ve been building are paying off. Discipline got us here. Discipline keeps us here.',
+  'Three wins from the last five. The system is functioning. Don\'t change anything.',
+];
+
+const PHILOSOPHER_FORM_POOR: readonly string[] = [
+  'A difficult patch. I\'m not panicking. The structure hasn\'t changed — the execution needs work.',
+  'We\'re not in a crisis. We\'re in a difficult spell. There\'s a meaningful difference.',
+  'The underlying numbers are not as bad as the run suggests. We stay with the plan.',
+];
+
+const PHILOSOPHER_WEEKLY_CHECKIN: readonly string[] = [
+  'We\'re on track. Don\'t judge the season by any individual week.',
+  'I\'m watching the underlying numbers. Position isn\'t everything at this stage.',
+  'Training has been structured and purposeful this week. I\'m satisfied with where we are.',
+  'Patience is a competitive advantage. We have it. Let\'s keep it.',
+];
+
+// ── SERGEANT ───────────────────────────────────────────────────────────────
+
+const SERGEANT_POST_WIN: readonly string[] = [
+  'Good. That\'s what I expect. Do it again.',
+  'Three points. Standards were met. Next game.',
+  'When we work hard, we get results. That\'s the deal. We kept our end of it.',
+  'Exactly what I asked for. No more, no less.',
+  'That\'s the minimum. Don\'t let it go to your head.',
+];
+
+const SERGEANT_POST_LOSS: readonly string[] = [
+  'Not good enough. I\'ve said that to the players. I\'m saying it to you now.',
+  'We were second best. That ends now.',
+  'No excuses. We work harder this week.',
+  'I won\'t accept that performance. Neither should you.',
+  'Second best in every department. Every single one. That changes in training tomorrow.',
+];
+
+const SERGEANT_FORM_GOOD: readonly string[] = [
+  'This is what hard work gets you. Don\'t get comfortable — that\'s when standards slip.',
+  'Three wins. Good. Now we show it wasn\'t a fluke.',
+  'High standards produce high results. Keep the standards.',
+];
+
+const SERGEANT_FORM_POOR: readonly string[] = [
+  'Three games without a win. I\'m not happy. The players know it.',
+  'This stops now. I\'ve demanded a response. Watch what happens.',
+  'Soft. We\'ve been soft. That changes this week or there will be consequences.',
+];
+
+const SERGEANT_WEEKLY_CHECKIN: readonly string[] = [
+  'Standards are being maintained. For now.',
+  'We\'re working hard. I\'m watching the effort levels closely.',
+  'Nobody is comfortable in their position. Good. That\'s how it should be.',
+  'The week has been acceptable. Acceptable isn\'t enough, but it\'s a start.',
+];
+
+// ── YOUTH DEVELOPER ────────────────────────────────────────────────────────
+
+const YOUTH_DEVELOPER_POST_WIN: readonly string[] = [
+  'The young lads were brilliant today. This is exactly why we invest in them.',
+  'Results like this make the development work worthwhile. We\'re building something real here.',
+  'Good win. More excitingly, some of the younger players are starting to really come on.',
+  'Exactly what I hoped for. The squad is growing into this system together.',
+  'That\'s the reward for patience. Brilliant.',
+];
+
+const YOUTH_DEVELOPER_POST_LOSS: readonly string[] = [
+  'A learning game. The young players will be better for having experienced this.',
+  'Disappointing result. But I\'ve seen plenty today to be positive about long-term.',
+  'We lost today. In three or four years, some of these players will be playing at a much higher level. Keep perspective.',
+  'Every setback is a lesson. We make sure the players understand what they\'re learning.',
+  'It hurts. It should hurt. But we won\'t panic and abandon what we\'re building.',
+];
+
+const YOUTH_DEVELOPER_FORM_GOOD: readonly string[] = [
+  'This run isn\'t a surprise to me. I\'ve watched this group develop. They were ready for it.',
+  'When you invest in the right way, this is what you get. Not immediately — but eventually.',
+  'The development work is paying dividends. This is the timeline we planned.',
+];
+
+const YOUTH_DEVELOPER_FORM_POOR: readonly string[] = [
+  'A tough spell. But we won\'t panic and abandon what we\'re building.',
+  'The players are learning what it takes at this level. That education has a cost sometimes.',
+  'Development isn\'t linear. We knew there would be patches like this. We stay the course.',
+];
+
+const YOUTH_DEVELOPER_WEEKLY_CHECKIN: readonly string[] = [
+  'Development takes time. We\'re seeing real progress in training this week.',
+  'The young group is coming on. Don\'t judge this season purely by the table.',
+  'I\'m more excited about this squad\'s ceiling than I am concerned about where we are now.',
+  'We\'re planting seeds. Some of them will take a season or two to grow. Trust the process.',
+];
+
+// ── PRAGMATIST ─────────────────────────────────────────────────────────────
+
+const PRAGMATIST_POST_WIN: readonly string[] = [
+  'A professional win. We did what was required.',
+  'Three points on the road. Exactly what we needed.',
+  'We were the better side. Results like that are repeatable if we stay organised.',
+  'Job done.',
+  'Expected. We were better prepared. The preparation showed.',
+];
+
+const PRAGMATIST_POST_LOSS: readonly string[] = [
+  'We gave away the margin. We\'ll be better next week.',
+  'A poor result. We analyse it and move on.',
+  'On the balance of chances, we probably deserved a point. We didn\'t get it. That happens.',
+  'Disappointing, but not unexpected against a side like that. Reset and go again.',
+  'The numbers will come right. One bad result doesn\'t change the underlying picture.',
+];
+
+const PRAGMATIST_FORM_GOOD: readonly string[] = [
+  'Three wins from five. The numbers are moving in the right direction.',
+  'Good form. Maintain the structure and it\'ll continue.',
+  'We\'re efficient right now. Efficient wins football matches.',
+];
+
+const PRAGMATIST_FORM_POOR: readonly string[] = [
+  'A difficult run. The data suggests it won\'t last if we stick to the plan.',
+  'These things happen over a forty-six game season. The underlying numbers are fine.',
+  'Variance. We\'re due a run. Keep working.',
+];
+
+const PRAGMATIST_WEEKLY_CHECKIN: readonly string[] = [
+  'Nothing unusual to report. We\'re working well.',
+  'Steady week. I\'ve got no particular concerns.',
+  'The squad is in reasonable shape. We prepare for the next game.',
+  'On track. No drama.',
+];
+
+// ── SHOWMAN ────────────────────────────────────────────────────────────────
+
+const SHOWMAN_POST_WIN: readonly string[] = [
+  'That\'s what this club can be when we believe in each other. That\'s the [CLUB] I know.',
+  'Did you feel that atmosphere at the end? That\'s the energy we feed off. Unbelievable.',
+  'We\'re flying right now. When this group clicks, nobody can stop us.',
+  'Brilliant. Just brilliant. This is why I got into football.',
+  'The crowd, the players, the occasion — everything came together. Days like this are everything.',
+];
+
+const SHOWMAN_POST_LOSS: readonly string[] = [
+  'I\'m gutted. The players are gutted. We let the fans down and we know it.',
+  'That wasn\'t us. That wasn\'t who we are. Next week is our chance to show our real face.',
+  'A bad day. But I\'ve seen what this group can do when they\'re switched on. We\'ll be back.',
+  'We owe the supporters a response. They were unbelievable today and we didn\'t give them what they deserved.',
+  'There\'s hurt in that dressing room. Good. Use it.',
+];
+
+const SHOWMAN_FORM_GOOD: readonly string[] = [
+  'We\'re on a roll and you can feel it around the whole club. Don\'t let it stop.',
+  'This is momentum. You can\'t buy it. We have it. We protect it.',
+  'The fans are buzzing, the players are buzzing — everything is alive right now.',
+];
+
+const SHOWMAN_FORM_POOR: readonly string[] = [
+  'I need the players to find something deep down. The supporters deserve a reaction.',
+  'We\'re in a rough patch. These are the moments that define a club\'s character.',
+  'The noise outside doesn\'t help. I\'m blocking it out and so are the players. Watch what\'s coming.',
+];
+
+const SHOWMAN_WEEKLY_CHECKIN: readonly string[] = [
+  'Energy in training has been electric this week. I like what I\'m seeing.',
+  'The boys are fired up. Watch this space.',
+  'Great atmosphere at the training ground. Everyone is bought in.',
+  'There\'s a real belief running through this squad right now. I can feel it.',
+];
+
+// ── Assembled pools ────────────────────────────────────────────────────────
+
+export const MANAGER_MESSAGE_POOLS: Record<ManagerArchetype, ManagerMessagePools> = {
+  PHILOSOPHER: {
+    postWin:       PHILOSOPHER_POST_WIN,
+    postLoss:      PHILOSOPHER_POST_LOSS,
+    formGood:      PHILOSOPHER_FORM_GOOD,
+    formPoor:      PHILOSOPHER_FORM_POOR,
+    weeklyCheckin: PHILOSOPHER_WEEKLY_CHECKIN,
+  },
+  SERGEANT: {
+    postWin:       SERGEANT_POST_WIN,
+    postLoss:      SERGEANT_POST_LOSS,
+    formGood:      SERGEANT_FORM_GOOD,
+    formPoor:      SERGEANT_FORM_POOR,
+    weeklyCheckin: SERGEANT_WEEKLY_CHECKIN,
+  },
+  YOUTH_DEVELOPER: {
+    postWin:       YOUTH_DEVELOPER_POST_WIN,
+    postLoss:      YOUTH_DEVELOPER_POST_LOSS,
+    formGood:      YOUTH_DEVELOPER_FORM_GOOD,
+    formPoor:      YOUTH_DEVELOPER_FORM_POOR,
+    weeklyCheckin: YOUTH_DEVELOPER_WEEKLY_CHECKIN,
+  },
+  PRAGMATIST: {
+    postWin:       PRAGMATIST_POST_WIN,
+    postLoss:      PRAGMATIST_POST_LOSS,
+    formGood:      PRAGMATIST_FORM_GOOD,
+    formPoor:      PRAGMATIST_FORM_POOR,
+    weeklyCheckin: PRAGMATIST_WEEKLY_CHECKIN,
+  },
+  SHOWMAN: {
+    postWin:       SHOWMAN_POST_WIN,
+    postLoss:      SHOWMAN_POST_LOSS,
+    formGood:      SHOWMAN_FORM_GOOD,
+    formPoor:      SHOWMAN_FORM_POOR,
+    weeklyCheckin: SHOWMAN_WEEKLY_CHECKIN,
+  },
+};

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -45,6 +45,8 @@ export * from './data/club-events';
 export * from './data/squad-generator';
 export * from './data/free-agent-generator';
 export * from './data/manager-generator';
+export * from './data/manager-archetypes';
+export * from './data/manager-message-templates';
 export * from './data/scout-target-generator';
 
 // Morale system

--- a/packages/domain/src/reducers/index.ts
+++ b/packages/domain/src/reducers/index.ts
@@ -419,10 +419,22 @@ function handleMatchSimulated(state: GameState, event: MatchSimulatedEvent): Gam
     boardConfidence = Math.max(5, Math.min(95, boardConfidence + confDelta));
   }
 
+  // Manager confidence — tracks their belief in their own position.
+  // Win: +5  |  Draw: +1  |  Loss: -6
+  // Clamped 0–100. Drives inbox tone; extreme values will eventually surface events.
+  let updatedManager = state.club.manager;
+  if (updatedManager && clubResult) {
+    const managerConfDelta = clubResult === 'W' ? 5 : clubResult === 'D' ? 1 : -6;
+    updatedManager = {
+      ...updatedManager,
+      confidence: Math.max(0, Math.min(100, updatedManager.confidence + managerConfDelta)),
+    };
+  }
+
   return {
     ...state,
     league: { ...state.league, entries: sorted },
-    club: { ...state.club, form: clubForm, squad },
+    club: { ...state.club, form: clubForm, squad, manager: updatedManager },
     clubRecords,
     currentWinStreak,
     boardConfidence,

--- a/packages/domain/src/simulation/npc-messages.ts
+++ b/packages/domain/src/simulation/npc-messages.ts
@@ -11,6 +11,8 @@ import { GameEvent, MatchSimulatedEvent } from '../events/types';
 import { computeWeeklyFinancials } from './revenue';
 import { formatMoney } from '../money/utils';
 import { createRng } from './rng';
+import { MANAGER_MESSAGE_POOLS } from '../data/manager-message-templates';
+import { MANAGER_PERSONAS } from '../data/manager-archetypes';
 import {
   VAL_SUMMARY_SURPLUS,
   VAL_SUMMARY_GREEN,
@@ -53,7 +55,7 @@ import {
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
-export type NpcSender = 'VAL' | 'KEV' | 'MARCUS' | 'DANI';
+export type NpcSender = 'VAL' | 'KEV' | 'MARCUS' | 'DANI' | 'MANAGER';
 
 export type NpcMessageCategory =
   | 'WEEKLY_SUMMARY'
@@ -527,5 +529,97 @@ export function generateNpcMessages(
     });
   }
 
+  // ── Manager archetype messages ─────────────────────────────────────────
+  // The hired manager sends one message per week, in character.
+  // Post-match messages fire on match weeks; weekly check-ins on non-match weeks
+  // (throttled to every 3rd non-match week to avoid noise).
+  // Form messages overlay the post-match message when a 3+ run is active.
+
+  const manager = state.club.manager;
+  if (manager) {
+    const pools = MANAGER_MESSAGE_POOLS[manager.archetype];
+    const managerFill: Record<string, string> = {
+      ...fillVars,
+      MANAGER: manager.name,
+    };
+
+    if (thisWeekMatch) {
+      // Post-match message — win or loss
+      const isManagerHome = thisWeekMatch.homeTeamId === state.club.id;
+      const mgrPlayerG    = isManagerHome ? thisWeekMatch.homeGoals : thisWeekMatch.awayGoals;
+      const mgrOppG       = isManagerHome ? thisWeekMatch.awayGoals : thisWeekMatch.homeGoals;
+
+      const postMatchPool = mgrPlayerG > mgrOppG ? pools.postWin : pools.postLoss;
+      messages.push({
+        id: `MANAGER-POST_MATCH-w${week}-s${season}`,
+        sender: 'MANAGER',
+        text: fillPlaceholders(pick(postMatchPool, rng), managerFill),
+        week,
+        season,
+        category: 'POST_MATCH',
+      });
+
+      // Additionally: form overlay if 3+ run active
+      if (state.club.form.length >= 3) {
+        const last3 = state.club.form.slice(-3);
+        const win3  = last3.every(r => r === 'W');
+        const loss3 = last3.every(r => r === 'L');
+        if (win3) {
+          messages.push({
+            id: `MANAGER-FORM_UPDATE-w${week}-s${season}`,
+            sender: 'MANAGER',
+            text: fillPlaceholders(pick(pools.formGood, rng), managerFill),
+            week,
+            season,
+            category: 'FORM_UPDATE',
+          });
+        } else if (loss3) {
+          messages.push({
+            id: `MANAGER-FORM_UPDATE-w${week}-s${season}`,
+            sender: 'MANAGER',
+            text: fillPlaceholders(pick(pools.formPoor, rng), managerFill),
+            week,
+            season,
+            category: 'FORM_UPDATE',
+          });
+        }
+      }
+    } else if (week % 3 === 0) {
+      // Non-match week check-in (throttled)
+      messages.push({
+        id: `MANAGER-WEEKLY_SUMMARY-w${week}-s${season}`,
+        sender: 'MANAGER',
+        text: fillPlaceholders(pick(pools.weeklyCheckin, rng), managerFill),
+        week,
+        season,
+        category: 'WEEKLY_SUMMARY',
+      });
+    }
+  }
+
   return messages;
+}
+
+// ── Manager persona helper ─────────────────────────────────────────────────
+
+/**
+ * Returns the display config (avatar colour, label, etc.) for the given
+ * manager's archetype. Falls back to a neutral style if no manager.
+ */
+export function getManagerSenderConfig(manager: import('../types/staff').Manager | null): {
+  initial: string;
+  name: string;
+  avatarClass: string;
+  nameClass: string;
+} {
+  if (!manager) {
+    return { initial: 'M', name: 'Manager', avatarClass: 'bg-white/10 text-txt-muted', nameClass: 'text-txt-muted' };
+  }
+  const persona = MANAGER_PERSONAS[manager.archetype];
+  return {
+    initial:     manager.name.charAt(0),
+    name:        manager.name,
+    avatarClass: persona.avatarClass,
+    nameClass:   persona.nameClass,
+  };
 }

--- a/packages/domain/src/types/staff.ts
+++ b/packages/domain/src/types/staff.ts
@@ -2,6 +2,8 @@
  * Staff-related types
  */
 
+import { ManagerArchetype } from '../data/manager-archetypes';
+
 export type StaffRole =
   | 'MANAGER'
   | 'ATTACKING_COACH'
@@ -46,19 +48,32 @@ export interface Manager {
   contractLengthWeeks: number;
   /** Absolute week the contract expires (set on hire) */
   contractExpiresWeek: number;
+  /**
+   * Personality archetype — defines voice, inbox style, and the character
+   * of the owner–manager relationship.
+   */
+  archetype: ManagerArchetype;
+  /**
+   * Manager's confidence in their position (0–100).
+   * Rises with wins, falls with losses. Drives inbox message tone and
+   * will eventually unlock friction events at extremes.
+   *
+   * Default: 60 (settled, no strong opinion either way).
+   */
+  confidence: number;
 }
 
 export interface Staff {
   id: string;
   name: string;
   role: StaffRole;
-  
+
   /** Quality rating (0-100) */
   quality: number;
-  
+
   /** Weekly salary in pence */
   salary: number;
-  
+
   /** Specialization bonus */
   bonus: StaffBonus;
 }
@@ -66,7 +81,7 @@ export interface Staff {
 export interface StaffBonus {
   /** What stat this improves */
   type: 'goals' | 'defense' | 'fitness' | 'youth' | 'injury';
-  
+
   /** Percentage improvement (e.g., 10 = 10% improvement) */
   improvement: number;
 }

--- a/packages/frontend/src/components/command-centre/BackroomTeamSlideOver.tsx
+++ b/packages/frontend/src/components/command-centre/BackroomTeamSlideOver.tsx
@@ -1,4 +1,4 @@
-import { GameState, GameCommand, Staff, StaffRole, Manager } from '@calculating-glory/domain';
+import { GameState, GameCommand, Staff, StaffRole, Manager, MANAGER_PERSONAS } from '@calculating-glory/domain';
 import { formatMoney } from '@calculating-glory/domain';
 
 // ── Role display config ───────────────────────────────────────────────────────
@@ -155,21 +155,62 @@ function ManagerRow({ manager }: { manager: Manager | null }) {
   }
 
   const { tactical, motivation, experience } = manager.attributes;
+  const persona = MANAGER_PERSONAS[manager.archetype];
+
+  // Confidence thresholds
+  const confidenceLabel =
+    manager.confidence >= 75 ? { text: 'Confident', colour: 'text-pitch-green' } :
+    manager.confidence >= 45 ? { text: 'Settled',   colour: 'text-txt-muted'  } :
+    manager.confidence >= 20 ? { text: 'Unsettled', colour: 'text-warn-amber' } :
+                               { text: 'Under pressure', colour: 'text-alert-red' };
+
   return (
-    <div className="flex items-center gap-3 py-3">
+    <div className="py-3 flex gap-3">
       <span className="text-2xl w-8 text-center shrink-0">🧑‍💼</span>
       <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-semibold text-txt-primary">Manager</span>
+        {/* Name + hired badge */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-sm font-semibold text-txt-primary">{manager.name}</span>
           <span className="badge bg-pitch-green/15 text-pitch-green text-xs2">Hired</span>
         </div>
-        <span className="text-xs2 text-txt-muted font-mono">{manager.name}</span>
-        <div className="flex items-center gap-3 mt-1 text-xs2 text-txt-muted">
+
+        {/* Archetype pill */}
+        <div className="mt-1">
+          <span className={`text-xs font-medium px-1.5 py-0.5 rounded-sm ${persona.avatarClass}`}>
+            {persona.label}
+          </span>
+        </div>
+
+        {/* Stats */}
+        <div className="flex items-center gap-3 mt-1.5 text-xs2 text-txt-muted flex-wrap">
           <span>⚔️ Tactical {tactical}</span>
           <span>📣 Motivation {motivation}</span>
           <span>📋 Experience {experience}</span>
         </div>
+
+        {/* Confidence bar */}
+        <div className="mt-2">
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-xs2 text-txt-muted">Manager confidence</span>
+            <span className={`text-xs2 font-medium ${confidenceLabel.colour}`}>
+              {confidenceLabel.text}
+            </span>
+          </div>
+          <div className="h-1 bg-bg-raised rounded-full overflow-hidden">
+            <div
+              className={`h-full rounded-full transition-all ${
+                manager.confidence >= 75 ? 'bg-pitch-green' :
+                manager.confidence >= 45 ? 'bg-warn-amber/60' :
+                manager.confidence >= 20 ? 'bg-warn-amber' :
+                'bg-alert-red'
+              }`}
+              style={{ width: `${manager.confidence}%` }}
+            />
+          </div>
+        </div>
       </div>
+
+      {/* Wage + experience stars */}
       <div className="flex flex-col items-end gap-1 shrink-0">
         <span className="text-xs2 font-mono text-txt-muted">
           {formatMoney(manager.wage)}<span className="text-txt-muted/50">/wk</span>

--- a/packages/frontend/src/components/command-centre/InboxCard.tsx
+++ b/packages/frontend/src/components/command-centre/InboxCard.tsx
@@ -1,4 +1,13 @@
-import { GameEvent, GameCommand, PendingClubEvent, LeagueTableEntry, NpcMessage, NpcSender } from '@calculating-glory/domain';
+import {
+  GameEvent,
+  GameCommand,
+  PendingClubEvent,
+  LeagueTableEntry,
+  NpcMessage,
+  NpcSender,
+  Manager,
+  MANAGER_PERSONAS,
+} from '@calculating-glory/domain';
 import { PendingEventCard } from './PendingEventCard';
 import {
   buildNotableMatches,
@@ -9,12 +18,33 @@ import {
 
 // ── NPC sender display config ─────────────────────────────────────────────────
 
-const NPC_CONFIG: Record<NpcSender, { initial: string; name: string; avatarClass: string; nameClass: string }> = {
+type StaticNpcSender = Exclude<NpcSender, 'MANAGER'>;
+
+const NPC_CONFIG: Record<StaticNpcSender, { initial: string; name: string; avatarClass: string; nameClass: string }> = {
   VAL:    { initial: 'V', name: 'Val Chen',       avatarClass: 'bg-warn-amber/20 text-warn-amber',   nameClass: 'text-warn-amber'   },
   KEV:    { initial: 'K', name: 'Kev Mulligan',   avatarClass: 'bg-data-blue/20 text-data-blue',     nameClass: 'text-data-blue'    },
   MARCUS: { initial: 'M', name: 'Marcus Webb',    avatarClass: 'bg-pitch-green/20 text-pitch-green', nameClass: 'text-pitch-green'  },
   DANI:   { initial: 'D', name: 'Dani Osei',      avatarClass: 'bg-alert-red/20 text-alert-red',     nameClass: 'text-alert-red'    },
 };
+
+function getSenderConfig(
+  sender: NpcSender,
+  manager?: Manager | null
+): { initial: string; name: string; avatarClass: string; nameClass: string } {
+  if (sender === 'MANAGER') {
+    if (!manager) {
+      return { initial: 'M', name: 'Manager', avatarClass: 'bg-white/10 text-txt-muted', nameClass: 'text-txt-muted' };
+    }
+    const persona = MANAGER_PERSONAS[manager.archetype];
+    return {
+      initial:     manager.name.charAt(0),
+      name:        manager.name,
+      avatarClass: persona.avatarClass,
+      nameClass:   persona.nameClass,
+    };
+  }
+  return NPC_CONFIG[sender as StaticNpcSender];
+}
 
 interface InboxCardProps {
   pendingEvents: PendingClubEvent[];
@@ -31,6 +61,8 @@ interface InboxCardProps {
   onMathChallenge: (event: PendingClubEvent) => void;
   onViewAll: () => void;
   npcMessages?: NpcMessage[];
+  /** Current hired manager — used to resolve MANAGER sender display config */
+  manager?: Manager | null;
 }
 
 const PREVIEW_LIMIT = 4;
@@ -50,6 +82,7 @@ export function InboxCard({
   onMathChallenge,
   onViewAll,
   npcMessages = [],
+  manager,
 }: InboxCardProps) {
   const unresolvedDecisions = pendingEvents.filter(e => !e.resolved);
 
@@ -187,7 +220,7 @@ export function InboxCard({
               From the Team
             </p>
             {npcMessages.map((msg) => {
-              const cfg = NPC_CONFIG[msg.sender];
+              const cfg = getSenderConfig(msg.sender, manager);
               return (
                 <div
                   key={msg.id}

--- a/packages/frontend/src/components/command-centre/sections/OverviewSection.tsx
+++ b/packages/frontend/src/components/command-centre/sections/OverviewSection.tsx
@@ -82,6 +82,7 @@ export function OverviewSection({
           onMathChallenge={onMathChallenge}
           onViewAll={() => onSectionChange('inbox')}
           npcMessages={npcMessages}
+          manager={state.club.manager}
         />
         {dim('inbox')}
       </div>

--- a/packages/frontend/src/components/owner-office/OwnerOffice.tsx
+++ b/packages/frontend/src/components/owner-office/OwnerOffice.tsx
@@ -9,6 +9,8 @@ import {
   formatMoney,
   isTransferWindowOpen,
   NpcMessage,
+  NpcSender,
+  MANAGER_PERSONAS,
 } from '@calculating-glory/domain';
 import { NewsTicker } from '../command-centre/NewsTicker';
 import { SlideOver } from '../shared/SlideOver';
@@ -414,7 +416,9 @@ interface InboxFeedProps {
   npcMessages: NpcMessage[];
 }
 
-const NPC_MSG_CONFIG = {
+type StaticNpcSender = Exclude<NpcSender, 'MANAGER'>;
+
+const NPC_MSG_CONFIG: Record<StaticNpcSender, { initial: string; avatarClass: string; nameClass: string; name: string }> = {
   VAL:    { initial: 'V', avatarClass: 'bg-warn-amber/20 text-warn-amber',   nameClass: 'text-warn-amber',   name: 'Val Okoro'    },
   KEV:    { initial: 'K', avatarClass: 'bg-data-blue/20 text-data-blue',     nameClass: 'text-data-blue',    name: 'Kev Mulligan' },
   MARCUS: { initial: 'M', avatarClass: 'bg-pitch-green/20 text-pitch-green', nameClass: 'text-pitch-green',  name: 'Marcus Webb'  },
@@ -463,7 +467,14 @@ function InboxFeed({
           )}
           <p className="text-xs2 text-txt-muted uppercase tracking-wider">From the Team</p>
           {npcMessages.map(msg => {
-            const cfg = NPC_MSG_CONFIG[msg.sender];
+            const cfg = msg.sender === 'MANAGER' && state.club.manager
+              ? {
+                  initial:     state.club.manager.name.charAt(0),
+                  avatarClass: MANAGER_PERSONAS[state.club.manager.archetype].avatarClass,
+                  nameClass:   MANAGER_PERSONAS[state.club.manager.archetype].nameClass,
+                  name:        state.club.manager.name,
+                }
+              : NPC_MSG_CONFIG[msg.sender as StaticNpcSender];
             const isDismissed = typeof msg.id === 'number' ? dismissed.has(msg.id) : false;
             if (isDismissed) return null;
             return (

--- a/packages/frontend/src/components/pre-season/ManagerPicker.tsx
+++ b/packages/frontend/src/components/pre-season/ManagerPicker.tsx
@@ -1,4 +1,4 @@
-import { Manager, formatMoney } from '@calculating-glory/domain';
+import { Manager, formatMoney, MANAGER_PERSONAS } from '@calculating-glory/domain';
 
 interface ManagerPickerProps {
   managers: Manager[];
@@ -55,6 +55,8 @@ function ManagerCard({
     avgRating >= 50 ? { label: 'Experienced', colour: 'text-warn-amber' } :
     { label: 'Journeyman', colour: 'text-txt-muted' };
 
+  const persona = MANAGER_PERSONAS[manager.archetype];
+
   return (
     <button
       onClick={affordable ? onSelect : undefined}
@@ -68,13 +70,25 @@ function ManagerCard({
             : 'border-white/5 bg-bg-surface opacity-50 cursor-not-allowed',
       ].join(' ')}
     >
-      <div className="flex items-start justify-between gap-3 mb-3">
-        <div>
-          <div className="flex items-center gap-2">
+      <div className="flex items-start justify-between gap-3 mb-2">
+        <div className="flex-1 min-w-0">
+          {/* Name + tier */}
+          <div className="flex items-center gap-2 flex-wrap">
             <span className="text-sm font-semibold text-txt-primary">{manager.name}</span>
             <span className={`text-xs ${tier.colour}`}>{tier.label}</span>
           </div>
-          <div className="text-xs text-txt-muted mt-0.5">
+          {/* Archetype pill */}
+          <div className="flex items-center gap-2 mt-1">
+            <span className={`text-xs font-medium px-1.5 py-0.5 rounded-sm ${persona.avatarClass}`}>
+              {persona.label}
+            </span>
+          </div>
+          {/* Persona description */}
+          <p className="text-xs2 text-txt-muted mt-1 leading-relaxed italic">
+            {persona.shortDesc}
+          </p>
+          {/* Wage + contract */}
+          <div className="text-xs text-txt-muted mt-1.5">
             {formatMoney(manager.wage)}/wk
             <span className="mx-1.5 text-white/20">·</span>
             {manager.contractLengthWeeks / 52} season contract
@@ -96,7 +110,7 @@ function ManagerCard({
         )}
       </div>
 
-      <div className="space-y-1.5">
+      <div className="space-y-1.5 mt-3">
         <StatBar value={manager.attributes.tactical} label="Tactical" />
         <StatBar value={manager.attributes.motivation} label="Motivation" />
         <StatBar value={manager.attributes.experience} label="Experience" />


### PR DESCRIPTION
## Summary

- **5 manager archetypes** — The Philosopher, The Sergeant, The Developer, The Pragmatist, The Showman — each with a distinct voice, colour identity, and one-line description
- **Inbox messages in character** — managers send post-match reactions and weekly check-ins drawn from archetype-specific message pools (25 pools × ~5 messages each)
- **Confidence arc** — a 0–100 confidence rating rises on wins (+5), ticks on draws (+1), and falls on losses (−6); displayed as a bar in the Backroom Team slide-over with threshold labels (Confident / Settled / Unsettled / Under pressure)
- **ManagerPicker updated** — archetype pill + persona description now shown on each card, making hiring feel like a character decision rather than a stat comparison

## Domain changes
- `manager-archetypes.ts` — archetype enum, persona config, tier pools
- `manager-message-templates.ts` — message pools per archetype × situation
- `staff.ts` — `archetype: ManagerArchetype` + `confidence: number` added to `Manager`
- `manager-generator.ts` — assigns archetype from tier pool + initialises confidence at 60
- `npc-messages.ts` — `MANAGER` added to `NpcSender`; manager message generation + `getManagerSenderConfig` helper
- `reducers/index.ts` — confidence updated on `MATCH_SIMULATED`

## Test plan
- [ ] Pre-season manager picker shows archetype pill and description on each card
- [ ] Hiring a manager → their messages appear in inbox each week in character
- [ ] Win streak → Showman/Sergeant messages noticeably different in tone
- [ ] Backroom Team slide-over shows archetype label + confidence bar
- [ ] Confidence bar colour shifts correctly across thresholds
- [ ] No manager → inbox renders cleanly with no MANAGER messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)