### PR TITLE
Streamline intro to ambition-first cold-open with guided onboarding

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -18,7 +18,7 @@ import { IntroScreen } from './components/intro/IntroScreen';
 import { OwnerBox } from './components/owner-box/OwnerBox';
 import { PostMatchScreen } from './components/owner-box/PostMatchScreen';
 import { PreMatchOverlay } from './components/owner-box/PreMatchOverlay';
-import { clearIntroCompleted } from './lib/introState';
+import { clearIntroCompleted, OnboardingMode } from './lib/introState';
 
 type Screen = 'menu' | 'intro' | 'game';
 // ActiveSection kept for compat with any remaining imports
@@ -98,10 +98,10 @@ export default function App() {
     setScreen('game');
   }
 
-  function handleNewGame(level: CurriculumLevel, clubName: string, stadiumName: string) {
+  function handleNewGame(level: CurriculumLevel, clubName: string, stadiumName: string, mode: OnboardingMode) {
     clearIntroCompleted();
     resetGame(level, clubName, stadiumName);
-    setScreen('intro');
+    setScreen(mode === 'skip' ? 'game' : 'intro');
   }
 
   function handleIntroComplete() {

--- a/packages/frontend/src/components/command-centre/GuidedTaskCard.tsx
+++ b/packages/frontend/src/components/command-centre/GuidedTaskCard.tsx
@@ -1,0 +1,71 @@
+import { GuidedTask, GuidedTaskId } from '../../lib/guidedTasks';
+import { NPC_COLOUR_CLASSES } from '../../lib/npcs';
+
+interface Props {
+  tasks: GuidedTask[];
+  onTaskClick: (id: GuidedTaskId) => void;
+}
+
+export function GuidedTaskCard({ tasks, onTaskClick }: Props) {
+  const completed = tasks.filter(t => t.done).length;
+  const total = tasks.length;
+
+  return (
+    <div className="bg-bg-surface border border-bg-raised rounded-card overflow-hidden">
+      <div className="px-4 py-3 border-b border-bg-raised flex items-center justify-between">
+        <div>
+          <div className="text-xs uppercase tracking-widest text-txt-muted font-semibold">
+            First week at the club
+          </div>
+          <div className="text-sm text-txt-primary mt-0.5">
+            Four things to get sorted — the rest of the season builds on these.
+          </div>
+        </div>
+        <div className="text-xs font-mono text-txt-muted shrink-0 ml-3">
+          {completed}/{total}
+        </div>
+      </div>
+
+      <ul className="divide-y divide-bg-raised">
+        {tasks.map(task => {
+          const c = NPC_COLOUR_CLASSES[task.npc.colour];
+          return (
+            <li key={task.id}>
+              <button
+                onClick={() => onTaskClick(task.id)}
+                className="w-full flex items-start gap-3 px-4 py-3 text-left hover:bg-bg-raised/60 transition-colors"
+              >
+                <div
+                  className={[
+                    'w-7 h-7 rounded-full flex items-center justify-center text-sm shrink-0 mt-0.5',
+                    task.done ? 'bg-pitch-green text-white' : `${c.bgSubtle} ring-2 ${c.ring}`,
+                  ].join(' ')}
+                >
+                  {task.done ? '✓' : task.npc.avatar}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-baseline gap-2">
+                    <span className={`text-sm font-semibold ${task.done ? 'text-txt-muted line-through' : 'text-txt-primary'}`}>
+                      {task.title}
+                    </span>
+                    <span className={`text-xs2 ${c.text} shrink-0`}>
+                      {task.npc.name.split(' ')[0]}
+                    </span>
+                  </div>
+                  {!task.done && (
+                    <p className="text-xs text-txt-muted leading-snug mt-0.5">
+                      {task.blurb}
+                    </p>
+                  )}
+                </div>
+                {!task.done && (
+                  <div className="text-txt-muted text-lg shrink-0">→</div>
+                )}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/command-centre/HeadlineStats.tsx
+++ b/packages/frontend/src/components/command-centre/HeadlineStats.tsx
@@ -1,5 +1,7 @@
 import { GameState } from '@calculating-glory/domain';
 import { formatMoney } from '@calculating-glory/domain';
+import { TermInfo } from '../shared/TermInfo';
+import { GlossaryTermId } from '../../lib/glossary';
 
 interface HeadlineStatsProps {
   state: GameState;
@@ -14,15 +16,20 @@ function TrendArrow({ trend }: { trend: 'up' | 'down' | 'flat' }) {
 
 interface StatCardProps {
   label: string;
+  termId?: GlossaryTermId;
   value: string;
   trend: 'up' | 'down' | 'flat';
   color: string;
 }
 
-function StatCard({ label, value, trend, color }: StatCardProps) {
+function StatCard({ label, termId, value, trend, color }: StatCardProps) {
   return (
     <div className="card flex flex-col gap-1">
-      <span className="text-xs text-txt-muted uppercase tracking-wide">{label}</span>
+      <span className="text-xs text-txt-muted uppercase tracking-wide">
+        {termId
+          ? <TermInfo termId={termId} label={label} size="inline" />
+          : label}
+      </span>
       <div className={`text-2xl font-bold flex items-center gap-1 ${color}`}>
         {value}
         <TrendArrow trend={trend} />
@@ -67,12 +74,14 @@ export function HeadlineStats({ state }: HeadlineStatsProps) {
       />
       <StatCard
         label="Confidence"
+        termId="board-confidence"
         value={`${boardConfidence}%`}
         trend={confidenceTrend}
         color={confidenceColor}
       />
       <StatCard
         label="Budget"
+        termId="transfer-budget"
         value={formatMoney(club.transferBudget)}
         trend={budgetTrend}
         color={budgetColor}

--- a/packages/frontend/src/components/command-centre/sections/OverviewSection.tsx
+++ b/packages/frontend/src/components/command-centre/sections/OverviewSection.tsx
@@ -5,7 +5,10 @@ import { HubTile } from '../HubTiles';
 import { InboxCard } from '../InboxCard';
 import { LeagueTable } from '../LeagueTable';
 import { SquadAuditTable } from '../SquadAuditTable';
+import { GuidedTaskCard } from '../GuidedTaskCard';
 import { ActiveSection } from '../../../App';
+import { getGuidedTasks, GuidedTaskId } from '../../../lib/guidedTasks';
+import { getOnboardingMode } from '../../../lib/introState';
 
 interface OverviewSectionProps {
   state: GameState;
@@ -52,6 +55,19 @@ export function OverviewSection({
     f => f.level > 0 && f.level < 5 && !(f.constructionWeeksRemaining ?? 0) && f.upgradeCost <= state.club.transferBudget
   );
 
+  const guidedTasks = getGuidedTasks(state, events);
+  const allDone = guidedTasks.every(t => t.done);
+  const showGuidedCard = getOnboardingMode() === 'guided' && !allDone && introSpotlight === undefined;
+
+  const handleTaskClick = (id: GuidedTaskId) => {
+    switch (id) {
+      case 'sponsor':  onSectionChange('inbox');     return;
+      case 'manager':  onSectionChange('inbox');     return;
+      case 'signing':  onSectionChange('transfers'); return;
+      case 'facility': onNavigateToStadium();        return;
+    }
+  };
+
   const dim = (sectionId: string) => {
     if (introSpotlight === undefined) return null;
     return (
@@ -64,6 +80,11 @@ export function OverviewSection({
 
   return (
     <div className="flex flex-col gap-2 px-4 pb-4">
+
+      {/* ── Guided task card (new players, tasks outstanding) ───────────── */}
+      {showGuidedCard && (
+        <GuidedTaskCard tasks={guidedTasks} onTaskClick={handleTaskClick} />
+      )}
 
       {/* ── Inbox (priority: at top, full height) ───────────────────────── */}
       <div className="relative">

--- a/packages/frontend/src/components/intro/IntroScreen.tsx
+++ b/packages/frontend/src/components/intro/IntroScreen.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 import { GameState, GameCommand, formatMoney, toPence } from '@calculating-glory/domain';
 import { OwnerOffice } from '../owner-office/OwnerOffice';
-import { IsometricBlueprint } from '../isometric/IsometricBlueprint';
 import { NpcMessage } from './NpcMessage';
 import { MathsChallenge } from './MathsChallenge';
 import { markIntroCompleted } from '../../lib/introState';
+import { NPCS } from '../../lib/npcs';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -15,48 +15,27 @@ interface Props {
   onComplete: () => void;
 }
 
-// ── Step → backdrop mode ────────────────────────────────────────────────────
+// ── Step → backdrop spotlight ────────────────────────────────────────────────
 //
-// Steps 7–11 use the stadium backdrop (no OwnerOffice spotlight needed).
-// Steps 0–6 and 12+ use OwnerOffice with a zone spotlight.
-//
-// Zone IDs: 'header-stats' | 'decisions-zone' | 'pitch-zone' | 'people-zone'
+// The intro is scoped down to an ambition-first cold-open. Kev opens with the
+// why, Val reframes money as the enabler, then we drop straight into the first
+// concrete pre-season decision (Marcus' sponsor deal + maths challenge).
 
 const STEP_SPOTLIGHT: Record<number, string | null> = {
-  0:  null,              // title screen
-  1:  null,              // Val intro
-  2:  'header-stats',    // Val: financial overview → header stats strip
-  3:  'header-stats',    // Val: keep green → header stats
-  4:  'decisions-zone',  // Kev: squad reality check → inbox decisions
-  5:  'pitch-zone',      // Marcus: revenue → pitch & league context
-  6:  'people-zone',     // Dani: stadium needs work → people & time
-  // 7–11: stadium tour (OwnerOffice hidden)
-  12: 'people-zone',     // Dani: closing — staff panel
-  13: 'decisions-zone',  // Kev: squad numbers → decisions
-  14: null,              // Val: I always do
-  15: 'decisions-zone',  // Kev: transfer window → inbox area
-  16: 'decisions-zone',  // Marcus: sponsor deal → inbox/decisions
-  17: 'header-stats',    // Val: attendance context → header stats
+  0: null,              // title screen (full takeover)
+  1: null,              // Kev: ambition
+  2: 'header-stats',    // Val: money as enabler
+  3: 'decisions-zone',  // Kev: squad honest picture
+  4: 'decisions-zone',  // Marcus: sponsor pitch
+  5: 'header-stats',    // Val: attendance context
+  // 6: maths challenge — spotlight hidden via challenge UI
+  7: null,              // Val: maths result
+  8: 'decisions-zone',  // Choice buttons
+  9: 'decisions-zone',  // Marcus: deal confirmed
+  10: null,             // Kev: let's go
 };
 
-// ── Stadium tour: which building to highlight per step ───────────────────────
-
-const TOUR_HIGHLIGHT: Record<number, string | null> = {
-  7:  null,          // transition "Let me walk you through a few"
-  8:  'training',    // Training Ground
-  9:  'medical',     // Medical Centre
-  10: 'commercial',  // Commercial Centre
-  11: 'pitch',       // The Pitch
-};
-
-// ── NPC avatars ───────────────────────────────────────────────────────────────
-
-const NPC = {
-  val:    { name: 'Val Okoro',   role: 'Finance Director',    avatar: '📊' },
-  kev:    { name: 'Kev Mulligan',role: 'Head of Football',    avatar: '⚽' },
-  marcus: { name: 'Marcus Webb', role: 'Commercial Director', avatar: '📣' },
-  dani:   { name: 'Dani Lopes',  role: 'Head of Operations',  avatar: '🔧' },
-};
+const LAST_STEP = 10;
 
 // ── Sponsor deal constants ────────────────────────────────────────────────────
 
@@ -72,18 +51,6 @@ export function IntroScreen({ state, events, dispatch, onComplete }: Props) {
   const [animKey, setAnimKey] = useState(0);
 
   const clubName = state.club.name;
-  const runwayWeeks = Math.floor(
-    state.club.transferBudget /
-    Math.max(1,
-      state.club.squad.reduce((s, p) => s + p.wage, 0) +
-      state.club.staff.reduce((s, p) => s + p.salary, 0) +
-      (state.club.manager?.wage ?? 0)
-    )
-  );
-
-  // Steps 7–11 show the stadium blueprint as the backdrop
-  const inStadiumTour = step >= 7 && step <= 11;
-  const tourHighlightId = inStadiumTour ? (TOUR_HIGHLIGHT[step] ?? null) : null;
 
   function advance() {
     setStep(s => s + 1);
@@ -92,7 +59,7 @@ export function IntroScreen({ state, events, dispatch, onComplete }: Props) {
 
   function handleMathsResult(correct: boolean) {
     setMathsCorrect(correct);
-    setStep(19);
+    setStep(7);
     setAnimKey(k => k + 1);
   }
 
@@ -105,7 +72,7 @@ export function IntroScreen({ state, events, dispatch, onComplete }: Props) {
       choice: picked,
       amount,
     });
-    setStep(21);
+    setStep(9);
     setAnimKey(k => k + 1);
   }
 
@@ -114,118 +81,61 @@ export function IntroScreen({ state, events, dispatch, onComplete }: Props) {
     onComplete();
   }
 
-  const spotlight = inStadiumTour ? undefined : (STEP_SPOTLIGHT[step] ?? null);
+  const spotlight = STEP_SPOTLIGHT[step] ?? null;
 
   // ── Render the message for the current step ───────────────────────────────
   function renderCurrentMessage() {
     switch (step) {
-      // ── Steps 1–6: original CommandCentre intro ──────────────────────────
+      // ── Beat 1: Kev — what are we chasing? ─────────────────────────────
       case 1: return (
-        <NpcMessage {...NPC.val} delay>
-          Morning. I'm Val. I handle the money at {clubName}. I should warn you: the previous owner didn't leave us in great shape. Let me show you where we stand.
+        <NpcMessage {...NPCS.kev} delay>
+          Right, boss. I'm Kev — I run the football side. What do you want from this season? Survival, a cup run, promotion? Whatever it is, the lads in the dressing room need to hear it, and the fans in the stand need to believe it. I've got the tactics. You've got the decisions.
         </NpcMessage>
       );
+      // ── Beat 2: Val — money is the enabler, not the headline ───────────
       case 2: return (
-        <NpcMessage {...NPC.val} delay>
-          This is your financial overview. The number on the left is how much cash we have. The number on the right is how many weeks it'll last at our current spending rate. Right now we've got roughly <strong>{runwayWeeks} weeks</strong> of runway. That sounds like a lot, but it goes fast when you're paying wages, maintaining facilities, and trying to win football matches.
+        <NpcMessage {...NPCS.val} delay>
+          Morning. Val Okoro, Finance. Love the ambition — and I'm the one who makes sure it's fundable. None of it, the signings, the stadium, the cup runs, happens without cash. I track it so you can chase it. Keep us out of the red and there's no ceiling on what {clubName} can do.
         </NpcMessage>
       );
+      // ── Beat 3: Kev — the squad you've inherited ───────────────────────
       case 3: return (
-        <NpcMessage {...NPC.val} delay>
-          Rule number one of this job: <strong>keep this bar green.</strong> If it turns amber, be careful. If it turns red... well, let's not find out.
+        <NpcMessage {...NPCS.kev} delay>
+          Honest picture: {state.club.squad.length} players on the books, most of them mid-table League Two at best. Room to bring {24 - state.club.squad.length} more in, and the free-agent pool's worth a proper look. Get me one signing the fans can get excited about, and we can chase something real.
         </NpcMessage>
       );
+      // ── Beat 4: Marcus — pre-season sponsor pitch ──────────────────────
       case 4: return (
-        <NpcMessage {...NPC.kev} delay>
-          Alright boss. I'm Kev. I look after the football side. The squad I've got is... well, it's what it is. We'll need to be smart in the market. I'll handle tactics and training, you just make sure I've got something to work with.
-        </NpcMessage>
-      );
-      case 5: return (
-        <NpcMessage {...NPC.marcus} delay>
-          Hey! Marcus here. Commercial and fan engagement. I've got some ideas to get revenue moving but we'll need to invest a bit to make money. I'll bring you opportunities, you decide what's worth backing.
-        </NpcMessage>
-      );
-      case 6: return (
-        <NpcMessage {...NPC.dani} delay>
-          Dani. I run the day-to-day. Facilities, suppliers, logistics. Come with me, I'll show you what we're working with.
-        </NpcMessage>
-      );
-
-      // ── Steps 7–11: Dani stadium tour ────────────────────────────────────
-      case 7: return (
-        <NpcMessage {...NPC.dani} delay>
-          Let me walk you through a few of the buildings. This is what your investment decisions actually look like.
-        </NpcMessage>
-      );
-      case 8: return (
-        <NpcMessage {...NPC.dani} delay>
-          <strong>Training Ground.</strong> Better facilities, faster improvement. Most owners let it rot. It's usually the first thing I'd fix.
-        </NpcMessage>
-      );
-      case 9: return (
-        <NpcMessage {...NPC.dani} delay>
-          <strong>Medical Centre.</strong> Keeps players on the pitch instead of the treatment table. If your squad is thin, you can't afford injuries.
-        </NpcMessage>
-      );
-      case 10: return (
-        <NpcMessage {...NPC.dani} delay>
-          <strong>Commercial Centre.</strong> Revenue from matchday and partnerships runs through here. A decent setup pays for itself quickly.
-        </NpcMessage>
-      );
-      case 11: return (
-        <NpcMessage {...NPC.dani} delay>
-          <strong>The Pitch.</strong> Everything else feeds off this. Attendance, reputation, sponsorship interest. Most expensive to upgrade. Biggest multiplier.
-        </NpcMessage>
-      );
-      case 12: return (
-        <NpcMessage {...NPC.dani} delay>
-          You won't be able to afford everything. Pick one or two to start. The others can wait.
-        </NpcMessage>
-      );
-
-      // ── Steps 13–22: back to Command Centre ──────────────────────────────
-      case 13: return (
-        <NpcMessage {...NPC.kev} delay>
-          Right, let me give you the honest picture. We've got {state.club.squad.length} players on the books. Most of them are... okay. League Two level, just about. We've got capacity for 24, so there's room to bring people in. But every signing costs wages, and Val's going to have something to say about that.
-        </NpcMessage>
-      );
-      case 14: return (
-        <NpcMessage {...NPC.val} delay>
-          I always do.
-        </NpcMessage>
-      );
-      case 15: return (
-        <NpcMessage {...NPC.kev} delay>
-          The transfer window's open for the first few weeks of the season. We've also got a free agent pool, players without a club. Some bargains, some traps. I'll flag who I think is worth looking at, but the budget calls are yours.
-        </NpcMessage>
-      );
-      case 16: return (
-        <NpcMessage {...NPC.marcus} delay>
-          Boss, before the season starts, I've got something that needs a decision. A local company has offered to sponsor our pre-season friendlies, three warm-up matches, their branding on the programme and pitch-side boards. They're offering two options:
+        <NpcMessage {...NPCS.marcus} delay>
+          Marcus Webb, Commercial. Before a ball's kicked I've got a deal on the table — a local firm wants their logo on our pre-season friendlies. Three warm-up matches, programme and pitch-side boards. Not glamorous, but it's how we fund the ambition. Two options:
           <ul className="mt-2 space-y-1 text-xs text-txt-muted">
-            <li><strong className="text-txt-primary">Option A:</strong> Flat fee, {formatMoney(OPTION_A_AMOUNT)} for all three matches. Simple, guaranteed money.</li>
-            <li><strong className="text-txt-primary">Option B:</strong> Per-attendance deal, £0.60 per fan per match. More money if attendance is good, less if it isn't.</li>
+            <li><strong className="text-txt-primary">Option A:</strong> Flat fee, {formatMoney(OPTION_A_AMOUNT)} for all three matches. Guaranteed.</li>
+            <li><strong className="text-txt-primary">Option B:</strong> £0.60 per fan per match. More if attendance is good, less if it isn't.</li>
           </ul>
         </NpcMessage>
       );
-      case 17: return (
-        <NpcMessage {...NPC.val} delay>
-          Our pre-season friendlies typically attract between 1,200 and 1,800 fans. Last year averaged about 1,500 across the three games.
+      // ── Beat 5: Val — attendance context ───────────────────────────────
+      case 5: return (
+        <NpcMessage {...NPCS.val} delay>
+          Our pre-season friendlies typically pull in 1,200–1,800. Last year averaged about 1,500 across the three games.
         </NpcMessage>
       );
-      case 18: return (
+      // ── Beat 6: maths challenge (no NPC bubble) ────────────────────────
+      case 6: return (
         <div className="animate-fade-in">
           <MathsChallenge onResult={handleMathsResult} />
         </div>
       );
-      case 19: return mathsCorrect !== null ? (
-        <NpcMessage {...NPC.val} delay>
+      // ── Beat 7: Val — maths result ─────────────────────────────────────
+      case 7: return mathsCorrect !== null ? (
+        <NpcMessage {...NPCS.val} delay>
           {mathsCorrect
-            ? `That's right. £2,700 versus the flat £2,000. Option B looks better on paper, but attendance isn't guaranteed. Your call.`
-            : `I make it £2,700, 1,500 fans, times 3 matches, times 60p each. So Option B is worth more if attendance holds up. But it's a gamble.`}
+            ? `That's right. £2,700 versus the flat £2,000. Option B looks better on paper — but attendance isn't guaranteed. Your call.`
+            : `I make it £2,700. 1,500 fans, three matches, 60p each. Option B's worth more if attendance holds up. But it's a gamble.`}
         </NpcMessage>
       ) : null;
-      case 20: return choice === null ? (
+      // ── Beat 8: choice buttons (no NPC bubble) ────────────────────────
+      case 8: return choice === null ? (
         <div className="animate-fade-in space-y-2">
           <p className="text-xs text-txt-muted px-1">Which deal do you want?</p>
           <div className="grid grid-cols-2 gap-3">
@@ -252,14 +162,16 @@ export function IntroScreen({ state, events, dispatch, onComplete }: Props) {
           </div>
         </div>
       ) : null;
-      case 21: return choice !== null ? (
-        <NpcMessage {...NPC.marcus} delay>
-          Done. I'll let them know. {choice === 'B' ? "Fingers crossed on the attendance." : "Nice and clean."}
+      // ── Beat 9: Marcus — deal locked in ────────────────────────────────
+      case 9: return choice !== null ? (
+        <NpcMessage {...NPCS.marcus} delay>
+          Done. I'll let them know. {choice === 'B' ? 'Fingers crossed on the attendance.' : 'Nice and clean.'}
         </NpcMessage>
       ) : null;
-      case 22: return choice !== null ? (
-        <NpcMessage {...NPC.val} delay>
-          First decision made. Let's see how it plays out. Now, let's get the squad ready for the season.
+      // ── Beat 10: Kev — handoff to pre-season ───────────────────────────
+      case 10: return choice !== null ? (
+        <NpcMessage {...NPCS.kev} delay>
+          First decision made. Let's get pre-season sorted — formation, manager, then a look at the squad. The fans are watching.
         </NpcMessage>
       ) : null;
       default: return null;
@@ -272,48 +184,25 @@ export function IntroScreen({ state, events, dispatch, onComplete }: Props) {
   return (
     <div className="fixed inset-0 flex flex-col overflow-hidden bg-bg-deep">
 
-      {/* ── Backdrop — Owner's Office or Stadium tour ────────────────────── */}
+      {/* ── Backdrop — Owner's Office with zone spotlight ─────────────────── */}
       <div className="absolute inset-0 pointer-events-none overflow-hidden">
-        {inStadiumTour ? (
-          <div key="stadium-backdrop" className="w-full h-full animate-fade-in">
-            <IsometricBlueprint
-              state={state}
-              dispatch={() => ({})}
-              onError={() => {}}
-              highlightedId={tourHighlightId}
-              fillParent
-            />
-          </div>
-        ) : (
-          <div className="flex flex-col flex-1 h-full overflow-hidden">
-            <OwnerOffice
-              state={state}
-              events={events}
-              dispatch={() => ({})}
-              isLoading={false}
-              onNavigateToStadium={() => {}}
-              onError={() => {}}
-              introSpotlight={spotlight}
-            />
-          </div>
-        )}
+        <div className="flex flex-col flex-1 h-full overflow-hidden">
+          <OwnerOffice
+            state={state}
+            events={events}
+            dispatch={() => ({})}
+            isLoading={false}
+            onNavigateToStadium={() => {}}
+            onError={() => {}}
+            introSpotlight={spotlight}
+          />
+        </div>
       </div>
 
-      {/* ── Dark gradient scrim ───────────────────────────────────────────── */}
-      {/* During stadium tour: light centre so buildings show, dark band at very
-          bottom to contrast the message panel. During Owner's Office steps: standard. */}
-      {inStadiumTour ? (
-        <>
-          {/* Subtle vignette — darkens edges without covering centre */}
-          <div className="absolute inset-0 pointer-events-none bg-gradient-to-t from-transparent via-transparent to-bg-deep/40" />
-          {/* Bottom band — gives the message panel a readable backdrop */}
-          <div className="absolute inset-x-0 bottom-0 h-56 pointer-events-none bg-gradient-to-t from-bg-deep via-bg-deep/90 to-transparent" />
-        </>
-      ) : (
-        <div className="absolute inset-0 bg-gradient-to-t from-bg-deep via-bg-deep/60 to-transparent pointer-events-none" />
-      )}
+      {/* ── Dark gradient scrim for readability ───────────────────────────── */}
+      <div className="absolute inset-0 bg-gradient-to-t from-bg-deep via-bg-deep/60 to-transparent pointer-events-none" />
 
-      {/* ── Beat 1, Step 0: Arrival title ───────────────────────────────── */}
+      {/* ── Beat 0: Arrival title ───────────────────────────────────────── */}
       {step === 0 && (
         <div
           className="absolute inset-0 flex flex-col items-center justify-center text-center px-8 cursor-pointer z-20"
@@ -324,7 +213,7 @@ export function IntroScreen({ state, events, dispatch, onComplete }: Props) {
             <h1 className="text-3xl font-bold text-txt-primary leading-tight">
               Welcome to<br />{clubName}.
             </h1>
-            <p className="text-lg text-txt-muted">You are the new owner.</p>
+            <p className="text-lg text-txt-muted">Time to chase some glory.</p>
           </div>
           <p className="absolute bottom-10 text-xs text-txt-muted/50 animate-pulse">
             Tap to continue
@@ -332,7 +221,7 @@ export function IntroScreen({ state, events, dispatch, onComplete }: Props) {
         </div>
       )}
 
-      {/* ── Steps 1+: Single-message panel anchored to the bottom ───────── */}
+      {/* ── Beats 1+: single-message panel anchored to bottom ───────────── */}
       {step >= 1 && (
         <div className="absolute inset-x-0 bottom-0 flex flex-col z-20">
           {currentMessage && (
@@ -347,12 +236,12 @@ export function IntroScreen({ state, events, dispatch, onComplete }: Props) {
           {showContinue && (
             <div className="px-4 pb-6 pt-3 max-w-lg mx-auto w-full">
               <button
-                onClick={step >= 22 ? handleComplete : advance}
+                onClick={step >= LAST_STEP ? handleComplete : advance}
                 className="w-full bg-data-blue hover:bg-data-blue/90 active:scale-[0.99]
                            text-white font-semibold text-sm rounded-card py-3 px-6
                            transition-all duration-150 animate-fade-in"
               >
-                {step >= 22 ? "Let's go →" : 'Continue →'}
+                {step >= LAST_STEP ? "Let's go →" : 'Continue →'}
               </button>
             </div>
           )}
@@ -372,9 +261,9 @@ function shouldShowContinue(
   choice: 'A' | 'B' | null,
 ): boolean {
   if (step === 0) return false;           // handled by full-screen click
-  if (step === 18) return false;          // maths challenge handles its own flow
-  if (step === 19 && mathsCorrect === null) return false;
-  if (step === 20 && choice === null) return false;
-  if (step === 21 && choice === null) return false;
+  if (step === 6) return false;           // maths challenge handles its own flow
+  if (step === 7 && mathsCorrect === null) return false;
+  if (step === 8 && choice === null) return false;
+  if (step === 9 && choice === null) return false;
   return true;
 }

--- a/packages/frontend/src/components/intro/NpcMessage.tsx
+++ b/packages/frontend/src/components/intro/NpcMessage.tsx
@@ -1,23 +1,37 @@
+import { NPC_COLOUR_CLASSES, NpcColourKey } from '../../lib/npcs';
+
 interface Props {
   name: string;
   role: string;
   avatar: string;
   children: React.ReactNode;
   delay?: boolean;
+  colour?: NpcColourKey;
 }
 
-export function NpcMessage({ name, role, avatar, children, delay = false }: Props) {
+export function NpcMessage({ name, role, avatar, children, delay = false, colour }: Props) {
+  const c = colour ? NPC_COLOUR_CLASSES[colour] : null;
   return (
     <div className={`flex gap-3 ${delay ? 'animate-fade-in' : ''}`}>
-      <div className="w-8 h-8 rounded-full bg-bg-raised flex items-center justify-center text-base shrink-0 mt-0.5">
+      <div
+        className={[
+          'w-8 h-8 rounded-full bg-bg-raised flex items-center justify-center text-base shrink-0 mt-0.5',
+          c ? `ring-2 ${c.ring}` : '',
+        ].join(' ').trim()}
+      >
         {avatar}
       </div>
       <div className="flex-1 min-w-0">
         <div className="flex items-baseline gap-2 mb-1">
-          <span className="text-xs font-semibold text-txt-primary">{name}</span>
+          <span className={`text-xs font-semibold ${c ? c.name : 'text-txt-primary'}`}>{name}</span>
           <span className="text-xs2 text-txt-muted">{role}</span>
         </div>
-        <div className="bg-bg-raised rounded-bubble rounded-tl-tag px-3 py-2 text-sm text-txt-primary leading-relaxed">
+        <div
+          className={[
+            'bg-bg-raised rounded-bubble rounded-tl-tag px-3 py-2 text-sm text-txt-primary leading-relaxed',
+            c ? `border-l-4 ${c.border}` : '',
+          ].join(' ').trim()}
+        >
           {children}
         </div>
       </div>

--- a/packages/frontend/src/components/menu/MenuScreen.tsx
+++ b/packages/frontend/src/components/menu/MenuScreen.tsx
@@ -1,14 +1,15 @@
 import { useState } from 'react';
 import { GameState, formatMoney, CurriculumLevel, CURRICULUM_LEVELS } from '@calculating-glory/domain';
+import { OnboardingMode, setOnboardingMode } from '../../lib/introState';
 
 interface Props {
   state: GameState;
   hasSave: boolean;
   onContinue: () => void;
-  onNewGame: (level: CurriculumLevel, clubName: string, stadiumName: string) => void;
+  onNewGame: (level: CurriculumLevel, clubName: string, stadiumName: string, mode: OnboardingMode) => void;
 }
 
-type MenuStep = 'main' | 'yearGroup' | 'clubSetup';
+type MenuStep = 'main' | 'yearGroup' | 'clubSetup' | 'onboarding';
 
 function phaseLabel(phase: GameState['phase']): string {
   switch (phase) {
@@ -55,10 +56,11 @@ export function MenuScreen({ state, hasSave, onContinue, onNewGame }: Props) {
     setStadiumName(value);
   }
 
-  function handleStartGame() {
+  function handleStartGame(mode: OnboardingMode) {
     const finalClub    = clubName.trim()    || 'Calculating Glory FC';
     const finalStadium = stadiumName.trim() || suggestStadiumName(finalClub) || 'Glory Park';
-    onNewGame(selected, finalClub, finalStadium);
+    setOnboardingMode(mode);
+    onNewGame(selected, finalClub, finalStadium, mode);
   }
 
   // ── Step: club name + stadium name ────────────────────────────────────────
@@ -116,7 +118,7 @@ export function MenuScreen({ state, hasSave, onContinue, onNewGame }: Props) {
           </div>
 
           <button
-            onClick={handleStartGame}
+            onClick={() => canStart && setMenuStep('onboarding')}
             disabled={!canStart}
             className={`w-full font-semibold text-sm rounded-card py-3 transition-all duration-150
               ${canStart
@@ -124,8 +126,51 @@ export function MenuScreen({ state, hasSave, onContinue, onNewGame }: Props) {
                 : 'bg-bg-raised text-txt-muted cursor-not-allowed'
               }`}
           >
-            Start game →
+            Next →
           </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Step: onboarding mode choice ──────────────────────────────────────────
+  if (menuStep === 'onboarding') {
+    return (
+      <div className="min-h-screen bg-bg-deep flex flex-col items-center justify-center px-6">
+        <div className="w-full max-w-xs">
+          <button
+            onClick={() => setMenuStep('clubSetup')}
+            className="text-xs text-txt-muted hover:text-txt-primary mb-6 flex items-center gap-1 transition-colors duration-150"
+          >
+            ← Back
+          </button>
+
+          <h2 className="text-xl font-bold text-txt-primary mb-1">How do you want to start?</h2>
+          <p className="text-sm text-txt-muted mb-6 leading-relaxed">
+            You can meet the team first, or jump straight to running the club.
+          </p>
+
+          <div className="flex flex-col gap-3">
+            <button
+              onClick={() => handleStartGame('guided')}
+              className="rounded-card px-5 py-4 text-left transition-all duration-150 bg-data-blue hover:bg-data-blue/90 active:scale-[0.99] text-white"
+            >
+              <div className="font-semibold text-sm leading-tight">Meet the team</div>
+              <div className="text-xs mt-1 text-blue-200 leading-snug">
+                A short intro from your staff — what the club is chasing, and the first decisions waiting for you.
+              </div>
+            </button>
+
+            <button
+              onClick={() => handleStartGame('skip')}
+              className="rounded-card px-5 py-4 text-left transition-all duration-150 bg-bg-surface hover:bg-bg-raised border border-bg-raised text-txt-primary"
+            >
+              <div className="font-semibold text-sm leading-tight">Skip intro</div>
+              <div className="text-xs mt-1 text-txt-muted leading-snug">
+                Drop straight into pre-season. No hand-holding.
+              </div>
+            </button>
+          </div>
         </div>
       </div>
     );
@@ -193,7 +238,7 @@ export function MenuScreen({ state, hasSave, onContinue, onNewGame }: Props) {
           Calculating<br />Glory
         </h1>
         <p className="text-txt-muted text-sm max-w-xs mx-auto leading-relaxed">
-          You're the owner. Every decision comes back to money. Keep the bar green.
+          Take a club from nothing and chase the glory. Cups, promotions, a stadium full of fans — it's yours to build.
         </p>
       </div>
 

--- a/packages/frontend/src/components/owner-office/OwnerOffice.tsx
+++ b/packages/frontend/src/components/owner-office/OwnerOffice.tsx
@@ -17,6 +17,8 @@ import { SlideOver } from '../shared/SlideOver';
 import { SocialFeed } from '../social-feed/SocialFeed';
 import { LearningProgressSlideOver } from '../command-centre/LearningProgressSlideOver';
 import { PendingEventCard } from '../command-centre/PendingEventCard';
+import { TermInfo } from '../shared/TermInfo';
+import { GlossaryTermId } from '../../lib/glossary';
 
 // ── NPC display config ────────────────────────────────────────────────────────
 
@@ -630,18 +632,22 @@ export function OwnerOffice({
           id="header-stats"
         >
           <SpotlightOverlay zoneId="header-stats" spotlight={introSpotlight} />
-          {[
-            { label: 'Budget',   value: fmtMoney(state.club.transferBudget),  colour: '' },
-            { label: 'Burn/wk', value: fmtMoney(burnPerWeek),                 colour: burnPerWeek > weeklyIncome ? 'text-alert-red' : 'text-txt-primary' },
-            { label: 'Board',   value: `${state.boardConfidence}%`,           colour: state.boardConfidence >= 60 ? 'text-pitch-green' : state.boardConfidence >= 40 ? 'text-warn-amber' : 'text-alert-red' },
-            { label: 'Position', value: `${playerPos}/${totalClubs}`,          colour: playerPos <= 3 ? 'text-pitch-green' : playerPos >= totalClubs - 3 ? 'text-alert-red' : 'text-txt-primary' },
-            { label: 'Runway',  value: fmtRunway(runwayVal),                  colour: runwayColour },
-          ].map(stat => (
+          {([
+            { label: 'Budget',   termId: 'transfer-budget' as GlossaryTermId,  value: fmtMoney(state.club.transferBudget),  colour: '' },
+            { label: 'Burn/wk',  termId: 'burn-per-week' as GlossaryTermId,    value: fmtMoney(burnPerWeek),                 colour: burnPerWeek > weeklyIncome ? 'text-alert-red' : 'text-txt-primary' },
+            { label: 'Board',    termId: 'board-confidence' as GlossaryTermId, value: `${state.boardConfidence}%`,           colour: state.boardConfidence >= 60 ? 'text-pitch-green' : state.boardConfidence >= 40 ? 'text-warn-amber' : 'text-alert-red' },
+            { label: 'Position', termId: undefined,                             value: `${playerPos}/${totalClubs}`,          colour: playerPos <= 3 ? 'text-pitch-green' : playerPos >= totalClubs - 3 ? 'text-alert-red' : 'text-txt-primary' },
+            { label: 'Runway',   termId: 'runway' as GlossaryTermId,            value: fmtRunway(runwayVal),                  colour: runwayColour },
+          ]).map(stat => (
             <div key={stat.label} className="px-3 py-1.5 text-center min-w-[56px]">
               <div className={`text-xs font-bold tabular-nums data-font ${stat.colour || 'text-txt-primary'}`}>
                 {stat.value}
               </div>
-              <div className="text-xs2 text-txt-muted">{stat.label}</div>
+              <div className="text-xs2 text-txt-muted">
+                {stat.termId
+                  ? <TermInfo termId={stat.termId} label={stat.label} size="inline" />
+                  : stat.label}
+              </div>
             </div>
           ))}
         </div>

--- a/packages/frontend/src/components/pre-season/PreSeasonScreen.tsx
+++ b/packages/frontend/src/components/pre-season/PreSeasonScreen.tsx
@@ -3,6 +3,7 @@ import { GameState, GameCommand, Formation, Manager, formatMoney } from '@calcul
 import { FormationPicker } from './FormationPicker';
 import { InheritedSquad } from './InheritedSquad';
 import { ManagerPicker } from './ManagerPicker';
+import { TermInfo } from '../shared/TermInfo';
 
 interface PreSeasonScreenProps {
   state: GameState;
@@ -82,7 +83,8 @@ export function PreSeasonScreen({ state, dispatch }: PreSeasonScreenProps) {
           </div>
           <h1 className="text-xl font-bold text-txt-primary">{club.name}</h1>
           <p className="text-sm text-txt-muted mt-0.5">
-            Budget: <span className="text-txt-primary font-mono">{formatMoney(club.transferBudget)}</span>
+            <TermInfo termId="transfer-budget" label="Budget" size="inline" />
+            : <span className="text-txt-primary font-mono">{formatMoney(club.transferBudget)}</span>
             <span className="mx-2 text-white/10">|</span>
             Weekly wages: <span className="text-txt-primary font-mono">{formatMoney(totalWages)}/wk</span>
           </p>
@@ -182,7 +184,8 @@ export function PreSeasonScreen({ state, dispatch }: PreSeasonScreenProps) {
                       a long season.
                     </p>
                     <p className="text-sm text-txt-muted leading-relaxed mt-2">
-                      Wage runway:{' '}
+                      <TermInfo termId="runway" label="Wage runway" size="inline" />
+                      :{' '}
                       <span className={wageRunway >= 8 ? 'text-txt-primary font-medium' : 'text-alert-red font-medium'}>
                         {wageRunway === Infinity ? '∞' : `${wageRunway}w runway`}
                       </span>

--- a/packages/frontend/src/components/shared/TermInfo.tsx
+++ b/packages/frontend/src/components/shared/TermInfo.tsx
@@ -1,0 +1,153 @@
+import { useState, useEffect } from 'react';
+import { GLOSSARY, GlossaryTermId } from '../../lib/glossary';
+import { NPCS, NPC_COLOUR_CLASSES } from '../../lib/npcs';
+import { hasSeenTerm, markTermSeen } from '../../lib/introState';
+import { NpcMessage } from '../intro/NpcMessage';
+
+interface Props {
+  termId: GlossaryTermId;
+  // Override the displayed label. Defaults to the glossary's canonical term.
+  label?: string;
+  // Visual size. Inline for dense strips, default for body copy.
+  size?: 'inline' | 'default';
+  className?: string;
+}
+
+// Tappable label + ⓘ icon. First tap opens a full NPC explainer (with "goes up
+// when / goes down when" rows). Subsequent taps show a compact popup with the
+// short definition. "First time" is tracked per-term in localStorage.
+export function TermInfo({ termId, label, size = 'default', className }: Props) {
+  const term = GLOSSARY[termId];
+  const [open, setOpen] = useState(false);
+  const [firstTime, setFirstTime] = useState(false);
+
+  // Close on Escape while any popup is open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  function handleOpen(e: React.MouseEvent) {
+    e.stopPropagation();
+    setFirstTime(!hasSeenTerm(termId));
+    markTermSeen(termId);
+    setOpen(true);
+  }
+
+  const iconSize = size === 'inline' ? 'w-3.5 h-3.5 text-[9px]' : 'w-4 h-4 text-[10px]';
+  const colour = NPC_COLOUR_CLASSES[NPCS[term.npc].colour];
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleOpen}
+        className={[
+          'inline-flex items-center gap-1 group hover:text-txt-primary transition-colors',
+          className ?? '',
+        ].join(' ').trim()}
+      >
+        <span>{label ?? term.term}</span>
+        <span
+          className={[
+            iconSize,
+            'inline-flex items-center justify-center rounded-full border font-bold',
+            colour.bgSubtle,
+            colour.text,
+            'border-current/40 group-hover:border-current',
+          ].join(' ')}
+          aria-label={`What is ${term.term}?`}
+        >
+          ?
+        </span>
+      </button>
+
+      {open && (
+        <TermPopup
+          termId={termId}
+          firstTime={firstTime}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+
+// ── Popup ────────────────────────────────────────────────────────────────────
+
+interface PopupProps {
+  termId: GlossaryTermId;
+  firstTime: boolean;
+  onClose: () => void;
+}
+
+function TermPopup({ termId, firstTime, onClose }: PopupProps) {
+  const term = GLOSSARY[termId];
+  const npc = NPCS[term.npc];
+  const colour = NPC_COLOUR_CLASSES[npc.colour];
+  const [expanded, setExpanded] = useState(firstTime);
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-end sm:items-center justify-center bg-bg-deep/70 backdrop-blur-sm p-4 animate-fade-in"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-sm bg-bg-surface border border-bg-raised rounded-card overflow-hidden shadow-xl"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header — term + close */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-bg-raised">
+          <div>
+            <div className="text-xs2 uppercase tracking-widest text-txt-muted">Explainer</div>
+            <div className="text-base font-bold text-txt-primary">{term.term}</div>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-txt-muted hover:text-txt-primary text-lg w-8 h-8 flex items-center justify-center"
+            aria-label="Close explainer"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Body — NPC voice */}
+        <div className="p-4 space-y-3">
+          <NpcMessage name={npc.name} role={npc.role} avatar={npc.avatar} colour={npc.colour}>
+            {expanded ? term.full : term.short}
+          </NpcMessage>
+
+          {expanded && (
+            <div className="space-y-2 pt-1">
+              <div className={`flex items-start gap-2 text-xs ${colour.bgSubtle} border-l-4 ${colour.border} rounded-tag px-3 py-2`}>
+                <span className="text-pitch-green font-bold shrink-0">↑</span>
+                <div>
+                  <span className="font-semibold text-txt-primary">Goes up when </span>
+                  <span className="text-txt-muted">{term.upWhen}</span>
+                </div>
+              </div>
+              <div className={`flex items-start gap-2 text-xs ${colour.bgSubtle} border-l-4 ${colour.border} rounded-tag px-3 py-2`}>
+                <span className="text-alert-red font-bold shrink-0">↓</span>
+                <div>
+                  <span className="font-semibold text-txt-primary">Goes down when </span>
+                  <span className="text-txt-muted">{term.downWhen}</span>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {!expanded && (
+            <button
+              onClick={() => setExpanded(true)}
+              className={`w-full text-xs ${colour.text} hover:underline py-1 text-center`}
+            >
+              Show full explainer →
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/lib/glossary.ts
+++ b/packages/frontend/src/lib/glossary.ts
@@ -1,0 +1,98 @@
+import { NpcId } from './npcs';
+
+// Jargon terms kids (Year 7–8) might not know. Each entry carries:
+// - short:   one-line tooltip shown on subsequent taps
+// - full:    the NPC's in-character explanation shown the first time a term
+//            is tapped (friendly, second-person)
+// - upWhen:  "the number goes up when…"
+// - downWhen: "the number goes down when…"
+// Keep copy tight — these are for a 12-year-old reader, not a finance textbook.
+
+export type GlossaryTermId =
+  | 'runway'
+  | 'burn-per-week'
+  | 'transfer-budget'
+  | 'board-confidence'
+  | 'wage-reserve';
+
+export interface GlossaryTerm {
+  id: GlossaryTermId;
+  term: string;
+  npc: NpcId;
+  short: string;
+  full: string;
+  upWhen: string;
+  downWhen: string;
+}
+
+export const GLOSSARY: Record<GlossaryTermId, GlossaryTerm> = {
+  'runway': {
+    id: 'runway',
+    term: 'Runway',
+    npc: 'val',
+    short: 'How many weeks of cash we have left at our current spending rate.',
+    full:
+      "Runway is how many weeks we can keep paying wages before the bank runs dry. " +
+      "Think of it like fuel in a plane — the bigger the number, the further we can fly before we need to land.",
+    upWhen:
+      "earning more than we spend each week — better sponsors, higher attendance, cheaper wages.",
+    downWhen:
+      "wages and running costs are higher than income. Big signings, expensive managers or fewer fans all eat into it.",
+  },
+
+  'burn-per-week': {
+    id: 'burn-per-week',
+    term: 'Burn/wk',
+    npc: 'val',
+    short: "The total cash we spend every week — wages, staff, running the place.",
+    full:
+      "Burn is everything going out of the bank account each week. Player wages, staff salaries, the manager's pay, " +
+      "keeping the lights on. If burn is bigger than the money coming in, we're losing cash every week.",
+    upWhen:
+      "we sign a player on big wages, hire a pricey manager or upgrade a facility that needs staffing.",
+    downWhen:
+      "we release a player, let a contract expire or bring in younger squad members on lower wages.",
+  },
+
+  'transfer-budget': {
+    id: 'transfer-budget',
+    term: 'Budget',
+    npc: 'val',
+    short: "The pot of cash you can spend on signing new players.",
+    full:
+      "Your transfer budget is the money ring-fenced for buying players. It's separate from the wage pot — " +
+      "signing someone costs a one-off fee from here, then their weekly wage comes out of the other pot.",
+    upWhen:
+      "a sponsor deal lands, we sell a player, cup prize money arrives, or the board grants a top-up.",
+    downWhen:
+      "we buy a player — the fee comes straight out. Bigger signings, bigger dent.",
+  },
+
+  'board-confidence': {
+    id: 'board-confidence',
+    term: 'Board',
+    npc: 'val',
+    short: "How much the people who own the club trust you to do the job.",
+    full:
+      "The board are the people above you — they gave you the job. This number is how much they still back you. " +
+      "High and they give you room to chase the big stuff. Low and they start making uncomfortable phone calls.",
+    upWhen:
+      "the team wins, we climb the league, or we land a cup run or a big sponsor.",
+    downWhen:
+      "we lose matches, drop in the table, blow through money or miss promises we made them.",
+  },
+
+  'wage-reserve': {
+    id: 'wage-reserve',
+    term: 'Wage reserve',
+    npc: 'val',
+    short: "The separate pot of cash set aside just for paying wages each week.",
+    full:
+      "Wages have to be paid every week — players, staff, the manager. The wage reserve is a ring-fenced pot " +
+      "just for that, so we can't accidentally spend it on a signing. When it runs out, we can't pay people.",
+    upWhen:
+      "matchday income comes in, sponsors pay out or the board tops it up.",
+    downWhen:
+      "every week that passes — wages come straight out. Hiring higher-paid staff drains it faster.",
+  },
+};

--- a/packages/frontend/src/lib/guidedTasks.ts
+++ b/packages/frontend/src/lib/guidedTasks.ts
@@ -1,0 +1,62 @@
+import { GameState, GameEvent } from '@calculating-glory/domain';
+import { NPCS, Npc } from './npcs';
+
+export type GuidedTaskId = 'sponsor' | 'manager' | 'signing' | 'facility';
+
+export interface GuidedTask {
+  id: GuidedTaskId;
+  npc: Npc;
+  title: string;
+  blurb: string;
+  done: boolean;
+}
+
+// Derive the four guided-pre-season task statuses from the event log. Every
+// signal we need is already fired by existing domain handlers — no new
+// reducer state is introduced for this feature.
+export function getGuidedTasks(state: GameState, events: GameEvent[]): GuidedTask[] {
+  const clubId = state.club.id;
+  const inClub = (e: GameEvent): e is Extract<GameEvent, { clubId: string }> =>
+    'clubId' in e && (e as { clubId?: string }).clubId === clubId;
+
+  const sponsorDone = events.some(
+    e => e.type === 'BUDGET_UPDATED' && inClub(e) && e.reason.startsWith('intro-sponsor-deal-option-')
+  );
+  const managerDone = state.club.manager !== null
+    || events.some(e => e.type === 'MANAGER_HIRED' && inClub(e));
+  const signingDone = events.some(
+    e => (e.type === 'TRANSFER_COMPLETED' || e.type === 'FREE_AGENT_SIGNED') && inClub(e)
+  );
+  const facilityDone = events.some(e => e.type === 'FACILITY_UPGRADE_STARTED' && inClub(e));
+
+  return [
+    {
+      id: 'sponsor',
+      npc: NPCS.marcus,
+      title: 'Lock in the pre-season sponsor',
+      blurb: 'Local firm wants their logo on our shirts. Not glamorous — but it funds the ambition.',
+      done: sponsorDone,
+    },
+    {
+      id: 'manager',
+      npc: NPCS.kev,
+      title: 'Appoint a manager',
+      blurb: 'Pick a gaffer who matches how you want us to play. Promotion-chasers need a different voice to survivalists.',
+      done: managerDone,
+    },
+    {
+      id: 'signing',
+      npc: NPCS.kev,
+      title: 'Sign a player the fans can get excited about',
+      blurb: 'The squad we inherited is mid-table at best. One standout signing changes the conversation.',
+      done: signingDone,
+    },
+    {
+      id: 'facility',
+      npc: NPCS.dani,
+      title: 'Put money into a facility',
+      blurb: 'Every trophy this club ever won started with a training pitch that worked. Your first statement of intent.',
+      done: facilityDone,
+    },
+  ];
+}

--- a/packages/frontend/src/lib/introState.ts
+++ b/packages/frontend/src/lib/introState.ts
@@ -1,5 +1,6 @@
-const INTRO_KEY = 'cg-intro-v1-completed';
-const MODE_KEY  = 'cg-onboarding-mode-v1';
+const INTRO_KEY     = 'cg-intro-v1-completed';
+const MODE_KEY      = 'cg-onboarding-mode-v1';
+const GLOSSARY_KEY  = 'cg-glossary-seen-v1';
 
 export type OnboardingMode = 'guided' | 'skip';
 
@@ -41,6 +42,36 @@ export function getOnboardingMode(): OnboardingMode {
 export function setOnboardingMode(mode: OnboardingMode): void {
   try {
     localStorage.setItem(MODE_KEY, mode);
+  } catch {
+    // unavailable — carry on
+  }
+}
+
+// ── Glossary: which jargon terms the player has seen the full explainer for.
+// Stored as a JSON array of term ids. The TermInfo component shows the full
+// NPC explainer the first time each term is tapped, and a short popup after.
+
+function readSeenTerms(): Set<string> {
+  try {
+    const raw = localStorage.getItem(GLOSSARY_KEY);
+    if (!raw) return new Set();
+    const arr = JSON.parse(raw);
+    return Array.isArray(arr) ? new Set(arr) : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+export function hasSeenTerm(id: string): boolean {
+  return readSeenTerms().has(id);
+}
+
+export function markTermSeen(id: string): void {
+  try {
+    const seen = readSeenTerms();
+    if (seen.has(id)) return;
+    seen.add(id);
+    localStorage.setItem(GLOSSARY_KEY, JSON.stringify([...seen]));
   } catch {
     // unavailable — carry on
   }

--- a/packages/frontend/src/lib/introState.ts
+++ b/packages/frontend/src/lib/introState.ts
@@ -1,4 +1,7 @@
 const INTRO_KEY = 'cg-intro-v1-completed';
+const MODE_KEY  = 'cg-onboarding-mode-v1';
+
+export type OnboardingMode = 'guided' | 'skip';
 
 export function isIntroCompleted(): boolean {
   try {
@@ -19,6 +22,25 @@ export function markIntroCompleted(): void {
 export function clearIntroCompleted(): void {
   try {
     localStorage.removeItem(INTRO_KEY);
+  } catch {
+    // unavailable — carry on
+  }
+}
+
+// Existing saves with no recorded preference default to 'skip' so they don't
+// see the guided UI appear out of nowhere.
+export function getOnboardingMode(): OnboardingMode {
+  try {
+    const raw = localStorage.getItem(MODE_KEY);
+    return raw === 'guided' ? 'guided' : 'skip';
+  } catch {
+    return 'skip';
+  }
+}
+
+export function setOnboardingMode(mode: OnboardingMode): void {
+  try {
+    localStorage.setItem(MODE_KEY, mode);
   } catch {
     // unavailable — carry on
   }

--- a/packages/frontend/src/lib/npcs.ts
+++ b/packages/frontend/src/lib/npcs.ts
@@ -1,0 +1,66 @@
+// Shared NPC dictionary. Used by IntroScreen, GuidedTaskCard, and any other
+// surface where one of the four directors speaks. Colour is a semantic key so
+// call sites never hand-pick a Tailwind token.
+
+export type NpcId = 'val' | 'kev' | 'marcus' | 'dani';
+export type NpcColourKey = 'emerald' | 'sky' | 'amber' | 'violet';
+
+export interface Npc {
+  id: NpcId;
+  name: string;
+  role: string;
+  avatar: string;
+  colour: NpcColourKey;
+}
+
+// Tailwind's JIT scanner can't follow dynamic class names built from template
+// strings, so every class we want to ship must appear as a static literal.
+// Keep this map in sync with any colour key added to NpcColourKey.
+export const NPC_COLOUR_CLASSES: Record<NpcColourKey, {
+  border: string;
+  ring: string;
+  name: string;
+  bg: string;
+  bgSubtle: string;
+  text: string;
+}> = {
+  emerald: {
+    border:   'border-emerald-500',
+    ring:     'ring-emerald-400/60',
+    name:     'text-emerald-300',
+    bg:       'bg-emerald-500',
+    bgSubtle: 'bg-emerald-500/10',
+    text:     'text-emerald-400',
+  },
+  sky: {
+    border:   'border-sky-500',
+    ring:     'ring-sky-400/60',
+    name:     'text-sky-300',
+    bg:       'bg-sky-500',
+    bgSubtle: 'bg-sky-500/10',
+    text:     'text-sky-400',
+  },
+  amber: {
+    border:   'border-amber-500',
+    ring:     'ring-amber-400/60',
+    name:     'text-amber-300',
+    bg:       'bg-amber-500',
+    bgSubtle: 'bg-amber-500/10',
+    text:     'text-amber-400',
+  },
+  violet: {
+    border:   'border-violet-500',
+    ring:     'ring-violet-400/60',
+    name:     'text-violet-300',
+    bg:       'bg-violet-500',
+    bgSubtle: 'bg-violet-500/10',
+    text:     'text-violet-400',
+  },
+};
+
+export const NPCS: Record<NpcId, Npc> = {
+  val:    { id: 'val',    name: 'Val Okoro',    role: 'Finance Director',    avatar: '📊', colour: 'emerald' },
+  kev:    { id: 'kev',    name: 'Kev Mulligan', role: 'Head of Football',    avatar: '⚽', colour: 'sky'     },
+  marcus: { id: 'marcus', name: 'Marcus Webb',  role: 'Commercial Director', avatar: '📣', colour: 'amber'   },
+  dani:   { id: 'dani',   name: 'Dani Lopes',   role: 'Head of Operations',  avatar: '🔧', colour: 'violet'  },
+};


### PR DESCRIPTION
## Summary

Restructures the intro sequence from a 22-step stadium tour into a focused 11-step ambition-first narrative, introduces an optional guided onboarding mode with task tracking, and adds a glossary system for explaining financial jargon to younger players.

## Key Changes

- **Intro redesign**: Removed the 5-step stadium tour (steps 7–11) and condensed the narrative to focus on Kev's ambition pitch, Val's financial framing, and Marcus' sponsor deal with an embedded maths challenge. New flow is 11 steps instead of 22.

- **Guided onboarding mode**: Added `OnboardingMode` preference ('guided' or 'skip') stored in localStorage. Players can choose at game start whether to see the intro and guided task card.

- **Guided task tracking**: New `GuidedTaskCard` component displays four pre-season tasks (sponsor deal, manager hire, player signing, facility upgrade) derived from the event log. Tasks auto-complete when corresponding domain events fire.

- **Glossary system**: Created `TermInfo` component and `glossary.ts` with five financial terms (runway, burn/wk, budget, board confidence, wage reserve). First tap shows full NPC explainer with "goes up/down when" context; subsequent taps show compact popup. Term-seen state tracked per-term in localStorage.

- **NPC centralization**: Extracted NPC definitions to `npcs.ts` with semantic colour keys (emerald, sky, amber, violet) and Tailwind class mappings. Used across intro, guided tasks, and glossary.

- **UI enhancements**: 
  - `NpcMessage` now accepts optional colour prop for ring styling
  - `HeadlineStats` and `PreSeasonScreen` integrate `TermInfo` for inline jargon tooltips
  - Menu adds onboarding mode selection step before game start

## Implementation Details

- Glossary terms are NPC-voiced (Val explains financial concepts) and include directional context ("goes up when…") to help players build mental models of the economy.
- Guided tasks are stateless—derived on-demand from existing event log, so no new reducer state is needed.
- Tailwind class names are hardcoded in `NPC_COLOUR_CLASSES` to ensure JIT scanner picks them up; dynamic class construction is avoided.
- Intro spotlight logic simplified: removed stadium tour conditional, now just looks up `STEP_SPOTLIGHT[step]`.

https://claude.ai/code/session_012rXBzGSEEEwUZpeZPhtPk3