### PR TITLE
fix: Kev commentary keyed to actual score context (#132)

### DIFF
--- a/packages/domain/src/data/commentary-templates.ts
+++ b/packages/domain/src/data/commentary-templates.ts
@@ -10,6 +10,17 @@
  *   [KEEPER]   — goalkeeper's name
  *   [OPPONENT] — opposing team name
  *   [SCORE]    — current scoreline e.g. "2-1"
+ *
+ * Goal reaction pools are score-context aware:
+ *   goal_player_opener     — first goal of the game (0-0 → 1-0)
+ *   goal_player_equaliser  — scoring to draw level (behind → level)
+ *   goal_player_go_ahead   — scoring to take the lead (level → ahead)
+ *   goal_player_reaction   — any other goal (adding to a lead)
+ *   goal_player_aftermath  — the beat after any player goal
+ *
+ * Near-miss pools are split by match state:
+ *   near_miss_opponent          — opponent nearly scores; we're under pressure or close
+ *   near_miss_comfortable       — opponent nearly scores; we're comfortable (2+ goal lead)
  */
 
 export const KEV_TEMPLATES = {
@@ -89,7 +100,7 @@ export const KEV_TEMPLATES = {
     "Chance wasted. Should've done better.",
     "Gets a shot away, just over the bar!",
     "Brilliant save! [SCORER] looked certain to score.",
-    "NEARLY! Inches away from the opener.",
+    "NEARLY! Agonisingly close to that.",
     "[SCORER] drives at goal, blocked on the line!",
     "What a chance! Gets there a fraction too late.",
   ],
@@ -107,6 +118,20 @@ export const KEV_TEMPLATES = {
     "[KEEPER] coming up big for us. Massive.",
   ],
 
+  /** Opponent near-miss when we're winning comfortably (2+ goal lead) — lower stakes reaction */
+  near_miss_comfortable: [
+    "Chance for them. [KEEPER] has it covered.",
+    "They had a go. Comfortable enough.",
+    "Good save but we're in control here.",
+    "They're not going away. Keep the shape.",
+    "Keeper's alert. Nothing to panic about.",
+    "Half chance. Nothing doing.",
+    "Managed well. Keep it tight.",
+    "They're trying. We're coping fine.",
+  ],
+
+  // ── Goal build-up — generic, fires before all player goals ─────────────
+
   goal_player_buildup: [
     "[SCORER] picks it up on the edge... drives inside...",
     "Good move, good move... [SCORER] through on goal...",
@@ -120,6 +145,51 @@ export const KEV_TEMPLATES = {
     "Cutback! [SCORER] unmarked six yards out...",
   ],
 
+  // ── Goal reactions — score-context aware ────────────────────────────────
+
+  /** First goal of the match — opening the scoring from 0-0 */
+  goal_player_opener: [
+    "OPENER! [SCORER]! GET IN!",
+    "GOAL! [SCORER]! WE'VE BROKEN THE DEADLOCK!",
+    "YES! [SCORER]! FIRST BLOOD! COME ON!",
+    "IT'S IN! [SCORER]! THE OPENER! BEAUTIFUL!",
+    "SCORES! [SCORER]! THAT'S WHAT WE NEEDED!",
+    "GOAL! [SCORER]! IN FRONT FIRST! GET IN!",
+    "YES YES YES! [SCORER]! THAT CHANGES EVERYTHING!",
+    "[SCORER]!!! THE OPENER!!! COME ON!!!",
+    "FIRST GOAL OF THE GAME! [SCORER]! YES!",
+    "IN! [SCORER]! WE'VE DONE IT! COME ON [TEAM]!",
+  ],
+
+  /** Scoring to draw level — from behind to level */
+  goal_player_equaliser: [
+    "EQUALISER! [SCORER]! WE'RE BACK LEVEL!",
+    "YES! [SCORER]! RIGHT BACK IN THIS!",
+    "WE'VE LEVELLED IT! [SCORER]! COME ON!",
+    "GOAL! [SCORER]! GAME ON!",
+    "[SCORER]!!! WE'RE LEVEL!!! DON'T STOP!!!",
+    "THAT'S MORE LIKE IT! [SCORER]! BACK IN THE GAME!",
+    "YES! LEVEL! [SCORER]! COME ON LADS!",
+    "WE'VE PULLED ONE BACK! [SCORER]! BRILLIANT!",
+    "BACK LEVEL! [SCORER]! THE FIGHT IS IN THIS SIDE!",
+    "GOAL! [SCORER]! ALL SQUARE! THIS ISN'T OVER!",
+  ],
+
+  /** Scoring to take the lead from level — 0-0→1-0, 1-1→2-1 etc. */
+  goal_player_go_ahead: [
+    "[SCORER]! WE'RE IN FRONT! GET IN!",
+    "THE GO-AHEAD GOAL! [SCORER]! YES!",
+    "GOAL! [SCORER]! WE'VE TAKEN THE LEAD!",
+    "IN FRONT! [SCORER]! THAT'S THE ONE WE NEEDED!",
+    "[SCORER]!!! LEADS!!! GET IN!!!",
+    "GOAL! [SCORER]! AHEAD FOR THE FIRST TIME! BRILLIANT!",
+    "YES! [SCORER]! IN FRONT! HOLD ON TO THIS!",
+    "WE'VE GOT THE LEAD! [SCORER]! ABSOLUTELY CLASS!",
+    "THAT'S IT! [SCORER]! AHEAD! COME ON [TEAM]!",
+    "GOAL! [SCORER]! WE'VE NICKED THE LEAD!",
+  ],
+
+  /** All other player goals — already ahead, adding to the lead */
   goal_player_reaction: [
     "SCORES! [SCORER]! GET IN!",
     "GOAL! [SCORER]! WHAT A STRIKE!",
@@ -131,8 +201,8 @@ export const KEV_TEMPLATES = {
     "[SCORER]!!! TAKE A BOW!!! GET IN!!!",
     "IN OFF THE POST! [SCORER]! DOESN'T MATTER HOW!",
     "HEADER! [SCORER]! BRILLIANT! ABSOLUTELY BRILLIANT!",
-    "GOAL! [SCORER]! [TEAM] ARE IN FRONT!",
-    "YES! [SCORER]! THAT'S WHAT [TEAM] ARE ABOUT!",
+    "GOAL! [SCORER]! ANOTHER ONE! COME ON!",
+    "YES! [SCORER]! THAT'S [TEAM] AT THEIR BEST!",
   ],
 
   goal_player_aftermath: [

--- a/packages/domain/src/simulation/commentary.ts
+++ b/packages/domain/src/simulation/commentary.ts
@@ -214,6 +214,9 @@ export function generateMatchTimeline(ctx: MatchCommentaryContext): MatchTimelin
   let runningOpponent = 0;
 
   for (const event of allGoalEvents) {
+    // Capture lead BEFORE this goal to determine reaction context
+    const leadBeforeGoal = runningPlayer - runningOpponent;
+
     if (event.isPlayer) runningPlayer++;
     else                runningOpponent++;
 
@@ -223,14 +226,34 @@ export function generateMatchTimeline(ctx: MatchCommentaryContext): MatchTimelin
     if (event.isPlayer) {
       const scorer = randomPlayerName();
 
+      // Pick reaction pool based on score context:
+      //   opener      — from 0-0 to 1-0 (first goal of match)
+      //   equaliser   — was trailing, now level
+      //   go_ahead    — was level (non-zero), now leading
+      //   reaction    — already leading, adding another goal
+      let reactionPool: readonly string[];
+      if (leadBeforeGoal === 0 && runningOpponent === 0) {
+        // No goals at all yet — this is the opener
+        reactionPool = KEV_TEMPLATES.goal_player_opener;
+      } else if (leadBeforeGoal < 0 && runningPlayer === runningOpponent) {
+        // Was behind, now level — equaliser
+        reactionPool = KEV_TEMPLATES.goal_player_equaliser;
+      } else if (leadBeforeGoal <= 0 && runningPlayer > runningOpponent) {
+        // Was level or behind, now ahead — go-ahead goal
+        reactionPool = KEV_TEMPLATES.goal_player_go_ahead;
+      } else {
+        // Already leading, extending the advantage
+        reactionPool = KEV_TEMPLATES.goal_player_reaction;
+      }
+
       // GOAL beat: buildup line + reaction line (UI displays with brief gap between)
       beats.push({
         matchMinute: event.minute,
         realTimeOffset: 0,
         type: 'GOAL',
         content: [
-          { sender: 'KEV', text: fill(pick(KEV_TEMPLATES.goal_player_buildup),  scorer), mood: 'excited' },
-          { sender: 'KEV', text: fill(pick(KEV_TEMPLATES.goal_player_reaction), scorer), mood: 'elated'  },
+          { sender: 'KEV', text: fill(pick(KEV_TEMPLATES.goal_player_buildup), scorer), mood: 'excited' },
+          { sender: 'KEV', text: fill(pick(reactionPool),                       scorer), mood: 'elated'  },
         ],
         crowdState: 'ROAR',
         scoreboardUpdate: { home: homeScore, away: awayScore },
@@ -288,18 +311,27 @@ export function generateMatchTimeline(ctx: MatchCommentaryContext): MatchTimelin
   }
 
   // NEAR_MISS beats (0–1 per half, 60% chance) ──────────────────────────────
+  // Pool and mood scale with how comfortable our lead is at that moment:
+  //   2+ goal lead → near_miss_comfortable (relaxed, no panic)
+  //   anything else → near_miss_opponent (worried, crowd groans)
   for (let half = 0; half < 2; half++) {
     if (rng.next() < 0.6) {
       const [lo, hi] = half === 0 ? [10, 42] : [50, 86];
       const m = pickMinute(lo, hi, reserved);
       if (m !== null) {
         reserved.add(m);
+        const leadAtMoment = playerLeadAtMinute(m);
+        const isComfortable = leadAtMoment >= 2;
         beats.push({
           matchMinute: m,
           realTimeOffset: 0,
           type: 'NEAR_MISS',
-          content: [{ sender: 'KEV', text: fill(pick(KEV_TEMPLATES.near_miss_opponent)), mood: 'worried' }],
-          crowdState: 'GROAN',
+          content: [{
+            sender: 'KEV',
+            text:  fill(pick(isComfortable ? KEV_TEMPLATES.near_miss_comfortable : KEV_TEMPLATES.near_miss_opponent)),
+            mood:  isComfortable ? 'neutral' : 'worried',
+          }],
+          crowdState: isComfortable ? 'MURMUR' : 'GROAN',
         });
       }
     }


### PR DESCRIPTION
## What was wrong

All player goals triggered the same reaction pool regardless of context — so "[TEAM] ARE IN FRONT!" would fire on a 3rd goal when already winning 2-0, or on an equaliser. Near-miss beats used the same panicked tone whether winning 4-0 or clinging to a 1-goal lead. The `chance_player` pool contained "Inches away from the opener" which would fire mid-match even if goals had already been scored.

## What's fixed

**Score-context goal reactions** — four separate pools now:
- `goal_player_opener` — 0-0 → 1-0 ("WE'VE BROKEN THE DEADLOCK!")
- `goal_player_equaliser` — from behind to level ("WE'RE BACK LEVEL!")
- `goal_player_go_ahead` — level to leading ("THE GO-AHEAD GOAL!")
- `goal_player_reaction` — extending an existing lead (generic celebration)

Selection logic in `commentary.ts` checks lead before/after each goal and routes to the appropriate pool.

**Score-context near-miss reactions** — `near_miss_comfortable` pool (8 lines) used when lead ≥ 2. Crowd state shifts from `GROAN` to `MURMUR`, mood shifts from `worried` to `neutral`. Kev stops panicking when comfortably ahead.

**Template cleanup:**
- Removed "NEARLY! Inches away from the opener." (replaced with "NEARLY! Agonisingly close to that.")
- Replaced "[TEAM] ARE IN FRONT!" with "GOAL! [SCORER]! ANOTHER ONE! COME ON!" in the extension pool

## Test plan
- [ ] Score first goal → Kev says opener-specific line ("WE'VE BROKEN THE DEADLOCK" etc.)
- [ ] Score from 0-1 down to 1-1 → Kev says equaliser line ("WE'RE BACK LEVEL!")
- [ ] Score from 1-1 to 2-1 → Kev says go-ahead line ("THE GO-AHEAD GOAL!")
- [ ] Score 3rd goal when 2-0 up → Kev says generic extension line
- [ ] Winning 3-0 and near-miss fires → Kev relaxed, not panicked
- [ ] Losing 0-1 and near-miss fires → Kev still worried

🤖 Generated with [Claude Code](https://claude.com/claude-code)