### PR TITLE
docs: update .build docs for PR #140

### DIFF
--- a/.build/BACKLOG.md
+++ b/.build/BACKLOG.md
@@ -1,7 +1,7 @@
 ---
 project: "Calculating Glory"
 type: "build"
-lastUpdated: "2026-04-12"
+lastUpdated: "2026-04-20"
 ---
 
 # Calculating Glory - Backlog & Ideas
@@ -14,7 +14,7 @@ lastUpdated: "2026-04-12"
 - [ ] Geometry challenges — 4 new MathTopics, stadium-themed templates (#21 PR 6)
 - [ ] Player database/market — pool of purchasable players with real(ish) names and stats
 - [ ] Transfer window UI — browse market, make offers, negotiate
-- [x] Tutorial/onboarding flow — Dani intro stadium tour with facility walkthrough ✅ (PR #94)
+- [x] Tutorial/onboarding flow — Dani intro stadium tour with facility walkthrough ✅ (PR #94; stadium tour later retired in PR #140 in favour of guided-task card)
 - [ ] Pre-season flow — squad building before the season starts
 - [ ] Season end screen — promotion/relegation celebration/commiseration
 - [ ] localStorage persistence — serialise event log on every command, rehydrate on load; prevents progress loss on browser close (no infrastructure needed)
@@ -39,6 +39,11 @@ lastUpdated: "2026-04-12"
 - [x] Section pages: Inbox, Transfers, Finances, Backroom, Squad replace slide-overs ✅ (PR #129)
 - [x] HeadlineStats strip: Position / Confidence / Budget above fold ✅ (PR #129)
 - [x] FinancesSection live runway counter alongside wage reserve slider ✅ (PR #129)
+- [x] Ambition-first intro cold-open — Kev opens with promotion/cups/fans, Val reframes money as enabler; cut from 23 steps to 10 ✅ (PR #140)
+- [x] NPC colour coding — shared `lib/npcs.ts` (Val emerald, Kev sky, Marcus amber, Dani violet); `NpcMessage` colour prop ✅ (PR #140)
+- [x] Skip-intro mode — onboarding mode picker after club setup, persisted in `cg-onboarding-mode-v1` ✅ (PR #140)
+- [x] Guided task card — 4 pre-season tasks (sponsor / manager / signing / facility) derived from event log ✅ (PR #140)
+- [x] Hybrid jargon explainers — `TermInfo` component, first-view NPC modal + short popup after; 5 terms wired (Runway, Burn/wk, Budget, Board, Wage reserve) ✅ (PR #140)
 
 ## Improvements / Optimisations
 

--- a/.build/NEXT.md
+++ b/.build/NEXT.md
@@ -1,7 +1,7 @@
 ---
 project: "Calculating Glory"
 type: "build"
-lastUpdated: "2026-04-12"
+lastUpdated: "2026-04-20"
 ---
 
 # Calculating Glory — Next Steps
@@ -10,11 +10,31 @@ lastUpdated: "2026-04-12"
 
 ---
 
-## Recently Completed (PR #131, in review 2026-04-12)
+## Recently Completed (PR #140, merged 2026-04-20)
+
+### ✅ Ambition-first intro + NPC colour coding + skip mode + jargon explainers
+- **Issue:** #111 (new-player ramp portion)
+- **Status:** MERGED (PR #140)
+- Intro re-toned to lead with ambition: Kev opens with promotion/cups/fans; Val reframes money as the enabler, not the headline. Cut from 23 steps to 10 — stadium tour and per-NPC introductions dropped
+- Maths challenge + sponsor decision retained as the first real pre-season choice
+- NPC colour coding via new `lib/npcs.ts`: Val emerald (finance), Kev sky (football), Marcus amber (commercial), Dani violet (operations). `NpcMessage` gains a `colour` prop (left-border accent + avatar ring + name tint)
+- "Meet the team / Skip intro" picker after club setup. Persisted in `cg-onboarding-mode-v1`. Existing saves default to skip so there's no UI regression
+- `GuidedTaskCard` on the Command Centre for guided-mode players — 4 tasks (sponsor deal, manager hire, signing, facility upgrade) derived from the existing event log. No new domain state
+- Hybrid jargon explainers for 5 opaque finance terms (Runway, Burn/wk, Budget, Board, Wage reserve): first tap opens a full NPC-voiced modal with "goes up when… / goes down when…" rows; subsequent taps show the short line with a "Show full explainer →" link. Seen state tracked per-term in `cg-glossary-seen-v1`
+- Terms wired into Command Centre header strip, `HeadlineStats`, and Pre-Season budget/runway labels
+
+**Deferred from the plan (follow-ups):**
+- Progressive disclosure on `OverviewSection` (hide league table / squad / news ticker until tasks complete) — not shipped
+- Gating "Begin Season" on guided task completion — structurally blocked: transfers and facility upgrades aren't reachable from `PreSeasonScreen` in the current flow
+- Stadium first-visit overlay — redundant once Dani's stadium monologue was cut
+
+---
+
+## Recently Completed (PR #131, merged 2026-04-12)
 
 ### ✅ Owner's Office — Three-Zone Fixed Layout
 - **Issue:** #124
-- **Status:** IN REVIEW (PR #131)
+- **Status:** MERGED (PR #131)
 - Replaces PR #129 sidebar-nav/section architecture with three-zone fixed layout per design brief
 - Left zone — Decisions & News: InboxFeed with priority pips, NewsTicker strip
 - Centre zone — Pitch & League: CompactLeague (top 3 + you ±1, gap separator), full table modal, Next Week button anchored at bottom
@@ -147,20 +167,26 @@ lastUpdated: "2026-04-12"
 - Three candidate approaches: tabbed zones, stacked vertical, priority-first fold
 - See issue #130 for full brief and AC
 
-### 2. 🔜 Sponsor Negotiation
+### 2. 🔜 Guided-mode follow-ups (from PR #140)
+- **Priority:** MEDIUM — finishes off the new-player ramp
+- Progressive disclosure on `OverviewSection` while guided tasks are outstanding (hide league table / squad / news ticker until sponsor+manager done)
+- Rework pre-season flow so transfers + facility upgrades are reachable before `START_SEASON` — unblocks gating "Begin Season" on guided task completion
+- Extend glossary to more jargon: Position, Morale, Formation, Free agent, Reputation (add entries to `GLOSSARY`, drop `TermInfo` onto labels)
+
+### 3. 🔜 Sponsor Negotiation
 - **Issue:** #80
 - **Priority:** HIGH — decision density
 - Val presents weekly sponsorship deals
 - Negotiate terms via maths challenge (percentage/ratio question gates a better deal)
 - Accept/reject with visible financial impact
 
-### 3. 🔜 Inbox Overflow — Full Fix
+### 4. 🔜 Inbox Overflow — Full Fix
 - **Issue:** #92
 - **Priority:** MEDIUM
 - Remaining stacking edge cases: NPC messages + pending events + news within PREVIEW_LIMIT
 - Check for double-notification on poach + construction events
 
-### 4. 🔜 Stadium View — Remaining Facility Panels
+### 5. 🔜 Stadium View — Remaining Facility Panels
 - **Issue:** #87 (remaining)
 - **Priority:** MEDIUM
 - Training Ground, Medical Centre, Scout Network, Youth Academy panels

--- a/.build/ROADMAP.md
+++ b/.build/ROADMAP.md
@@ -2,7 +2,7 @@
 project: "Calculating Glory"
 type: "build"
 createdAt: "2026-03-03"
-lastUpdated: "2026-04-12"
+lastUpdated: "2026-04-20"
 ---
 
 # Calculating Glory - Roadmap
@@ -79,13 +79,25 @@ An educational football club management game for Year 7 maths, built on event-so
 - Intro spotlight system remapped to new zone IDs
 - **#130** Mobile layout brief raised — candidate approaches defined (tabbed zones, stacked, priority-first fold)
 
+### Phase 14: New-Player Ramp ✅ (PR #140)
+- **#111** (partial) ✅ Ambition-first intro cold-open — Kev opens with stakes (promotion/cups/fans); Val reframes money as the enabler. Intro cut from 23 steps to 10; stadium tour and per-NPC introductions dropped
+- ✅ NPC colour coding — shared `lib/npcs.ts` (Val emerald, Kev sky, Marcus amber, Dani violet); `NpcMessage` left-border accent + avatar ring + name tint
+- ✅ Skip-intro mode — "Meet the team / Skip intro" picker after club setup, persisted in `cg-onboarding-mode-v1`; existing saves default to skip
+- ✅ `GuidedTaskCard` on Command Centre — 4 tasks (sponsor / manager / signing / facility upgrade) derived from existing event log; no new domain state
+- ✅ Hybrid jargon explainers — `TermInfo` component: first tap opens NPC-voiced full explainer with "goes up when / goes down when" rows, subsequent taps show compact popup. 5 terms wired (Runway, Burn/wk, Budget, Board, Wage reserve); seen state per-term in `cg-glossary-seen-v1`
+
+**Deferred from the ramp plan (follow-ups, tracked in NEXT.md):**
+- Progressive disclosure on `OverviewSection` while guided tasks are outstanding
+- Gating "Begin Season" on guided task completion (blocked on current pre-season flow not exposing transfers/facilities)
+- Extending glossary to Position, Morale, Formation, Free agent, Reputation
+
 ---
 
 ## Current Work
 
 ### Owner's Office Depth
 - **#130** Mobile layout — implement mobile-first layout for Owner's Office (tabbed zones or priority-first fold)
-- **#111** Progressive disclosure — priority ordering, collapsible sections, new-player ramp
+- **#111** (remainder) Progressive disclosure + task-gated "Begin Season" — blocked on pre-season flow rework
 - **#119** Chat area rethink — negotiate panel becomes NPC conversation hub; inbox reverts to read-only updates
 
 ### Gameplay Systems

--- a/.build/SESSION_START.md
+++ b/.build/SESSION_START.md
@@ -1,78 +1,78 @@
-# Session Progress — 2026-04-12
+# Session Progress — 2026-04-20
 
 ## Session Goals
-- Implement #124 — Command Centre UX/UI overhaul (persistent nav, section routing, headline stats)
-- Update .build docs
-- Raise PR
+- Tackle #111 — progressive disclosure / new-player ramp
+- Re-tone the intro away from a money-first opening toward ambition-first (explicit feedback mid-session)
+- Colour-code NPCs so the speaker is identifiable at a glance (explicit feedback mid-session)
+- Add hybrid jargon explainers so Year 7/8 readers understand terms like "runway" (explicit feedback mid-session)
+- Merge, update .build docs
 
 ## Completed Work
 
-### 1. Command Centre UX/UI Overhaul — #124 ✅ (PR #129, in review)
+### 1. Ambition-first intro + guided ramp + jargon explainers — #111 ✅ (PR #140, merged 2026-04-20)
 
 **New files:**
-- `AppNav.tsx` — persistent left sidebar (lg+): Overview/Inbox/Squad/Transfers/Finances/Backroom + Stadium at bottom
-- `AppNavMobile.tsx` — fixed bottom tab bar (mobile, lg:hidden): 6 sections + unresolved-events badge on Inbox
-- `HeadlineStats.tsx` — 3-stat headline strip (Position / Board Confidence / Transfer Budget) with trend arrows
-- `sections/OverviewSection.tsx` — inbox-first, HeadlineStats → DataTiles → HubTiles → tables
-- `sections/InboxSection.tsx` — full-page InboxHistory
-- `sections/TransferSection.tsx` — full-page TransferMarketSlideOver
-- `sections/FinancesSection.tsx` — FinancialHealthBar + budget sliders + live ≈Nw runway counter
-- `sections/BackroomSection.tsx` — full-page BackroomTeamSlideOver
-- `sections/SquadSection.tsx` — full-page SquadAuditTable
+- `packages/frontend/src/lib/npcs.ts` — shared NPC dictionary with semantic colour keys (emerald / sky / amber / violet) and static Tailwind class map
+- `packages/frontend/src/lib/guidedTasks.ts` — `getGuidedTasks(state, events)`, derives 4-task completion from existing event log
+- `packages/frontend/src/lib/glossary.ts` — 5 terms with NPC voice, short + full + up/down explainers
+- `packages/frontend/src/components/command-centre/GuidedTaskCard.tsx` — 4-task checklist UI on the Overview
+- `packages/frontend/src/components/shared/TermInfo.tsx` — tappable label + ⓘ chip; first tap opens full NPC modal, subsequent taps show short popup with expand link
 
 **Modified files:**
-- `CommandCentre.tsx` — section routing via activeSection prop; 7 slide-over booleans → 3 (Negotiations, Practice, Learning)
-- `App.tsx` — activeSection state, flex sidebar layout, pb-16 lg:pb-0 for mobile safe area
-- `IntroScreen.tsx` — 1-line compat fix: pass activeSection="overview" onSectionChange={() => {}}
+- `packages/frontend/src/App.tsx` — routes new-game to `intro` or `game` based on onboarding mode
+- `packages/frontend/src/lib/introState.ts` — adds `getOnboardingMode()` / `setOnboardingMode()` and glossary seen tracking (`hasSeenTerm` / `markTermSeen`)
+- `packages/frontend/src/components/menu/MenuScreen.tsx` — new "Meet the team / Skip intro" step after club setup
+- `packages/frontend/src/components/intro/IntroScreen.tsx` — slimmed 23 → 10 steps; Kev opens with ambition; Val reframes money as enabler; stadium tour removed; uses `NPCS` dict
+- `packages/frontend/src/components/intro/NpcMessage.tsx` — optional `colour` prop for left-border accent + avatar ring + name tint
+- `packages/frontend/src/components/command-centre/sections/OverviewSection.tsx` — mounts `GuidedTaskCard` at top when guided mode + tasks outstanding
+- `packages/frontend/src/components/command-centre/HeadlineStats.tsx` — wires `TermInfo` on Confidence + Budget
+- `packages/frontend/src/components/owner-office/OwnerOffice.tsx` — wires `TermInfo` on Budget / Burn/wk / Board / Runway header chips
+- `packages/frontend/src/components/pre-season/PreSeasonScreen.tsx` — wires `TermInfo` on Budget and Wage runway labels
 
 ### 2. .build Docs Updated ✅
-- STATUS.md: Phase 13, progress 30%, PR #129 listed
-- NEXT.md: PR #129 section added at top
-- ROADMAP.md: Phase 13 shows #124 as done, remaining issues still open
-- BACKLOG.md: 4 new ✅ items for PR #129
+- STATUS.md: Phase 14, progress 20%, PR #140 listed
+- NEXT.md: PR #140 section at top; guided-mode follow-ups added to priority queue
+- ROADMAP.md: Phase 14 added; remaining #111 work moved to current work
+- BACKLOG.md: 5 new ✅ items for PR #140; PR #94 entry annotated (stadium tour retired)
 - SESSION_START.md: this file
 
 ## Architecture Notes
 
-- No router introduced — section routing via `activeSection` state in App.tsx
-- `ActiveSection` type exported from App.tsx; imported by AppNav, AppNavMobile, CommandCentre
-- FinancesSection is a self-contained reimplementation of BudgetAllocationSlideOver content (not a wrapper) — adds live runway counter per-slider
-- Slide-overs that remain: Negotiations (contextual, linked to PendingClubEvent), Practice (Marcus Webb), Learning Progress (acumen breakdown)
-- Worktree domain symlink rule: domain dist always reads from main project — rebuild there if domain changes
+- `NPC_COLOUR_CLASSES` uses static Tailwind literals so the JIT scanner picks them up — dynamic template-string class construction is avoided by design
+- Guided task completion is stateless — derived on-demand from existing events (`BUDGET_UPDATED` with `intro-sponsor-deal-option-*` reason, `MANAGER_HIRED`, `TRANSFER_COMPLETED` / `FREE_AGENT_SIGNED`, `FACILITY_UPGRADE_STARTED`). No new reducer state introduced.
+- `TermInfo` keeps NPC tone inside the explainer — the modal reuses `NpcMessage` with the NPC's colour, so the speaker is consistent across intro, guided tasks, and glossary surfaces.
+- Hybrid explainer: first view shows the full explainer (short + full + ↑/↓ rows) because the user hasn't seen the term before; subsequent views start with the short line and offer "Show full explainer →" to expand. Seen state tracked in `cg-glossary-seen-v1`.
+- Skip mode routes past `IntroScreen` entirely — App.tsx goes directly from menu to `game`, and pre-season is rendered via the existing `phase === 'PRE_SEASON'` check.
+
+## Known Gaps (tracked in NEXT.md)
+
+- Progressive disclosure on `OverviewSection` while guided tasks are outstanding — not shipped
+- Gating "Begin Season" on guided task completion — blocked on pre-season flow not exposing transfers or facility upgrades
+- Glossary extension to Position / Morale / Formation / Free agent / Reputation — easy follow-up, just add entries to `GLOSSARY` and drop `TermInfo` on labels
+- Domain test suite has 3 failing tests (transfers / reducer-match / manager) — pre-existing, unrelated to this PR
 
 ## Current Status
 
 ### ✅ Working
-- TypeScript: 0 errors
-- Sidebar visible at lg+, hidden mobile
-- Bottom tab bar visible mobile, hidden lg+
-- All 6 sections render correctly
-- Inbox badge shows unresolved count
-- FinancesSection: runway counter updates live as slider moves
-- Negotiations/Practice slide-overs still open from Overview HubTiles
-- Intro walkthrough: spotlight dimming unaffected
+- Frontend TypeScript: 0 errors
+- Frontend build: clean (vite build succeeds)
+- Skip-intro routes past the intro to pre-season
+- Guided-mode card appears on Command Centre, ticks off as tasks complete, hides when all 4 are done
+- NPC bubbles show the correct accent across intro + guided task card + glossary explainer
+- Glossary modal: first-view full explainer, subsequent short + expand link
 
 ### 🟡 Pending
-- PR #129 awaiting review/merge
+- Guided-mode follow-ups listed above
 
 ### 🔴 Blocked
-- Nothing
-
-## Key Files
-
-- `src/App.tsx` — activeSection state, layout wrapper
-- `src/components/nav/AppNav.tsx` — desktop sidebar
-- `src/components/nav/AppNavMobile.tsx` — mobile bottom bar
-- `src/components/command-centre/HeadlineStats.tsx` — 3-stat strip
-- `src/components/command-centre/sections/` — 6 section components
-- `src/components/command-centre/CommandCentre.tsx` — section router
+- "Begin Season" gating blocked on pre-season flow rework
 
 ## Next Session Goals
 
-- Merge PR #129
-- Pick up #111 (progressive disclosure) or #119 (chat area rethink)
-- Consider #92 inbox overflow full fix
+- Mobile layout (#130) or guided-mode follow-ups
+- Consider extending glossary to the remaining jargon terms
+- Raise a dedicated issue for the "pre-season flow exposes transfers + facilities" refactor
 
 ---
 
-**Status**: PR #129 in review — Command Centre nav overhaul complete, Phase 13 ~30% done
+**Status**: PR #140 merged — ambition-first intro, NPC colour coding, skip mode, and hybrid jargon explainers all live. Phase 14 new-player ramp ~20% done (core narrative + explainer loop shipped; progressive disclosure + task gating deferred).

--- a/.build/STATUS.md
+++ b/.build/STATUS.md
@@ -2,17 +2,17 @@
 project: "Calculating Glory"
 type: "build"
 priority: 2
-phase: "Phase 13 — Owner's Office"
-progress: 70
-lastUpdated: "2026-04-12"
-lastTouched: "2026-04-12"
+phase: "Phase 14 — New-Player Ramp"
+progress: 20
+lastUpdated: "2026-04-20"
+lastTouched: "2026-04-20"
 status: "in-progress"
 ---
 
 # Calculating Glory - Current Status
 
-**Phase:** Phase 13 — Owner's Office (70% complete)
-**Last Updated:** 2026-04-12
+**Phase:** Phase 14 — New-Player Ramp (20% complete)
+**Last Updated:** 2026-04-20
 
 ## What's Done
 
@@ -99,7 +99,7 @@ status: "in-progress"
   - Budget allocation slider UI: three linked sliders in slide-over, opened from Financial Health Bar
   - Facility upgrades deduct from Infrastructure Fund, not Transfer Fund
 
-**PR #131 — Owner's Office — Three-Zone Fixed Layout (in review 2026-04-12):**
+**PR #131 — Owner's Office — Three-Zone Fixed Layout (merged 2026-04-12):**
 - Replaces PR #129 sidebar-nav/section architecture with three-zone fixed layout per design brief
 - Left zone — Decisions & News: InboxFeed with priority pips, NewsTicker strip
 - Centre zone — Pitch & League: CompactLeague (top 3 + you ±1, gap separator), full table modal, Next Week button anchored at bottom
@@ -108,10 +108,17 @@ status: "in-progress"
 - IntroScreen.tsx: spotlight IDs remapped to zone IDs (header-stats, decisions-zone, pitch-zone, people-zone)
 - Issue #130 raised: mobile layout brief with three candidate approaches
 
+**PR #140 — Ambition-first intro + NPC colour coding + skip mode + jargon explainers (merged 2026-04-20):**
+- #111 New-player ramp: intro re-toned to lead with ambition (Kev opens; Val reframes money as the enabler, not the headline). Cut from 23 steps to 10 — stadium tour and per-NPC introductions dropped; maths challenge + sponsor decision kept as the first real pre-season choice
+- NPC colour coding via new `lib/npcs.ts` as single source of truth: Val emerald, Kev sky, Marcus amber, Dani violet. `NpcMessage` gains a `colour` prop (left-border accent + avatar ring + name tint)
+- "Meet the team / Skip intro" picker after club setup, persisted in `cg-onboarding-mode-v1`. Existing saves default to skip
+- `GuidedTaskCard` on Command Centre for guided-mode players — 4 tasks (sponsor, manager, signing, facility upgrade) derived from existing event log; no new domain state
+- Hybrid jargon explainers for 5 opaque finance terms (Runway, Burn/wk, Budget, Board, Wage reserve): first tap per term opens full NPC modal with "goes up when… / goes down when…" rows; subsequent taps show short line with expand link. Seen state per-term in `cg-glossary-seen-v1`
+- Terms wired into Command Centre header strip, `HeadlineStats`, and Pre-Season budget/runway labels
+
 ## What's In Progress
 
 - #130 Mobile layout — Owner's Office mobile reimagining
-- #111 Progressive disclosure — priority ordering, collapsible sections, new-player ramp
 - #119 Chat area rethink — negotiate panel as NPC conversation hub
 
 ## What's Next


### PR DESCRIPTION
## Summary

Reflects the merged PR #140 across the .build docs.

- **STATUS.md**: phase bumped to 14 (New-Player Ramp, 20%); PR #140 summary added
- **NEXT.md**: new "Recently Completed (PR #140)" section at top; guided-mode follow-ups added to priority queue (progressive disclosure, pre-season flow rework to unblock task-gated Begin Season, glossary extension)
- **ROADMAP.md**: new Phase 14 entry; #111 partial completion noted, remainder moved to current work
- **BACKLOG.md**: 5 new ✅ items for PR #140; PR #94 stadium-tour entry annotated as retired
- **SESSION_START.md**: rewritten for 2026-04-20 session

## Test plan

- [ ] Read STATUS.md / NEXT.md / ROADMAP.md — summary of what shipped in #140 is accurate
- [ ] Follow-up items correctly describe what was deferred and why

https://claude.ai/code/session_012rXBzGSEEEwUZpeZPhtPk3