### PR TITLE
feat: paid transfer market — NPC listed players + free agent bimodal rebalance (#138)

### DIFF
--- a/packages/domain/src/commands/handlers.ts
+++ b/packages/domain/src/commands/handlers.ts
@@ -84,6 +84,8 @@ export function handleCommand(command: GameCommand, state: GameState): CommandRe
       return handleListPlayerForSale(command, state);
     case 'UNLIST_PLAYER':
       return handleUnlistPlayer(command, state);
+    case 'BUY_TRANSFER_LISTED_PLAYER':
+      return handleBuyTransferListedPlayer(command, state);
     default:
       return {
         error: {
@@ -1208,6 +1210,61 @@ function handleUnlistPlayer(command: any, state: GameState): CommandResult {
       timestamp: Date.now(),
       playerId: player.id,
       clubId: state.club.id,
+    }],
+  };
+}
+
+function handleBuyTransferListedPlayer(command: any, state: GameState): CommandResult {
+  // Must be inside a transfer window
+  if (!isTransferWindowOpen(state.currentWeek, state.phase)) {
+    return { error: { code: 'WINDOW_CLOSED', message: 'The transfer window is not open.' } };
+  }
+
+  // Find the player in the transfer listed pool
+  const listed = state.transferListedPool?.find(p => p.id === command.playerId);
+  if (!listed) {
+    return { error: { code: 'PLAYER_NOT_FOUND', message: `Player '${command.playerId}' not found in transfer market.` } };
+  }
+
+  // Check squad capacity
+  if (state.club.squad.length >= state.club.squadCapacity) {
+    return { error: { code: 'SQUAD_LIMIT_EXCEEDED', message: `Squad is at capacity (${state.club.squadCapacity} players).` } };
+  }
+
+  // Check transfer budget covers the asking price
+  if (state.club.transferBudget < listed.askingPrice) {
+    return { error: { code: 'INSUFFICIENT_BUDGET', message: `Transfer budget too low. Need ${listed.askingPrice} pence, have ${state.club.transferBudget}.` } };
+  }
+
+  // Check wage runway — new player's wages must leave ≥ 8 weeks runway
+  const currentTotalWages = state.club.squad.reduce((sum, p) => sum + p.wage, 0);
+  const newTotalWages = currentTotalWages + listed.wage;
+  const runwayAfter = newTotalWages > 0 ? state.club.wageReserve / newTotalWages : Infinity;
+  if (runwayAfter < 8) {
+    return {
+      error: {
+        code: 'INSUFFICIENT_BUDGET',
+        message: `Wage reserve too low — would leave only ${Math.floor(runwayAfter)} weeks of wages.`,
+      },
+    };
+  }
+
+  // Strip TransferListedPlayer-specific fields to get a plain Player
+  const { sellingClubId, sellingClubName, askingPrice, ...playerBase } = listed;
+  const player: Player = {
+    ...playerBase,
+    contractExpiresWeek: state.currentWeek + 46,
+    morale: Math.min(100, listed.morale + 5), // slight morale boost from move
+  };
+
+  return {
+    events: [{
+      type: 'TRANSFER_LISTED_PLAYER_BOUGHT',
+      timestamp: Date.now(),
+      playerId: listed.id,
+      sellingClubId,
+      fee: askingPrice,
+      player,
     }],
   };
 }

--- a/packages/domain/src/commands/types.ts
+++ b/packages/domain/src/commands/types.ts
@@ -35,7 +35,8 @@ export type GameCommand =
   | UpgradeCurriculumCommand
   | SetBudgetAllocationCommand
   | ListPlayerForSaleCommand
-  | UnlistPlayerCommand;
+  | UnlistPlayerCommand
+  | BuyTransferListedPlayerCommand;
 
 export interface MakeTransferCommand {
   type: 'MAKE_TRANSFER';
@@ -185,6 +186,14 @@ export interface ListPlayerForSaleCommand {
 export interface UnlistPlayerCommand {
   type: 'UNLIST_PLAYER';
   playerId: string;
+}
+
+export interface BuyTransferListedPlayerCommand {
+  type: 'BUY_TRANSFER_LISTED_PLAYER';
+  /** ID of the player in transferListedPool */
+  playerId: string;
+  /** The player's own club ID (for validation) */
+  clubId: string;
 }
 
 export interface CommandResult {

--- a/packages/domain/src/data/free-agent-generator.ts
+++ b/packages/domain/src/data/free-agent-generator.ts
@@ -154,6 +154,19 @@ function generateAttributes(position: Position, rng: Rng, qualityBoost = 0): Pla
  * Generate the free agent pool (60 players) from a seed.
  * Deterministic — same seed always produces the same pool.
  *
+ * The pool is bimodal by design:
+ *
+ *   Bargain bin (40 players) — age 28–36, OVR ~25–50.
+ *   Released castoffs, over-the-hill journeymen, youth that never made it.
+ *   Low wages because nobody else wants them.
+ *
+ *   Expensive gamble (20 players) — age 23–30, OVR ~52–72.
+ *   Decent players demanding a freedom premium for their time without a club.
+ *   Good enough to strengthen the squad; expensive enough to be a budget risk.
+ *
+ * This creates a real decision: pay the premium for quality, or save wages
+ * and accept the risk of a bargain-bin signing.
+ *
  * @param division  Current division — scales attribute quality upward for higher tiers.
  *                  Defaults to LEAGUE_TWO (original baseline).
  */
@@ -161,50 +174,54 @@ export function generateFreeAgentPool(seed: string, division: Division = 'LEAGUE
   const qualityBoost = DIVISION_QUALITY_BOOST[division];
   const rng = createRng(`${seed}-free-agents`);
 
-  // Build full name list: parody names first, then journeymen
-  // Shuffle both lists separately using rng for variety
   const allNames = [...PARODY_NAMES, ...JOURNEYMEN_NAMES];
-
-  // Shuffle the name list deterministically
   const shuffledNames = [...allNames];
   for (let i = shuffledNames.length - 1; i > 0; i--) {
     const j = Math.floor(rng.next() * (i + 1));
     [shuffledNames[i], shuffledNames[j]] = [shuffledNames[j], shuffledNames[i]];
   }
 
-  // Shuffle position distribution
   const positions = [...POSITION_DISTRIBUTION];
   for (let i = positions.length - 1; i > 0; i--) {
     const j = Math.floor(rng.next() * (i + 1));
     [positions[i], positions[j]] = [positions[j], positions[i]];
   }
 
+  // Wage bands per division tier index (0=L2, 1=L1, 2=Champ, 3=PL)
+  const tierIdx = DIVISION_QUALITY_BOOST[division] / 10;
+  // Bargain bin wages — low, reflects unwantedness
+  const bargainWageFloor = [20_000,  40_000,  80_000, 200_000][tierIdx] ?? 20_000;
+  const bargainWageCeil  = [80_000, 160_000, 320_000, 800_000][tierIdx] ?? 80_000;
+  // Expensive gamble wages — premium for freedom
+  const premiumWageFloor = [180_000, 360_000, 700_000, 1_500_000][tierIdx] ?? 180_000;
+  const premiumWageCeil  = [450_000, 900_000, 1_800_000, 4_500_000][tierIdx] ?? 450_000;
+
   return positions.map((position, index) => {
+    const playerId = `free-agent-${index}-${seed}`;
     const name = shuffledNames[index] ?? `Free Agent ${index + 1}`;
 
-    // Age: 18–34
-    const age = rng.nextInt(18, 34);
+    // First 40 = bargain bin; last 20 = expensive gamble
+    const isBargain = index < 40;
 
-    // Wages scale with division: L2 £500–£3k, L1 £1k–£5k, Champ £2k–£10k, PL £5k–£25k (pence)
-    const wageFloor = [50_000, 100_000, 200_000, 500_000][DIVISION_QUALITY_BOOST[division] / 10] ?? 50_000;
-    const wageCeil  = [300_000, 500_000, 1_000_000, 2_500_000][DIVISION_QUALITY_BOOST[division] / 10] ?? 300_000;
-    const wage = rng.nextInt(wageFloor, wageCeil);
+    const age = isBargain
+      ? rng.nextInt(28, 36)   // older / declining
+      : rng.nextInt(23, 30);  // prime / pre-peak
 
-    // Attributes based on position, scaled up for higher divisions
-    const attributes = generateAttributes(position, rng, qualityBoost);
+    // Quality boost for bargain bin is reduced (these are poor players)
+    const bargainQualityPenalty = isBargain ? -10 : 10;
+    const attributes = generateAttributes(position, rng, qualityBoost + bargainQualityPenalty);
 
-    // Career curve — determines growth/decline arc and retirement age
+    const wage = isBargain
+      ? rng.nextInt(bargainWageFloor, bargainWageCeil)
+      : rng.nextInt(premiumWageFloor, premiumWageCeil);
+
     const curve = generatePlayerCurve(rng, age, attributes.attack, attributes.defence, position);
-
-    // truePotential: career-arc position indicator derived from the curve
     const truePotential = computeTruePotential(curve, age);
-
-    // publicPotential: noisy level-0 read of truePotential (±15 noise at L0 scout)
-    const playerId = `free-agent-${index}-${seed}`;
     attributes.publicPotential = getScoutedPotential({ id: playerId, truePotential } as Player, 0);
 
-    // Morale: 65–85 (they're keen to get a club)
-    const morale = rng.nextInt(65, 85);
+    // Bargain bin morale: 55–75 (frustrated, not despairing)
+    // Expensive gamble morale: 70–88 (confident, knows their worth)
+    const morale = isBargain ? rng.nextInt(55, 75) : rng.nextInt(70, 88);
 
     return {
       id: playerId,

--- a/packages/domain/src/data/transfer-listed-generator.ts
+++ b/packages/domain/src/data/transfer-listed-generator.ts
@@ -1,0 +1,230 @@
+/**
+ * Transfer Listed Pool Generator
+ *
+ * Generates a pool of players listed for sale by NPC clubs.
+ * Each NPC contributes 1–3 players scaled to their evolved strength.
+ *
+ * These players are generally better quality than average free agents —
+ * they're contracted professionals, not castoffs. Their wages are lower
+ * than the "expensive gamble" free agent tier because they're not
+ * demanding a freedom premium.
+ *
+ * Asking price = transferValue × 1.3–1.6 (clubs don't sell at cost).
+ */
+
+import { TransferListedPlayer, Position, PlayerAttributes } from '../types/player';
+import { Division } from '../types/game-state-updated';
+import { createRng, Rng } from '../simulation/rng';
+import { generatePlayerCurve, computeTruePotential } from '../simulation/progression';
+import { getScoutedPotential } from '../types/facility';
+
+// ── Name pool ─────────────────────────────────────────────────────────────────
+// Distinct from free-agent journeymen — these are contracted squad players.
+
+const TRANSFER_NAMES: string[] = [
+  'Tom Calloway',    'Danny Hirst',      'Rob Alcott',      'Jamie Neville',
+  'Lee Bramley',     'Carl Whitmore',    'Andy Dunbar',     'Phil Cassidy',
+  'Ryan Lockwood',   'Dave Partridge',   'Shane Cotter',    'Gary Mellor',
+  'Niall Brennan',   'Sean Tully',       'Pete Ashton',     'Craig Hadley',
+  'Mark Etheridge',  'Neil Forsythe',    'Barry Stubbs',    'Dion Cartwright',
+  'Josh Penney',     'Liam Norcross',    'Chris Owers',     'Paul Dempsey',
+  'Will Hartigan',   'Owen Farris',      'Gus Holden',      'Fred Whitaker',
+  'Adrian Kral',     'Tomaz Blaha',      'Sergio Morales',  'Emilio Rivas',
+  'Lukasz Wojcik',   'Piotr Sobczak',    'Ivan Petrov',     'Georgi Toshev',
+  'Jean-Luc Morel',  'Pierre Renaud',    'Tobias Frick',    'Lars Wenzel',
+  'Kosta Nikolaou',  'Nikos Papadakis',  'Andres Vidal',    'Carlos Prieto',
+  'Enzo Marchetti',  'Lorenzo Pinto',    'Kweku Asante',    'Tobi Ogundimu',
+  'Yusuf Karimi',    'Hassan Almutairi', 'Taishi Kato',     'Ryo Hayashi',
+  'Marcus Ewolo',    'Edouard Ngom',     'Bruno Fonseca',   'Miguel Esteves',
+  'Ciaran Maguire',  'Declan Farley',    'Ross Templeton',  'Scott Gallacher',
+  'Adam Trueman',    'Kevin Briers',     'Darren Poole',    'Gareth Blaine',
+];
+
+// ── Attribute ranges by NPC strength band ────────────────────────────────────
+// Strength 25–40 → weak clubs listing backup/fringe players
+// Strength 40–55 → average clubs listing workmanlike pros
+// Strength 55–70 → strong clubs listing quality reserves
+// Strength 70+   → elite clubs listing genuine assets
+
+interface AttributeRange { lo: number; hi: number }
+
+function strengthBand(strength: number): { attack: AttributeRange; defence: AttributeRange; addBonus: number } {
+  if (strength >= 65) return { attack: { lo: 58, hi: 75 }, defence: { lo: 55, hi: 72 }, addBonus: 8 };
+  if (strength >= 50) return { attack: { lo: 48, hi: 65 }, defence: { lo: 45, hi: 62 }, addBonus: 4 };
+  if (strength >= 35) return { attack: { lo: 38, hi: 56 }, defence: { lo: 36, hi: 54 }, addBonus: 2 };
+  return               { attack: { lo: 28, hi: 48 }, defence: { lo: 26, hi: 46 }, addBonus: 0 };
+}
+
+const DIVISION_QUALITY_BOOST: Record<Division, number> = {
+  LEAGUE_TWO:      0,
+  LEAGUE_ONE:      8,
+  CHAMPIONSHIP:   16,
+  PREMIER_LEAGUE: 26,
+};
+
+function generateListedAttributes(
+  position: Position,
+  rng: Rng,
+  band: ReturnType<typeof strengthBand>,
+  divBoost: number,
+): PlayerAttributes {
+  const b = (lo: number, hi: number) =>
+    Math.min(rng.nextInt(lo + divBoost, hi + divBoost), 99);
+  const { attack: atk, defence: def, addBonus } = band;
+
+  switch (position) {
+    case 'GK':
+      return {
+        attack:          b(10, 20),
+        defence:         b(def.lo + 4 + addBonus, def.hi + 4 + addBonus),
+        teamwork:        b(40, 70),
+        charisma:        b(28, 58),
+        publicPotential: 0,
+      };
+    case 'DEF':
+      return {
+        attack:          b(20, 38 + addBonus),
+        defence:         b(def.lo + addBonus, def.hi + addBonus),
+        teamwork:        b(40, 70),
+        charisma:        b(28, 60),
+        publicPotential: 0,
+      };
+    case 'MID':
+      return {
+        attack:          b(atk.lo, atk.hi),
+        defence:         b(def.lo, def.hi),
+        teamwork:        b(46 + addBonus, 76 + addBonus),
+        charisma:        b(32, 65),
+        publicPotential: 0,
+      };
+    case 'FWD':
+      return {
+        attack:          b(atk.lo + addBonus, atk.hi + addBonus),
+        defence:         b(14, 32),
+        teamwork:        b(34, 65),
+        charisma:        b(40, 72),
+        publicPotential: 0,
+      };
+  }
+}
+
+/** Transfer value (pence) from OVR: roughly quadratic curve for lower-league sums. */
+function computeTransferValue(ovr: number, age: number): number {
+  // Peak value at ~26, depreciation from 30+
+  const ageFactor = age <= 26 ? 1.0 : Math.max(0.4, 1.0 - (age - 26) * 0.06);
+  return Math.round(Math.pow(ovr, 2.2) * 1000 * ageFactor);
+}
+
+// ── Position distribution per club ───────────────────────────────────────────
+// 1–3 players per club; position spread across all clubs ensures market variety.
+
+const POSITION_CYCLE: Position[] = ['GK', 'DEF', 'DEF', 'MID', 'MID', 'FWD'];
+
+// ── Main export ───────────────────────────────────────────────────────────────
+
+/**
+ * Generate the transfer listed pool for a season.
+ * Each NPC club contributes 1–3 players. Player quality tracks the club's
+ * evolved strength. Deterministic — same inputs always produce the same pool.
+ *
+ * @param npcClubs     All NPC clubs in the current league
+ * @param npcStrengths Evolved strength map (clubId → strength 25–99)
+ * @param season       Current season number (used in seed)
+ * @param playerClubId Player's own club id — excluded from listing
+ * @param division     Current division — scales quality upward for higher tiers
+ */
+export function generateTransferListedPool(
+  npcClubs: Array<{ id: string; name: string }>,
+  npcStrengths: Record<string, number>,
+  season: number,
+  playerClubId: string,
+  division: Division = 'LEAGUE_TWO',
+): TransferListedPlayer[] {
+  const rng = createRng(`transfer-listed-${season}`);
+  const divBoost = DIVISION_QUALITY_BOOST[division];
+
+  // Shuffle names once
+  const names = [...TRANSFER_NAMES];
+  for (let i = names.length - 1; i > 0; i--) {
+    const j = Math.floor(rng.next() * (i + 1));
+    [names[i], names[j]] = [names[j], names[i]];
+  }
+
+  const pool: TransferListedPlayer[] = [];
+  let nameIdx = 0;
+  let posIdx = 0;
+
+  for (const club of npcClubs) {
+    if (club.id === playerClubId) continue;
+
+    const strength = npcStrengths[club.id] ?? 50;
+    // Stronger clubs list more players (top third: 3, mid: 2, bottom: 1)
+    const listCount = strength >= 60 ? 3 : strength >= 45 ? 2 : 1;
+    const band = strengthBand(strength);
+
+    for (let i = 0; i < listCount; i++) {
+      const position = POSITION_CYCLE[posIdx % POSITION_CYCLE.length] as Position;
+      posIdx++;
+
+      const name = names[nameIdx % names.length];
+      nameIdx++;
+
+      // Age 20–30 (peak/pre-peak players worth buying)
+      const age = rng.nextInt(20, 30);
+
+      const attributes = generateListedAttributes(position, rng, band, divBoost);
+      const curve = generatePlayerCurve(rng, age, attributes.attack, attributes.defence, position);
+      const truePotential = computeTruePotential(curve, age);
+
+      const playerId = `listed-${club.id}-${i}-s${season}`;
+      attributes.publicPotential = getScoutedPotential(
+        { id: playerId, truePotential } as TransferListedPlayer,
+        0,
+      );
+
+      const ovr = Math.round((attributes.attack + attributes.defence + attributes.teamwork) / 3);
+      const transferValue = computeTransferValue(ovr, age);
+
+      // Asking price: 1.3–1.6× markup on transferValue
+      const markup = 1.3 + rng.next() * 0.3;
+      const askingPrice = Math.round(transferValue * markup);
+
+      // Wages: competitive but not a freedom premium — 60–85% of free-agent "expensive" tier
+      const wageBase = [8_000, 16_000, 32_000, 80_000][divBoost / 8] ?? 8_000;
+      const wageScale = 0.6 + (ovr / 100) * 0.6; // scales with quality
+      const wage = Math.round(wageBase * wageScale * (0.9 + rng.next() * 0.2));
+
+      // Morale: 60–80 (content at their club, not desperate)
+      const morale = rng.nextInt(60, 80);
+
+      // Contract expires ~end of this season or next (not immediately available free agent)
+      const contractExpiresWeek = (season - 1) * 46 + rng.nextInt(30, 92);
+
+      pool.push({
+        id:              playerId,
+        name,
+        position,
+        wage,
+        transferValue,
+        age,
+        morale,
+        attributes,
+        truePotential,
+        curve,
+        contractExpiresWeek,
+        stats: {
+          goals:         0,
+          assists:       0,
+          cleanSheets:   0,
+          appearances:   0,
+          averageRating: ovr,
+        },
+        sellingClubId:   club.id,
+        sellingClubName: club.name,
+        askingPrice,
+      });
+    }
+  }
+
+  return pool;
+}

--- a/packages/domain/src/events/types.ts
+++ b/packages/domain/src/events/types.ts
@@ -52,7 +52,8 @@ export type GameEvent =
   | BudgetAllocationSetEvent
   | PlayerListedEvent
   | PlayerUnlistedEvent
-  | BoardUltimatumIssuedEvent;
+  | BoardUltimatumIssuedEvent
+  | TransferListedPlayerBoughtEvent;
 
 export interface TransferCompletedEvent {
   type: 'TRANSFER_COMPLETED';
@@ -472,4 +473,18 @@ export interface BudgetAllocationSetEvent {
   transfer: number;
   infrastructure: number;
   wages: number;
+}
+
+/** Player bought a transfer-listed player from an NPC club. */
+export interface TransferListedPlayerBoughtEvent {
+  type: 'TRANSFER_LISTED_PLAYER_BOUGHT';
+  timestamp: number;
+  /** ID of the player being transferred */
+  playerId: string;
+  /** NPC club selling the player */
+  sellingClubId: string;
+  /** Transfer fee paid (pence) */
+  fee: number;
+  /** Full player object, updated with new contractExpiresWeek */
+  player: Player;
 }

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -44,6 +44,7 @@ export * from './data/division-teams';
 export * from './data/club-events';
 export * from './data/squad-generator';
 export * from './data/free-agent-generator';
+export * from './data/transfer-listed-generator';
 export * from './data/manager-generator';
 export * from './data/scout-target-generator';
 

--- a/packages/domain/src/reducers/index.ts
+++ b/packages/domain/src/reducers/index.ts
@@ -4,7 +4,7 @@
  * Pure functions that apply events to state.
  */
 
-import { GameEvent, GameStartedEvent, MatchSimulatedEvent, TransferCompletedEvent, StaffHiredEvent, MathAttemptRecordedEvent, ClubEventOccurredEvent, ClubEventResolvedEvent, SeasonStartedEvent, TrainingFocusSetEvent, FormationSetEvent, FreeAgentSignedEvent, PlayerReleasedEvent, NpcPlayerSignedEvent, ManagerHiredEvent, ManagerSackedEvent, PreSeasonStartedEvent, ScoutMissionStartedEvent, ScoutTargetFoundEvent, ScoutBidPlacedEvent, ScoutTransferCompletedEvent, OwnerForcedOutEvent, TakeoverAcceptedEvent, ParachuteOfferedEvent, CurriculumUpgradedEvent, BoardUltimatumIssuedEvent } from '../events/types';
+import { GameEvent, GameStartedEvent, MatchSimulatedEvent, TransferCompletedEvent, StaffHiredEvent, MathAttemptRecordedEvent, ClubEventOccurredEvent, ClubEventResolvedEvent, SeasonStartedEvent, TrainingFocusSetEvent, FormationSetEvent, FreeAgentSignedEvent, PlayerReleasedEvent, NpcPlayerSignedEvent, ManagerHiredEvent, ManagerSackedEvent, PreSeasonStartedEvent, ScoutMissionStartedEvent, ScoutTargetFoundEvent, ScoutBidPlacedEvent, ScoutTransferCompletedEvent, OwnerForcedOutEvent, TakeoverAcceptedEvent, ParachuteOfferedEvent, CurriculumUpgradedEvent, BoardUltimatumIssuedEvent, TransferListedPlayerBoughtEvent } from '../events/types';
 import { GameState, Division } from '../types/game-state-updated';
 import { Club } from '../types/club';
 import { LeagueTable, LeagueTableEntry, sortLeagueTable } from '../types/league';
@@ -14,6 +14,7 @@ import { getDefaultFacilities, getUpgradeCost } from '../types/facility';
 import { facilityRevenue, squadCharismaRevenue } from '../simulation/revenue';
 import { generateStartingSquad } from '../data/squad-generator';
 import { generateFreeAgentPool } from '../data/free-agent-generator';
+import { generateTransferListedPool } from '../data/transfer-listed-generator';
 import { generateManagerPool } from '../data/manager-generator';
 import {
   applyResultMoraleDelta,
@@ -135,6 +136,8 @@ export function reduceEvent(state: GameState, event: GameEvent): GameState {
       };
     case 'BOARD_ULTIMATUM_ISSUED':
       return handleBoardUltimatumIssued(state, event);
+    case 'TRANSFER_LISTED_PLAYER_BOUGHT':
+      return handleTransferListedPlayerBought(state, event as TransferListedPlayerBoughtEvent);
     default:
       return state;
   }
@@ -172,6 +175,7 @@ export function buildState(events: GameEvent[]): GameState {
     resolvedEventHistory: [],
     season: 1,
     freeAgentPool: [],
+    transferListedPool: [],
     managerPool: [],
     lowMoraleWeeks: 0,
     moraleEventCooldowns: {},
@@ -261,6 +265,16 @@ function handleGameStarted(state: GameState, event: GameStartedEvent): GameState
     initialNpcStrengths[team.id] = team.baseStrength;
   }
 
+  // Generate the transfer listed pool for season 1
+  const npcTeamsForListing = getTeamsForDivision('LEAGUE_TWO');
+  const transferListedPool = generateTransferListedPool(
+    npcTeamsForListing,
+    initialNpcStrengths,
+    1,
+    event.clubId,
+    'LEAGUE_TWO',
+  );
+
   return {
     ...state,
     phase: 'PRE_SEASON',
@@ -294,8 +308,21 @@ function handleGameStarted(state: GameState, event: GameStartedEvent): GameState
       entries: sortedEntries
     },
     freeAgentPool,
+    transferListedPool,
     managerPool,
     npcStrengths: initialNpcStrengths,
+  };
+}
+
+function handleTransferListedPlayerBought(state: GameState, event: TransferListedPlayerBoughtEvent): GameState {
+  return {
+    ...state,
+    club: {
+      ...state.club,
+      squad: [...state.club.squad, event.player],
+      transferBudget: state.club.transferBudget - event.fee,
+    },
+    transferListedPool: (state.transferListedPool ?? []).filter(p => p.id !== event.playerId),
   };
 }
 
@@ -1027,6 +1054,15 @@ function handlePreSeasonStarted(state: GameState, event: PreSeasonStartedEvent):
     state.division,
   );
 
+  // Refresh transfer listed pool for the new season.
+  const freshTransferListedPool = generateTransferListedPool(
+    npcTeams,
+    evolvedStrengths,
+    event.season,
+    state.club.id,
+    state.division,
+  );
+
   return {
     ...state,
     phase: 'PRE_SEASON',
@@ -1036,6 +1072,7 @@ function handlePreSeasonStarted(state: GameState, event: PreSeasonStartedEvent):
     league: { ...state.league, entries: freshEntries },
     npcStrengths: evolvedStrengths,
     freeAgentPool: freshFreeAgentPool,
+    transferListedPool: freshTransferListedPool,
     club: {
       ...state.club,
       squad: updatedSquad,

--- a/packages/domain/src/types/game-state-updated.ts
+++ b/packages/domain/src/types/game-state-updated.ts
@@ -9,7 +9,7 @@ import { GameEvent } from '../events/types';
 import { Club } from './club';
 import { LeagueTable } from './league';
 import { CurriculumConfig } from '../curriculum/curriculum-config';
-import { Player, Position } from './player';
+import { Player, Position, TransferListedPlayer } from './player';
 import { Manager } from './staff';
 import { MathsChallengeSpec, NpcId } from '../data/club-events';
 import { MathTopic } from '../curriculum/curriculum-config';
@@ -182,6 +182,13 @@ export interface GameState {
 
   /** Pool of available free agents */
   freeAgentPool: Player[];
+
+  /**
+   * Players listed for sale by NPC clubs this season.
+   * Generated at PRE_SEASON_STARTED; players are removed when bought.
+   * Requires an open transfer window to purchase.
+   */
+  transferListedPool: TransferListedPlayer[];
 
   /** Available managers to hire (generated at game start, removed on hire) */
   managerPool: Manager[];
@@ -393,7 +400,8 @@ export type ErrorCode =
   | 'SQUAD_LIMIT_EXCEEDED'
   | 'PLAYER_NOT_FOUND'
   | 'INVALID_PHASE'
-  | 'VALIDATION_FAILED';
+  | 'VALIDATION_FAILED'
+  | 'WINDOW_CLOSED';
 
 /**
  * Projection builder function type

--- a/packages/domain/src/types/player.ts
+++ b/packages/domain/src/types/player.ts
@@ -211,3 +211,23 @@ export function getTotalContractCost(
   const totalWages = getAnnualWageCost(player) * contractYears;
   return transferFee + totalWages;
 }
+
+/**
+ * A player currently contracted to an NPC club and available for purchase.
+ * Extends Player with the selling club identity and the asking transfer fee.
+ *
+ * The asking price is set above the player's transferValue (clubs don't sell at cost).
+ * Wages are the player's existing contract rate — generally lower than a free agent
+ * demanding a freedom premium.
+ */
+export interface TransferListedPlayer extends Player {
+  /** ID of the NPC club selling this player */
+  sellingClubId: string;
+  /** Display name of the selling club */
+  sellingClubName: string;
+  /**
+   * Fee required to sign this player (pence).
+   * Always > transferValue (1.3–1.6× markup set at generation).
+   */
+  askingPrice: number;
+}

--- a/packages/frontend/src/components/transfer-market/TransferMarketSlideOver.tsx
+++ b/packages/frontend/src/components/transfer-market/TransferMarketSlideOver.tsx
@@ -3,6 +3,7 @@ import {
   GameState,
   GameCommand,
   Player,
+  TransferListedPlayer,
   Position,
   Formation,
   formatMoney,
@@ -24,7 +25,7 @@ interface TransferMarketSlideOverProps {
   onError: (msg: string) => void;
 }
 
-type Tab = 'free-agents' | 'my-squad';
+type Tab = 'transfer-market' | 'free-agents' | 'my-squad';
 type SortKey = 'rating' | 'attack' | 'defence' | 'wage';
 type PlayerWillingness = 'eager' | 'neutral' | 'reluctant';
 /** formation = manage mode (list + sell/release); list = flat list; lineup = manager's selected XI */
@@ -749,6 +750,126 @@ function SquadPlayerCard({
   );
 }
 
+// ─── Transfer listed player card ──────────────────────────────────────────────
+
+interface TransferListedCardProps {
+  player: TransferListedPlayer;
+  canAfford: boolean;
+  hasSquadRoom: boolean;
+  scoutLevel: number;
+  isWindowOpen: boolean;
+  onBuy: () => void;
+}
+
+function TransferListedCard({ player, canAfford, hasSquadRoom, scoutLevel, isWindowOpen, onBuy }: TransferListedCardProps) {
+  const [buying, setBuying] = useState(false);
+  const [done, setDone] = useState(false);
+  const ovr = computeOverallRating(player);
+  const potential = getScoutedPotential(player, scoutLevel);
+  const noiseRange = scoutNoiseRange(scoutLevel);
+
+  if (done) {
+    const signingLine = getSigningLine(player.id);
+    return (
+      <div className="bg-pitch-green/5 border border-pitch-green/20 rounded-card px-4 py-3 flex items-center gap-3 animate-fade-in">
+        <div className="w-6 h-6 rounded-full bg-pitch-green/20 flex items-center justify-center text-xs text-pitch-green">✓</div>
+        <div className="flex-1 min-w-0">
+          <p className="text-xs font-semibold text-pitch-green">{player.name} signed!</p>
+          <p className={`text-xs2 ${signingLine.colour}`}>"{signingLine.line}" — {signingLine.name}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-bg-surface border border-white/[0.06] rounded-card px-3 py-3 flex flex-col gap-2">
+      {/* Header row */}
+      <div className="flex items-start gap-3">
+        {/* Position badge */}
+        <div className="shrink-0 w-8 h-8 rounded-md bg-data-blue/10 border border-data-blue/20 flex items-center justify-center text-xs font-bold text-data-blue">
+          {player.position}
+        </div>
+
+        {/* Name + club */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm font-semibold text-txt-primary">{player.name}</span>
+            <span className="text-xs2 text-txt-muted/60">Age {player.age}</span>
+          </div>
+          <div className="flex items-center gap-1 mt-0.5">
+            <span className="text-xs2 text-txt-muted">From</span>
+            <span className="text-xs2 font-medium text-warn-amber">{player.sellingClubName}</span>
+          </div>
+        </div>
+
+        {/* OVR */}
+        <div className={`shrink-0 text-sm font-bold tabular-nums ${ovrTextClass(ovr)}`}>
+          {ovr}
+        </div>
+      </div>
+
+      {/* Stats row */}
+      <div className="flex items-center gap-3 text-xs2 text-txt-muted">
+        <span>⚔ {player.attributes.attack}</span>
+        <span>🛡 {player.attributes.defence}</span>
+        <span>🤝 {player.attributes.teamwork}</span>
+        <span className="ml-auto">
+          ◈ {potential}{noiseRange > 0 ? <span className="text-txt-muted/50"> ±{noiseRange}</span> : null}
+        </span>
+      </div>
+
+      {/* Fee + wage row */}
+      <div className="flex items-center gap-3 text-xs">
+        <span className="text-warn-amber font-semibold font-mono">{formatMoney(player.askingPrice)}</span>
+        <span className="text-txt-muted/40">fee</span>
+        <span className="text-txt-muted font-mono">{formatMoney(player.wage)}/wk</span>
+        <span className="text-txt-muted/40">wages</span>
+      </div>
+
+      {/* Buy action */}
+      {buying ? (
+        <div className="flex items-center gap-2 text-xs">
+          <span className="text-txt-muted flex-1">Pay {formatMoney(player.askingPrice)} to sign {player.name}?</span>
+          <button
+            onClick={() => { onBuy(); setDone(true); setBuying(false); }}
+            className="px-2.5 py-1 bg-pitch-green/20 text-pitch-green border border-pitch-green/40 rounded hover:bg-pitch-green/30 transition-colors"
+          >
+            Confirm
+          </button>
+          <button
+            onClick={() => setBuying(false)}
+            className="px-2.5 py-1 bg-white/5 text-txt-muted border border-white/10 rounded hover:bg-white/10 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={() => setBuying(true)}
+          disabled={!isWindowOpen || !canAfford || !hasSquadRoom}
+          title={
+            !isWindowOpen ? 'Transfer window is closed'
+            : !canAfford ? 'Insufficient transfer budget'
+            : !hasSquadRoom ? 'Squad is at capacity'
+            : undefined
+          }
+          className={[
+            'w-full text-xs py-1.5 rounded border transition-colors font-semibold',
+            isWindowOpen && canAfford && hasSquadRoom
+              ? 'bg-data-blue/15 text-data-blue border-data-blue/40 hover:bg-data-blue/25'
+              : 'bg-white/5 text-txt-muted border-white/10 opacity-50 cursor-not-allowed',
+          ].join(' ')}
+        >
+          {!isWindowOpen ? 'Window closed'
+            : !canAfford ? `Need ${formatMoney(player.askingPrice - 0)}`
+            : !hasSquadRoom ? 'Squad full'
+            : `Sign for ${formatMoney(player.askingPrice)}`}
+        </button>
+      )}
+    </div>
+  );
+}
+
 // ─── Deadline day banner ───────────────────────────────────────────────────────
 
 function DeadlineDayBanner({ week, phase }: { week: number; phase: string }) {
@@ -791,7 +912,7 @@ function DeadlineDayBanner({ week, phase }: { week: number; phase: string }) {
 // ─── Main component ────────────────────────────────────────────────────────────
 
 export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMarketSlideOverProps) {
-  const [activeTab, setActiveTab] = useState<Tab>('free-agents');
+  const [activeTab, setActiveTab] = useState<Tab>('transfer-market');
   const [positionFilter, setPositionFilter] = useState<Position | 'ALL'>('ALL');
   const [sortKey, setSortKey] = useState<SortKey>('rating');
   const [squadViewMode, setSquadViewMode] = useState<SquadViewMode>('formation');
@@ -830,9 +951,15 @@ export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMa
   }
 
   const filteredFreeAgents = filterPlayers(state.freeAgentPool ?? []);
+  const filteredListed = filterPlayers(state.transferListedPool ?? []);
   const filteredSquad = filterPlayers(state.club.squad);
 
   // ── Handlers ───────────────────────────────────────────────────────────────
+
+  function handleBuyListed(playerId: string) {
+    const result = dispatch({ type: 'BUY_TRANSFER_LISTED_PLAYER', playerId, clubId: state.club.id });
+    if (result.error) onError(result.error);
+  }
 
   function handleSign(playerId: string, wage: number) {
     const result = dispatch({ type: 'SIGN_FREE_AGENT', playerId, offeredWage: wage });
@@ -885,6 +1012,10 @@ export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMa
       {/* ── Budget / squad bar ─────────────────────────────────────────────── */}
       <div className="bg-bg-raised rounded-card border border-white/5 px-4 py-2 flex items-center gap-4 text-sm flex-wrap">
         <span className="text-txt-muted">
+          Budget: <span className="text-warn-amber font-semibold font-mono">{formatMoney(state.club.transferBudget)}</span>
+        </span>
+        <span className="text-white/20">|</span>
+        <span className="text-txt-muted">
           Wage runway: <span className={wageRunway < 8 ? 'text-alert-red font-semibold' : 'text-pitch-green font-semibold'}>{wageRunway === Infinity || !isFinite(wageRunway) ? '∞' : `${Math.floor(wageRunway)}w`}</span>
         </span>
         <span className="text-white/20">|</span>
@@ -897,17 +1028,21 @@ export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMa
 
       {/* ── Tabs ──────────────────────────────────────────────────────────── */}
       <div className="flex items-center gap-1">
-        {(['free-agents', 'my-squad'] as Tab[]).map(tab => (
+        {([
+          { id: 'transfer-market', label: `Transfer Market (${(state.transferListedPool ?? []).length})` },
+          { id: 'free-agents',    label: `Free Agents (${(state.freeAgentPool ?? []).length})` },
+          { id: 'my-squad',       label: `My Squad (${squadCount})` },
+        ] as { id: Tab; label: string }[]).map(({ id, label }) => (
           <button
-            key={tab}
-            onClick={() => setActiveTab(tab)}
+            key={id}
+            onClick={() => setActiveTab(id)}
             className={`px-3 py-1.5 text-sm rounded-card transition-colors ${
-              activeTab === tab
+              activeTab === id
                 ? 'bg-data-blue/20 text-data-blue border border-data-blue/40'
                 : 'text-txt-muted hover:text-txt-primary border border-white/5 hover:border-white/10'
             }`}
           >
-            {tab === 'free-agents' ? `Free Agents (${(state.freeAgentPool ?? []).length})` : `My Squad (${squadCount})`}
+            {label}
           </button>
         ))}
         {/* View mode toggle — only visible on My Squad tab */}
@@ -967,7 +1102,28 @@ export function TransferMarketSlideOver({ state, dispatch, onError }: TransferMa
 
       {/* ── Player list ──────────────────────────────────────────────────── */}
       <div className="flex-1 overflow-y-auto flex flex-col gap-2 pr-1">
-        {activeTab === 'free-agents' ? (
+        {activeTab === 'transfer-market' ? (
+          !isWindowOpen ? (
+            <div className="text-center py-8">
+              <p className="text-txt-muted text-sm">Transfer window is closed.</p>
+              <p className="text-txt-muted/60 text-xs mt-1">Window opens weeks 1–4 (summer) and 21–24 (January).</p>
+            </div>
+          ) : filteredListed.length === 0 ? (
+            <div className="text-txt-muted text-sm text-center py-8">No listed players match your filters.</div>
+          ) : (
+            filteredListed.map(player => (
+              <TransferListedCard
+                key={player.id}
+                player={player}
+                canAfford={state.club.transferBudget >= player.askingPrice}
+                hasSquadRoom={squadCount < squadCapacity}
+                scoutLevel={scoutLevel}
+                isWindowOpen={isWindowOpen}
+                onBuy={() => handleBuyListed(player.id)}
+              />
+            ))
+          )
+        ) : activeTab === 'free-agents' ? (
           filteredFreeAgents.length === 0 ? (
             <div className="text-txt-muted text-sm text-center py-8">No free agents match your filters.</div>
           ) : (


### PR DESCRIPTION
## Summary

- Each NPC club lists 1–3 players for sale each season, quality scaled to their evolved `npcStrengths` — generally better than the average free agent
- New **Transfer Market** tab (default landing) in the transfers UI alongside Free Agents and My Squad
- Free agent pool **rebalanced to bimodal**: 40 bargain-bin castoffs (cheap/poor) + 20 expensive gambles (decent quality, premium wages) — creates a real buy vs. sign decision
- Transfer budget now visible in the header bar

## What the market looks like

| Tier | Count | Quality | Fee | Wages |
|---|---|---|---|---|
| NPC listed | ~45–60 | OVR ~48–72 (scales with club strength) | 1.3–1.6× transferValue | Contracted rate — lower than free agent premium |
| Free agents (expensive gamble) | 20 | OVR ~52–72 | None | High — freedom premium |
| Free agents (bargain bin) | 40 | OVR ~25–48 | None | Very low — nobody else wants them |

## Domain changes
- `TransferListedPlayer` type: extends `Player` with `sellingClubId`, `sellingClubName`, `askingPrice`
- `generateTransferListedPool(npcClubs, npcStrengths, season, playerClubId, division)`
- `transferListedPool: TransferListedPlayer[]` on `GameState` (refreshed each season)
- `BUY_TRANSFER_LISTED_PLAYER` command — window gate, budget check, wage runway check
- `TRANSFER_LISTED_PLAYER_BOUGHT` event + reducer
- `WINDOW_CLOSED` added to `ErrorCode`

## Test plan
- [ ] New game: Transfer Market tab loads with players from NPC clubs
- [ ] Each listed player shows selling club name, fee, wages, and OVR
- [ ] Window closed (week 5–20): buy button disabled, "Window closed" message shown
- [ ] Insufficient budget: buy button shows error state
- [ ] Successful buy: fee deducted from transferBudget, player appears in squad, disappears from market
- [ ] Season 2: market refreshes with evolved NPC strengths (stronger clubs list better players)
- [ ] Free agent pool: check the quality split — first ~40 should be weaker/older, last ~20 stronger/pricier

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)